### PR TITLE
fix: tighten resource and exception handling

### DIFF
--- a/src/blade/binary_runner.py
+++ b/src/blade/binary_runner.py
@@ -178,17 +178,18 @@ class BinaryRunner(object):
                                 '%s.testdata' % target.name)
         if os.path.isfile(testdata):
             runfiles_dir = self._runfiles_dir(target)
-            for line in open(testdata):
-                data = line.strip().split()
-                if len(data) == 1:
-                    src, dst = data[0], ''
-                else:
-                    src, dst = data[0], data[1]
-                dst = os.path.join(runfiles_dir, dst)
-                dst_dir = os.path.dirname(dst)
-                if not os.path.isdir(dst_dir):
-                    os.makedirs(dst_dir)
-                shutil.copy2(src, dst)
+            with open(testdata) as f:
+                for line in f:
+                    data = line.strip().split()
+                    if len(data) == 1:
+                        src, dst = data[0], ''
+                    else:
+                        src, dst = data[0], data[1]
+                    dst = os.path.join(runfiles_dir, dst)
+                    dst_dir = os.path.dirname(dst)
+                    if not os.path.isdir(dst_dir):
+                        os.makedirs(dst_dir)
+                    shutil.copy2(src, dst)
 
     def _clean_target(self, target):
         """Clean the executive environment."""

--- a/src/blade/build_manager.py
+++ b/src/blade/build_manager.py
@@ -283,15 +283,17 @@ class Blade(object):
             output_file = sys.stdout
             console.info('Query result:')
 
-        output_format = self.__options.output_format
-        if output_format == 'dot':
-            self.query_dependency_dot(output_file)
-        elif output_format == 'tree':
-            self.query_dependency_tree(output_file)
-        else:
-            self.query_dependency_plain(output_file)
-        if output_file_name:
-            output_file.close()
+        try:
+            output_format = self.__options.output_format
+            if output_format == 'dot':
+                self.query_dependency_dot(output_file)
+            elif output_format == 'tree':
+                self.query_dependency_tree(output_file)
+            else:
+                self.query_dependency_plain(output_file)
+        finally:
+            if output_file_name:
+                output_file.close()
         return 0
 
     def query_dependency_plain(self, output_file):

--- a/src/blade/dwp_wrapper.py
+++ b/src/blade/dwp_wrapper.py
@@ -165,7 +165,8 @@ def run_dwp(output_path, dwo_files, dwp_tool='dwp'):
     if not dwo_files:
         console.warning("Warning: No .dwo files found, skipping dwp generation")
         # Create an empty file to satisfy ninja
-        open(output_path, 'w').close()
+        with open(output_path, 'w'):
+            pass
         return 0
 
     # Use a response file if there are many .dwo files
@@ -187,7 +188,7 @@ def run_dwp(output_path, dwo_files, dwp_tool='dwp'):
             # Clean up response file
             try:
                 os.unlink(rsp_path)
-            except:  # pylint: disable=bare-except
+            except OSError:
                 pass
     else:
         # Call dwp directly with all .dwo files

--- a/src/blade/inclusion_check.py
+++ b/src/blade/inclusion_check.py
@@ -39,7 +39,8 @@ class GlobalDeclaration(object):
         if self._initialized:
             return
         console.debug("Load global declaration file, " + reason)
-        declaration = pickle.load(open(self._declaration_file, 'rb'))
+        with open(self._declaration_file, 'rb') as f:
+            declaration = pickle.load(f)
         # pylint: disable=attribute-defined-outside-init
         self._hdr_targets_map = declaration['public_hdrs']
         self._hdr_dir_targets_map = declaration['public_incs']
@@ -407,7 +408,8 @@ class Checker(object):
 
 
 def check(target_check_info_file):
-    target = pickle.load(open(target_check_info_file, 'rb'))
+    with open(target_check_info_file, 'rb') as f:
+        target = pickle.load(f)
     extra_file = target_check_info_file + '.extra'
     if os.path.exists(extra_file):
         with open(extra_file, 'rb') as f:

--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -399,7 +399,7 @@ class JavaTargetMixIn(object):
         if not os.path.isfile(file_name):
             return ''
         package_pattern = r'^\s*package\s+([\w.]+)'
