### PR TITLE
为CcTarget增加汇编语言支持

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -200,6 +200,13 @@ class CcTarget(Target):
         if incs_list:
             self._write_rule('%s.Append(CPPPATH=%s)' % (env_name, incs_list))
 
+    def _setup_as_flags(self):
+        """_setup_as_flags. """
+        env_name = self._env_name()
+        as_flags = self._get_as_flags()
+        if as_flags:
+            self._write_rule('%s.Append(ASFLAGS=%s)' % (env_name, as_flags))
+
     def _setup_extra_link_flags(self):
         """extra_linkflags. """
         extra_linkflags = self.data.get('extra_linkflags')
@@ -277,6 +284,17 @@ class CcTarget(Target):
                 incs_list.append(new_inc)
 
         return (cpp_flags, incs_list)
+
+    def _get_as_flags(self):
+        """_get_as_flags.
+
+        Return the as flags according to the build architecture.
+
+        """
+        options = self.blade.get_options()
+        as_flags = ["--" + options.m]
+        return as_flags
+
 
     def _dep_is_library(self, dep):
         """_dep_is_library.
@@ -524,6 +542,7 @@ class CcTarget(Target):
         env_name = self._env_name()
 
         self._setup_cc_flags()
+        self._setup_as_flags()
 
         objs = []
         sources = []

--- a/src/blade/rules_generator.py
+++ b/src/blade/rules_generator.py
@@ -228,6 +228,9 @@ compile_resource_message = '%sCompiling %s$SOURCE%s as resource file%s' % \
 compile_source_message = '%sCompiling %s$SOURCE%s%s' % \
     (colors('cyan'), colors('purple'), colors('cyan'), colors('end'))
 
+assembling_source_message = '%sAssembling %s$SOURCE%s%s' % \
+    (colors('cyan'), colors('purple'), colors('cyan'), colors('end'))
+
 link_program_message = '%sLinking Program %s$TARGET%s%s' % \
     (colors('green'), colors('purple'), colors('green'), colors('end'))
 
@@ -265,6 +268,7 @@ compile_swig_php_message = '%sCompiling %s$SOURCE%s to php source%s' % \
 top_env.Append(
     CXXCOMSTR = compile_source_message,
     CCCOMSTR = compile_source_message,
+    ASCOMSTR = assembling_source_message,
     SHCCCOMSTR = compile_source_message,
     SHCXXCOMSTR = compile_source_message,
     ARCOMSTR = link_library_message,


### PR DESCRIPTION
SCons天生支持汇编语言，因此，目前只要在cc_target的srcs里面写入.s文件，就可以编译。这个改动利用了SCons的两个参数ASFLAGS、ASCOMSTR使得这种集成更加平滑。

http://www.scons.org/doc/1.2.0/HTML/scons-user/a4774.html
