### PR TITLE
support other arch rather than x86, remove x86 spcified arguments for gc...

### DIFF
--- a/src/blade/blade_platform.py
+++ b/src/blade/blade_platform.py
@@ -152,8 +152,13 @@ class CcFlagsManager(object):
 
     def get_flags_except_warning(self):
         """Get the flags that are not warning flags. """
-        flags_except_warning = ['-m%s' % self.options.m, '-mcx16', '-pipe']
-        linkflags = ['-m%s' % self.options.m]
+        flags_except_warning = ['-pipe']
+        linkflags = []
+
+        if self.options.arch == 'x86':
+            flags_except_warning += ['-m%s' % self.options.m, '-mcx16']
+            linkflags += ['-m%s' % self.options.m]
+
         if self.options.profile == 'debug':
             flags_except_warning += ['-ggdb3', '-fstack-protector']
         elif self.options.profile == 'release':

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -288,9 +288,10 @@ class CcTarget(Target):
 
         """
         options = self.blade.get_options()
-        as_flags = ["--" + options.m]
-        return as_flags
-
+        if options.arch == 'x86':
+            return ["--" + options.m]
+        else:
+            return []
 
     def _dep_is_library(self, dep):
         """_dep_is_library.

--- a/src/blade/command_args.py
+++ b/src/blade/command_args.py
@@ -114,6 +114,7 @@ class CmdArguments(object):
             self.options.profile != 'release'):
             console.error_exit('--profile must be "debug" or "release".')
 
+        self.options.arch = self._arch()
         if self.options.m is None:
             self.options.m = self._arch_bits()
         else:
@@ -377,11 +378,19 @@ class CmdArguments(object):
         return arg_parser.parse_known_args()
 
     def _arch_bits(self):
-        """Platform arch."""
-        if 'x86_64' == platform.machine():
+        """Platform arch bit."""
+        if '64bit' == platform.architecture()[0]:
             return '64'
         else:
             return '32'
+
+    def _arch(self):
+        """Platform arch name."""
+        arch = platform.machine()
+        if arch in ['i386', 'i686', 'x86_64']:
+            return 'x86'
+        else:
+            return arch
 
     def get_command(self):
         """Return blade command. """

--- a/src/blade/load_build_files.py
+++ b/src/blade/load_build_files.py
@@ -49,10 +49,13 @@ class TargetAttributes(object):
 
     @property
     def arch(self):
-        if self._options.m == '32':
-            return 'i386'
+        if self._options.arch == 'x86':
+            if self._options.m == '32':
+                return 'i386'
+            else:
+                return 'x86_64'
         else:
-            return 'x86_64'
+            return self._options.arch
 
     def is_debug(self):
         return self._options.profile == 'debug'

--- a/src/blade/rules_generator.py
+++ b/src/blade/rules_generator.py
@@ -54,7 +54,7 @@ class SconsFileHeaderGenerator(object):
         self.version_cpp_compile_template = string.Template("""
 env_version = Environment(ENV = os.environ)
 env_version.Append(SHCXXCOMSTR = '%s$updateinfo%s' % (colors('cyan'), colors('end')))
-env_version.Append(CPPFLAGS = '-m$m')
+env_version.Append(CPPFLAGS = '$m')
 version_obj = env_version.SharedObject('$filename')
 """)
         self.blade_config = configparse.blade_config
@@ -140,9 +140,11 @@ version_obj = env_version.SharedObject('$filename')
         version_cpp.close()
 
         self._add_rule('VariantDir("%s", ".", duplicate=0)' % self.build_dir)
+
+        # todo - may not work in python 2.4
         self._add_rule(self.version_cpp_compile_template.substitute(
             updateinfo='Updating version information',
-            m=self.options.m,
+            m='-m%s' % self.options.m if self.options.arch == 'x86' else '',
             filename='%s/version.cpp' % self.build_dir))
 
     def generate_imports_functions(self, blade_path):

--- a/src/test/blade_test.py
+++ b/src/test/blade_test.py
@@ -39,6 +39,7 @@ class TargetTest(unittest.TestCase):
         self.current_building_path = 'build64_release'
         self.current_source_dir = '.'
         options = {
+                'arch': 'x86',
                 'm': '64',
                 'profile': 'release',
                 'generate_dynamic': True,

--- a/src/test/java_jar_test.py
+++ b/src/test/java_jar_test.py
@@ -119,11 +119,13 @@ class TestJavaJar(blade_test.TargetTest):
         self.assertTrue('poppy_client_javawrap.cxx' in com_swig_java)
 
         self.assertTrue('-fno-omit-frame-pointer' in com_swig_python_cxx)
-        self.assertTrue('-mcx16 -pipe -g' in com_swig_python_cxx)
+        self.assertTrue('-mcx16 -g' in com_swig_python_cxx)
+        self.assertTrue('-pipe' in com_swig_python_cxx)
         self.assertTrue('-DNDEBUG -D_FILE_OFFSET_BITS' in com_swig_python_cxx)
 
         self.assertTrue('-fno-omit-frame-pointer' in com_swig_java_cxx)
-        self.assertTrue('-mcx16 -pipe -g' in com_swig_java_cxx)
+        self.assertTrue('-mcx16 -g' in com_swig_java_cxx)
+        self.assertTrue('-pipe' in com_swig_java_cxx)
         self.assertTrue('-DNDEBUG -D_FILE_OFFSET_BITS' in com_swig_java_cxx)
 
         self.assertTrue(java_com_line)


### PR DESCRIPTION
gcc不支持-m32的原因是我是在arm上执行的gcc, -m32 -m64 -mcx16等都是x86架构专有的参数.

现在通过platform.architecture()来获取位数,并且参考platform.machine()来判断架构. 如果不是x86则不对CC, CXX, CPP, LD加入-mXX及-mcx16等参数, 并且不对AS加入-32或-64

测试之前好像有8个不通过, 不太熟悉代码, 没修.. 把新加代码break的一个测试改了改
