### PR TITLE
Add extra_cppflags for ProtoLibrary

### DIFF
--- a/blade.conf
+++ b/blade.conf
@@ -96,7 +96,8 @@ proto_library_config(
     protobuf_incs = 'thirdparty',
     protobuf_java_libs = [],
     protobuf_php_path='thirdparty/Protobuf-PHP/library',
-    protoc_php_plugin='thirdparty/Protobuf-PHP/protoc-gen-php.php'
+    protoc_php_plugin='thirdparty/Protobuf-PHP/protoc-gen-php.php',
+    extra_cppflags = [],
 )
 
 thrift_library_config(

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -243,6 +243,7 @@ class BladeConfig(object):
                 'protobuf_python_libs': [],
                 'protoc_direct_dependencies': False,
                 'well_known_protos': [],
+                'extra_cppflags': [],
             },
 
             'protoc_plugin_config': {

--- a/src/blade/proto_library_target.py
+++ b/src/blade/proto_library_target.py
@@ -116,7 +116,7 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
                 export_incs=[],
                 optimize=optimize,
                 linkflags=None,
-                extra_cppflags=[],
+                extra_cppflags=proto_config['extra_cppflags'],
                 extra_linkflags=[],
                 kwargs=kwargs)
 


### PR DESCRIPTION
Aim to add "-g1" cppflags for proto library, to reduce debug info size of the final binary