### PR TITLE
fix: replace shell=True with argv lists for internal commands

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -619,7 +619,7 @@ class CcTarget(Target):
 
     def _soname_of(self, so_path):
         """Get the `soname` of a shared library."""
-        returncode, output, unused_stderr = run_command('objdump -p %s' % so_path, shell=True)
+        returncode, output, unused_stderr = run_command(['objdump', '-p', so_path])
         if returncode != 0:
             return None
         for line in output.splitlines():

--- a/src/blade/go_targets.py
+++ b/src/blade/go_targets.py
@@ -85,7 +85,7 @@ class GoTarget(Target):
     def _init_go_environment(self):
         if GoTarget._go_os is None and GoTarget._go_arch is None:
             go = config.get_item('go_config', 'go')
-            returncode, stdout, stderr = run_command('%s env' % go, shell=True)
+            returncode, stdout, stderr = run_command([go, 'env'])
             if returncode != 0:
                 self.error('Failed to initialize go environment: %s' % stderr)
                 return

--- a/src/blade/toolchain.py
+++ b/src/blade/toolchain.py
@@ -122,7 +122,7 @@ class ToolChain(object):
 
     def _get_cc_version(self):
         version = ''
-        returncode, stdout, stderr = run_command(self.cc + ' -dumpversion', shell=True)
+        returncode, stdout, stderr = run_command([self.cc, '-dumpversion'])
         if returncode == 0:
             version = stdout.strip()
         if not version:
@@ -133,7 +133,7 @@ class ToolChain(object):
     def get_cc_target_arch():
         """Get the cc target architecture."""
         cc = ToolChain._get_cc_command('CC', 'gcc')
-        returncode, stdout, stderr = run_command(cc + ' -dumpmachine', shell=True)
+        returncode, stdout, stderr = run_command([cc, '-dumpmachine'])
         if returncode == 0:
             return stdout.strip()
         return ''

--- a/src/blade/util.py
+++ b/src/blade/util.py
@@ -134,7 +134,7 @@ def get_cwd():
     So in practice we simply use system('pwd') to get current working directory.
 
     """
-    p = subprocess.Popen(['pwd'], stdout=subprocess.PIPE, shell=True)
+    p = subprocess.Popen(['pwd'], stdout=subprocess.PIPE)
     return to_string(p.communicate()[0].strip())
 
 
@@ -357,7 +357,7 @@ def open_zip_file_for_write(filename, compression_level):
 
 
 def which(cmd):
-    returncode, stdout, _ = run_command("which %s" % cmd, shell=True)
+    returncode, stdout, _ = run_command(['which', cmd])
     if returncode != 0:
         return None
     return stdout.strip()

--- a/src/blade/workspace.py
+++ b/src/blade/workspace.py
@@ -22,7 +22,7 @@ from blade import util
 
 def _generate_scm_svn():
     url = revision = 'unknown'
-    returncode, stdout, stderr = util.run_command('svn info', shell=True)
+    returncode, stdout, stderr = util.run_command(['svn', 'info'])
     if returncode != 0:
         console.debug('Failed to generate svn scm: %s' % stderr)
     else:
@@ -40,16 +40,16 @@ def _generate_scm_git():
     url = revision = 'unknown'
 
     def git(cmd):
-        returncode, stdout, stderr = util.run_command(cmd, shell=True)
+        returncode, stdout, stderr = util.run_command(cmd)
         if returncode != 0:
             console.debug('Failed to generate git scm: %s' % stderr)
             return ''
         return stdout
 
-    out = git('git rev-parse HEAD')
+    out = git(['git', 'rev-parse', 'HEAD'])
     if out:
         revision = out.strip()
-    out = git('git remote -v')
+    out = git(['git', 'remote', '-v'])
     # $ git remote -v
     # origin  https://github.com/chen3feng/blade-build.git (fetch)
     # origin  https://github.com/chen3feng/blade-build.git (push)


### PR DESCRIPTION
## Summary

Tightens argument-passing in subprocess calls by replacing `shell=True`
+ string formatting with explicit argv lists wherever the command line
is built from user-controlled data (BUILD configuration, artifact ids,
shared-library paths, etc.).

This is the **no-behaviour-change** subset of the subprocess-hardening
plan. A follow-up PR (A2b) will cover the two remaining sites that
need more than a mechanical substitution.

## Changes

| File | Before | After |
| --- | --- | --- |
| `util.py:137` | `Popen(['pwd'], stdout=PIPE, shell=True)` (latent bug — list + `shell=True` runs `sh -c pwd`) | `Popen(['pwd'], stdout=PIPE)` |
| `util.py:360` | `run_command("which %s" % cmd, shell=True)` | `run_command(['which', cmd])` |
| `cc_targets.py:622` | `run_command('objdump -p %s' % so_path, shell=True)` | `run_command(['objdump', '-p', so_path])` |
| `go_targets.py:88` | `run_command('%s env' % go, shell=True)` | `run_command([go, 'env'])` |
| `toolchain.py:125` | `run_command(self.cc + ' -dumpversion', shell=True)` | `run_command([self.cc, '-dumpversion'])` |
| `toolchain.py:136` | `run_command(cc + ' -dumpmachine', shell=True)` | `run_command([cc, '-dumpmachine'])` |
| `workspace.py:25` | `run_command('svn info', shell=True)` | `run_command(['svn', 'info'])` |
| `workspace.py:40-52` | nested `git()` helper took shell strings | helper accepts argv list; callers pass `['git', 'rev-parse', 'HEAD']` / `['git', 'remote', '-v']` |

5 files changed, +10/-10.

## What is retained (and why)

| Site | Reason |
| --- | --- |
| `backend.py:64` | Literal `'set -o pipefail 2>/dev/null'` probe, no variable splicing, no risk. |
| `ninja_runner.py:69,77` | `cmdstr` intentionally contains shell redirection (`' > output_file'`); refactoring requires separating the redirect from the argv, out of scope. |
| `util.shell()` + `dwp_wrapper.py` / `builtin_tools.py` callers | `util.shell()`'s documented contract is "shell-style command"; callers pass pipelines. Out of scope. |
| `toolchain.filter_cc_flags` (line 170) | Planned for A2b — needs a real rewrite (stdin pipe + `env=` dict instead of `export LC_ALL=C; echo ... \| cc`). |
| `maven.py:168,175,216` | Planned for A2b — needs `stdout=open(log, 'w')` to replace shell redirection of `mvn > log`. |

## Verification

```
$ python3 -m py_compile src/blade/{util,cc_targets,go_targets,toolchain,workspace}.py
OK

$ grep -n 'shell=True' src/blade/*.py
# only the intentionally retained call sites remain

$ bash src/test/runall.sh
Ran 26 tests in 15.219s
FAILED (failures=9, skipped=3)
# Identical to master's baseline on this macOS environment; all 9
# failures are `clang: error: unsupported option '-static-libgcc'`
# and pre-date this change.
```

The fact that `get_cc_version` / `get_cc_target_arch` get exercised
early during toolchain init (before the clang linker errors) is
indirect evidence that the argv conversion did not break the cc
probe path.

## Related

Follow-up to #1086, #1088 (same audit trail). A2b (maven + filter_cc_flags)
will come as a separate PR once this is merged, to keep each review small.
