### PR TITLE
fix(proto) add java package and outerclassname into proto fingerprint

### DIFF
--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -127,6 +127,8 @@ class JavaTargetMixIn(object):
                 dep = self.target_database[k]
                 if 'generate_java' in dep.attr:  # Has this attribute
                     dep.attr['generate_java'] = True
+                    if hasattr(dep, 'update_java_gen_info'):
+                        dep.update_java_gen_info()
                     queue.extend(dep.deps)
 
     def _get_maven_dep_ids(self):


### PR DESCRIPTION
Issue:
When java_package or java_outer_classname changes, ninja will not update. This is because these two pieces of information are not included in the fingerprint calculation corresponding to the proto.