### PR TITLE
remove the first '/' in path

### DIFF
--- a/fix-include-path.sh
+++ b/fix-include-path.sh
@@ -103,6 +103,9 @@ convert_headers ()
             # check if header file exists from source root
             if [[ $hdr_path != "" ]] ; then
                 new_hdr=${hdr_path#$root}
+                if [[ "${new_hdr:0:1}" == "/" ]] ; then
+                    new_hdr=${new_hdr:1}
+                fi
                 if [[ "$hdr" != "$new_hdr" ]] ; then
                     _info "Replace '$hdr' to '$new_hdr'"
                     sed_cmd=${sed_cmd}"$lineno {s|$(escape_slash $hdr)|$(escape_slash $new_hdr)|g}"$'\n'


### PR DESCRIPTION
support we have the following directory structure:

root/
    a/
        a.cc
    b/
        b.h

and in a.cc, we include b.h

```
#include "b.h"
```

and in the original implementation, it would be changed to

```
#include "/b/b.h"
```

this is because `${hdr_path#$root}` operation is incomplete for this scenario:

```
    hdr_path = "/root/b/b.h"
    root = /root"
```