-        with open(file_name) as f:
+        with open(file_name, encoding='utf-8') as f:
             content = f.read()
         m = re.search(package_pattern, content, re.MULTILINE)
         if m:

--- a/src/blade/load_build_files.py
+++ b/src/blade/load_build_files.py
@@ -315,7 +315,7 @@ def __load_build_file(source_dir, blade):
                 return True
             except SystemExit:
                 console.fatal('%s: Fatal error' % build_file)
-            except:  # pylint: disable=bare-except
+            except Exception:
                 console.fatal('Parse error in %s\n%s' % (
                     build_file, traceback.format_exc()))
         else:

--- a/src/blade/main.py
+++ b/src/blade/main.py
@@ -184,7 +184,7 @@ def main(blade_path, argv):
     except KeyboardInterrupt:
         console.error('KeyboardInterrupt')
         exit_code = -signal.SIGINT
-    except:  # pylint: disable=bare-except
+    except Exception:
         exit_code = 1
         console.error(traceback.format_exc())
     if exit_code != 0:

--- a/src/blade/ninja_runner.py
+++ b/src/blade/ninja_runner.py
@@ -78,8 +78,7 @@ def _run_ninja_command(cmdstr):
     try:
         p.wait()
         return p.returncode
-    # pylint: disable=bare-except
-    except:  # KeyboardInterrupt
+    except KeyboardInterrupt:
         return 1
 
 

--- a/src/blade/swig_library_target.py
+++ b/src/blade/swig_library_target.py
@@ -84,11 +84,12 @@ class SwigLibrary(CcTarget):
 
     def _swig_extract_dependency_files(self, src):
         dep = []
-        for line in open(src):
-            if line.startswith('#include') or line.startswith('%include'):
-                line = line.split(' ')[1].strip("""'"\r\n""")
-                if not ('<' in line or line in dep):
-                    dep.append(line)
+        with open(src) as f:
+            for line in f:
+                if line.startswith('#include') or line.startswith('%include'):
+                    line = line.split(' ')[1].strip("""'"\r\n""")
+                    if not ('<' in line or line in dep):
+                        dep.append(line)
         return [i for i in dep if os.path.exists(i)]
 
     def generate(self):

--- a/src/blade/test_scheduler.py
+++ b/src/blade/test_scheduler.py
@@ -118,7 +118,7 @@ class WorkerThread(threading.Thread):
                     self.cleanup_job()
                 finally:
                     self.job_lock.release()
-        except:  # pylint: disable=bare-except
+        except Exception:
             traceback.print_exc()
 
 

--- a/src/blade/thrift_helper.py
+++ b/src/blade/thrift_helper.py
@@ -50,38 +50,39 @@ class ThriftParser(object):
         self._parse_file()
 
     def _parse_file(self):
-        for line in open(self.path):
-            line = line.strip()
-            if line.startswith('//') or line.startswith('#'):
-                continue
-            pos = line.find('//')
-            if pos != -1:
-                line = line[:pos]
-            pos = line.find('#')
-            if pos != -1:
-                line = line[:pos]
+        with open(self.path) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith('//') or line.startswith('#'):
+                    continue
+                pos = line.find('//')
+                if pos != -1:
+                    line = line[:pos]
+                pos = line.find('#')
+                if pos != -1:
+                    line = line[:pos]
 
-            matched = re.match('^namespace ([0-9_a-zA-Z]+) ([0-9_a-zA-Z.]+)', line)
-            if matched:
-                lang, package = matched.groups()
-                self.package_name[lang] = package
-                continue
+                matched = re.match('^namespace ([0-9_a-zA-Z]+) ([0-9_a-zA-Z.]+)', line)
+                if matched:
+                    lang, package = matched.groups()
+                    self.package_name[lang] = package
+                    continue
 
-            matched = re.match('(const|struct|service|enum|exception) ([0-9_a-zA-Z]+)', line)
-            if not matched:
-                continue
+                matched = re.match('(const|struct|service|enum|exception) ([0-9_a-zA-Z]+)', line)
+                if not matched:
+                    continue
 
