### PR TITLE
chore: remove dead code flagged by pyflakes

### DIFF
--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -571,8 +571,6 @@ class _NinjaFileHeaderGenerator(object):
         java_config = config.get_section('java_config')
         self.generate_javac_rules(java_config)
         self.generate_java_resource_rules()
-        jar = self.get_java_command(java_config, 'jar')
-        args = '%s ${out} ${in}' % jar
         self.generate_java_jar_rules(java_config)
         self.generate_java_test_rules()
         self.generate_fatjar_rules(java_config)

--- a/src/blade/thrift_library.py
+++ b/src/blade/thrift_library.py
@@ -69,7 +69,7 @@ class ThriftLibrary(CcTarget):
 
         # For each thrift file initialize a ThriftHelper, which will be used
         # to get the source files generated from thrift file.
-        sources, headers = [], []
+        headers = []
         self.thrift_helpers = {}
         for src in self.srcs:
             self.thrift_helpers[src] = ThriftHelper(self.path, src)


### PR DESCRIPTION
Cleanup discovered by a pyflakes scan. No behavior change.

### backend.py: drop unused 'jar' and 'args' in 'generate_java_scala_rules'
```python
jar = self.get_java_command(java_config, 'jar')
args = '%s ${out} ${in}' % jar
```
These two locals were never consumed; the actual jar / jar-building rules are emitted by `generate_java_jar_rules`. They look like a leftover from the pre-Ninja (SCons) implementation.

### thrift_library.py: drop unused 'sources'
```python
sources, headers = [], []
```
Only `headers` is ever appended to or read. Tuple-unpacked `sources` was never touched after the initial empty assignment. Replaced with a single `headers = []`.

### Diff summary
```
 src/blade/backend.py        | 2 --
 src/blade/thrift_library.py | 2 +-
 2 files changed, 1 insertion(+), 3 deletions(-)
```