### PR TITLE
fix: close files via 'with', rename typo'd method, use monotonic for durations

### DIFF
--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -803,6 +803,5 @@ class NinjaFileGenerator(object):
     def generate_build_script(self):
         """Generate build script for underlying build system."""
         code = self.generate_build_code()
-        script = open(self.script_path, 'w')
-        script.writelines(code)
-        script.close()
+        with open(self.script_path, 'w') as script:
+            script.writelines(code)

--- a/src/blade/build_manager.py
+++ b/src/blade/build_manager.py
@@ -168,7 +168,7 @@ class Blade(object):
         with open(inclusion_declaration_file, 'wb') as f:
             pickle.dump(cc_targets.inclusion_declaration(), f)
 
-    def _write_build_stamp_fime(self, start_time, exit_code):
+    def _write_build_stamp_file(self, start_time, exit_code):
         """Record some useful data for other tools."""
         stamp_data = {
             'start_time': start_time,
@@ -205,7 +205,7 @@ class Blade(object):
             self.build_jobs_num(),
             targets='',  # FIXME: because not all targets has a targets
             options=self.__options)
-        self._write_build_stamp_fime(start_time, returncode)
+        self._write_build_stamp_file(start_time, returncode)
         if returncode != 0:
             console.error('Build failure.')
         else:

--- a/src/blade/builtin_tools.py
+++ b/src/blade/builtin_tools.py
@@ -147,9 +147,8 @@ def generate_tar_package(path, sources, destinations, mode):
     tar = tarfile.open(path, mode, dereference=True)
     manifest = archive_package_sources(tar.add, sources, destinations)
     manifest_path = '%s.MANIFEST' % path
-    m = open(manifest_path, 'w')
-    m.write('\n'.join(manifest) + '\n\n')
-    m.close()
+    with open(manifest_path, 'w') as m:
+        m.write('\n'.join(manifest) + '\n\n')
     tar.add(manifest_path, _PACKAGE_MANIFEST)
     tar.close()
 

--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -399,7 +399,8 @@ class JavaTargetMixIn(object):
         if not os.path.isfile(file_name):
             return ''
         package_pattern = r'^\s*package\s+([\w.]+)'
-        content = open(file_name).read()
+        with open(file_name) as f:
+            content = f.read()
         m = re.search(package_pattern, content, re.MULTILINE)
         if m:
             return m.group(1)

--- a/src/blade/main.py
+++ b/src/blade/main.py
@@ -174,9 +174,9 @@ def format_timedelta(seconds):
 def main(blade_path, argv):
     exit_code = 0
     try:
-        start_time = time.time()
+        start_time = time.monotonic()
         exit_code = _main(blade_path, argv)
-        cost_time = time.time() - start_time
+        cost_time = time.monotonic() - start_time
         console.info('Cost time %s' % format_timedelta(cost_time))
     except SystemExit as e:
         # pylint misreport e.code as classobj


### PR DESCRIPTION
## 概述

本 PR 是一次小而独立的代码加固，**不涉及任何行为/功能修改**，仅做资源管理、拼写与时间量测上的修复。

## 改动

### 1. 文件句柄泄漏修复（改用 `with` 语句）

| 文件 | 问题 |
| --- | --- |
| `src/blade/java_targets.py` | `content = open(file_name).read()` 在 CPython 下依赖引用计数瞬时关闭，在 PyPy/异常路径下文件描述符会悬空。|
| `src/blade/backend.py` | `generate_build_script` 使用裸 `open/writelines/close`，`writelines` 抛异常时不会关闭句柄。|
| `src/blade/builtin_tools.py` | `generate_tar_package` 写 manifest 时同样是裸 `open/write/close`。|

三处统一改为 `with open(...) as f: ...` 惯用法。

### 2. 方法名拼写修复

- `Blade._write_build_stamp_fime` → `_write_build_stamp_file`
- 该方法写的正是 `blade_build_stamp.json` 文件，`fime` 显然是 `file` 的手误。
- 是私有方法（`_` 前缀）且仅在同文件内被调用一次，零外部影响。

### 3. 构建耗时改用单调时钟

- `src/blade/main.py` 的 `main()` 中，`start_time` 只用来和函数末尾的 `time.time()` 相减得到 `Cost time`，是纯粹的时长量测。
- 改为 `time.monotonic()`。
- 语义等价，但在构建过程中如果系统时钟被 NTP 回拨/手动调整，不再会输出类似 `Cost time -0:00:05` 这种令人困惑的负值。
- `start_time` 没有被传出函数外，也没有被当做日历时间戳使用，改动完全局部安全。

## 风险评估

- 所有改动均为语义等价的重构或严格修复，**没有**任何一处会改变可观察行为的"正常路径"。
- `py_compile` 全部通过，`pyflakes` 无新增告警。
- 改动总计 5 文件，10 增 11 删。

## 相关背景

延续前序的审计与修复系列（#1082 / #1083 / #1084 / #1085），这是审计过程中识别出但尚未落地的剩余可即修项的打包交付。