-            kw, name = matched.groups()
-            if kw == 'const':
-                self.has_constants = True
-            elif kw == 'struct':
-                self.structs.append(name)
-            elif kw == 'service':
-                self.services.append(name)
-            elif kw == 'enum':
-                self.enums.append(name)
-            elif kw == 'exception':
-                self.exceptions.append(name)
+                kw, name = matched.groups()
+                if kw == 'const':
+                    self.has_constants = True
+                elif kw == 'struct':
+                    self.structs.append(name)
+                elif kw == 'service':
+                    self.services.append(name)
+                elif kw == 'enum':
+                    self.enums.append(name)
+                elif kw == 'exception':
+                    self.exceptions.append(name)
 
         if self.has_constants or self.structs or self.enums or \
                 self.exceptions or self.services:

--- a/src/blade/util.py
+++ b/src/blade/util.py
@@ -287,7 +287,8 @@ def eval_file(filepath):
     The string or node provided may only consist of the following Python literal structures:
     strings, bytes, numbers, tuples, lists, dicts, sets, booleans, and None.
     """
-    return ast.literal_eval(open(filepath).read())
+    with open(filepath) as f:
+        return ast.literal_eval(f.read())
 
 
 def source_location(filename):


### PR DESCRIPTION
## Summary

Three small, related classes of defects in resource and exception handling, no behaviour change on the happy path.

### 1. File handle leaks on exceptional paths (B2)

Several `open()` calls were not wrapped in `with`, so the file object only got closed when GC happened to run. On CPython this is "usually fine" until an exception is raised in the body of the loop/function; then the fd lingers until GC and (on Windows) also holds an exclusive lock.

Converted to `with` (or `try/finally` where the file object must outlive a single block):

- `util.eval_file`
- `inclusion_check.lazy_init`, `inclusion_check.check`
- `thrift_helper._parse_file`
- `swig_library_target._swig_extract_dependency_files`
- `binary_runner._prepare_extra_test_data`
- `dwp_wrapper.generate_dwp` (the "create empty file" branch)
- `build_manager.query`

The module-level `_log` in `console.py` is deliberately left as-is: its lifetime equals the process lifetime.

### 2. Encoding-dependent crash when reading Java source (B3)

`java_targets._get_source_package_name` opened Java source files with the platform default encoding. On Windows (cp1252/gbk) any non-ASCII byte in a comment makes `f.read()` raise `UnicodeDecodeError`, which kills the whole build.

Java source is UTF-8 per the language spec, so pass `encoding="utf-8"` explicitly. The regex only looks for `package x.y.z;` (pure ASCII), so decoding correctness only needs to hold for the rest of the file.

### 3. Bare `except:` swallowing KeyboardInterrupt / SystemExit (B4)

Five bare `except:` clauses also caught `KeyboardInterrupt` and `SystemExit`, which made Ctrl+C either sluggish or completely ineffective, and silently hid `sys.exit()` calls. Narrowed to the actually intended exception class:

| Location | Was | Now |
| --- | --- | --- |
| `ninja_runner._run_ninja_command` | bare (commented "KeyboardInterrupt") | `except KeyboardInterrupt` |
| `dwp_wrapper` cleanup of rsp file | bare | `except OSError` |
| `test_scheduler` worker loop | bare | `except Exception` |
| `load_build_files` BUILD-file exec | bare | `except Exception` |
| `main._wrap_main` top-level | bare | `except Exception` |

The accompanying `# pylint: disable=bare-except` comments are removed along with the bare clauses.

## Out of scope (intentionally)

- Mutable default argument (`def f(xs=[])`) occurrences. Will be handled together with the type-hint migration.
- Python 2 compatibility shims (`__future__`, `iteritems`, short `super()`, etc.). Deferred to a dedicated PR after Py2 support is dropped.
- `src/blade/pathlib.py`: scheduled for removal, not touched here.

## Test

- `python3 -m compileall` all touched files: OK.
- `bash src/test/runall.sh`: 17 passing tests remain passing. The 9 failures (`cc/libuppercase.so` etc.) also reproduce on `master` on macOS without a full C++ toolchain set up; they are environmental, not introduced by this PR.
- `pyflakes` on all touched files: only pre-existing warnings remain.
