### PR TITLE
fix: correct wrong class name in _TestResult super() call

### DIFF
--- a/src/test/html_test_runner.py
+++ b/src/test/html_test_runner.py
@@ -466,7 +466,7 @@ class _TestResult(TestResult):
     # It lacks the output and reporting ability compares to unittest._TextTestResult.
 
     def __init__(self, verbosity=1):
-        super(_TextTestResult, self).__init__()
+        super(_TestResult, self).__init__()
         self.stdout0 = None
         self.stderr0 = None
         self.success_count = 0


### PR DESCRIPTION
## Summary

One-line fix to `_TestResult.__init__` in [`src/test/html_test_runner.py`](src/test/html_test_runner.py): the `super(...)` call referenced a class name that does not exist in this module, which means the HTML test runner raises `NameError` the moment anyone actually uses it.

## The bug

```python
class _TestResult(TestResult):
    # ...
    def __init__(self, verbosity=1):
        super(_TextTestResult, self).__init__()   # ← _TextTestResult is undefined here
```

`_TextTestResult` is a class from CPython's `unittest` module (the comment block right above this method even mentions it). It was never imported or defined locally, so on Python 2/3 this would raise:

```
NameError: name '_TextTestResult' is not defined
```

`_TestResult` is instantiated from `HTMLTestRunner.run()`:

```python
result = _TestResult(self.verbosity)
```

…so any user of the HTML test runner (`blade test --coverage` paths that emit HTML reports, and direct consumers of `HTMLTestRunner`) would hit this immediately.

## The fix

```diff
-        super(_TextTestResult, self).__init__()
+        super(_TestResult, self).__init__()
```

Use the correct local class name. No behavior change beyond "the constructor no longer explodes".

## Why this wasn't caught earlier

- The code path is only reached when someone constructs a `_TestResult` — a plain `import html_test_runner` succeeds.
- There are no unit tests exercising `HTMLTestRunner.run()` end to end in this repo.
- Static analyzers (pyflakes/pylint) *do* flag `_TextTestResult` as an undefined name; this was surfaced by an automated audit sweep.

## Risk

Minimal. The fix restores what the author originally intended (the class's own MRO) and matches the documented purpose of `_TestResult` as a local subclass of `unittest.TestResult`.

## Test plan

```python
from blade.test.html_test_runner import _TestResult
r = _TestResult()           # before: NameError; after: ok
```
