### PR TITLE
setup cc flags in lex_yacc_target

### DIFF
--- a/src/blade/lex_yacc_target.py
+++ b/src/blade/lex_yacc_target.py
@@ -91,6 +91,8 @@ class LexYaccLibrary(CcTarget):
         self._write_rule('%s.Depends(lex_%s, yacc_%s)' % (env_name,
                                                           var_name, var_name))
 
+        self._setup_cc_flags()
+
         obj_names = []
         obj_name = '%s_object' % self._generate_variable_name(
                     self.path, self.srcs[0] + '.cc')


### PR DESCRIPTION
N/A

Include paths introduced by the 'export_incs' property of lex_yacc_target's
dependencies are not added while compiling the c source code generated from lex
yacc source. This change will fix it.

Change-Id: I3aef7be0cd556b296ebf173156b9a25427551643
Signed-off-by: liuhuahang liuhuahang@zerus.co
