### PR TITLE
fix: replace shell=True with argv in filter_cc_flags and maven

### DIFF
--- a/src/blade/maven.py
+++ b/src/blade/maven.py
@@ -156,23 +156,27 @@ class MavenCache(object):
         if classifier:
             id = '%s:%s' % (id, classifier)
         target.info('Downloading maven_jar %s' % id)
-        cmd = ' '.join([self.__maven,
-                        'dependency:get',
-                        '-DgroupId=%s' % group,
-                        '-DartifactId=%s' % artifact,
-                        '-Dversion=%s' % version])
+        cmd = [self.__maven,
+               'dependency:get',
+               '-DgroupId=%s' % group,
+               '-DartifactId=%s' % artifact,
+               '-Dversion=%s' % version]
         if classifier:
-            cmd += ' -Dclassifier=%s' % classifier
-        cmd += ' -e -X'  # More detailed debug message
-        target.debug(cmd)
-        if subprocess.call('%s > %s' % (cmd, log_path), shell=True) != 0:
+            cmd.append('-Dclassifier=%s' % classifier)
+        cmd += ['-e', '-X']  # More detailed debug message
+        target.debug(subprocess.list2cmdline(cmd))
+        with open(log_path, 'w') as logf:
+            rc = subprocess.call(cmd, stdout=logf)
+        if rc != 0:
             message = ('Error downloading maven_jar %s, see "%s" for details.' % (id, log_path))
             # Rertry without transitive
-            cmd += ' -Dtransitive=false'
+            cmd.append('-Dtransitive=false')
             with open(log_path, 'a') as f:
                 f.write('\n\nBlade: Retry without transitive dependencies\n\n')
 
-            if subprocess.call('%s >> %s' % (cmd, log_path), shell=True) != 0:
+            with open(log_path, 'a') as logf:
+                rc = subprocess.call(cmd, stdout=logf)
+            if rc != 0:
                 target.error(message)
                 return False
             target.warning('Downloaded maven_jar %s, but without its transitive dependencies.' % id)
@@ -206,14 +210,17 @@ class MavenCache(object):
         target.info('Querying dependencies for maven_jar %s' % id)
         classpath_tmp = classpath + '.tmp'
         pom = os.path.join(artifact_dir, artifact + '-' + version + '.pom')
-        cmd = ' '.join([self.__maven,
-                        'dependency:build-classpath',
-                        '-DincludeScope=runtime',
-                        '-Dmdep.outputFile=%s' % classpath_tmp])
-        cmd += ' -e -X -f %s > %s' % (pom, log)
+        cmd = [self.__maven,
+               'dependency:build-classpath',
+               '-DincludeScope=runtime',
+               '-Dmdep.outputFile=%s' % classpath_tmp,
+               '-e', '-X',
+               '-f', pom]
         classpath = os.path.join(artifact_dir, classpath)
         classpath_tmp = os.path.join(artifact_dir, classpath_tmp)
-        if subprocess.call(cmd, shell=True) != 0:
+        with open(log, 'w') as logf:
+            rc = subprocess.call(cmd, stdout=logf)
+        if rc != 0:
             target.warning('Failed to query dependencies of %s , see "%s" for details.' % (id, log))
             try:
                 os.remove(classpath_tmp)

--- a/src/blade/toolchain.py
+++ b/src/blade/toolchain.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 
 import os
 import re
+import subprocess
 import tempfile
 
 from blade import console
@@ -164,17 +165,28 @@ class ToolChain(object):
         # with status 1 which makes '--coverage' unsupported
         # echo "int main() { return 0; }" | gcc -o /dev/null -c -x c --coverage - > /dev/null 2>&1
         fd, obj = tempfile.mkstemp('.o', 'filter_cc_flags_test')
-        cmd = ('export LC_ALL=C; echo "int main() { return 0; }" | '
-               '%s -o %s -c -x %s -Werror %s -' % (
-                   self.cc, obj, language, ' '.join(flag_list)))
-        returncode, _, stderr = run_command(cmd, shell=True)
-
+        # Force C locale so we can reliably match the error messages below.
+        env = os.environ.copy()
+        env['LC_ALL'] = 'C'
+        argv = [self.cc, '-o', obj, '-c', '-x', language, '-Werror'] + list(flag_list) + ['-']
         try:
-            # In case of error, the `.o` file will be deleted by the compiler
-            os.remove(obj)
-        except OSError:
-            pass
-        os.close(fd)
+            proc = subprocess.Popen(
+                argv,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env)
+            _, stderr = proc.communicate(input=b'int main() { return 0; }\n')
+            returncode = proc.returncode
+            if isinstance(stderr, bytes):
+                stderr = stderr.decode('utf-8', errors='replace')
+        finally:
+            try:
+                # In case of error, the `.o` file will be deleted by the compiler
+                os.remove(obj)
+            except OSError:
+                pass
+            os.close(fd)
 
         if returncode == 0:
             return flag_list


### PR DESCRIPTION
## Summary

Complete the subprocess hardening plan started in #1089. This PR covers
the two call sites that needed **more than a mechanical argv conversion**:
one shell pipe with `export LC_ALL=C; echo ... | cc ...`, and three
shell redirections of the form `mvn ... > log` / `>> log`.

After this PR, every remaining `shell=True` in `src/blade/*.py` is
either a fixed string literal (no variable splicing) or carries shell
redirection by design (`ninja_runner`'s build command string,
`util.shell()` helper with its three documented callers).

## Changes

### `toolchain.filter_cc_flags`

Before:

```python
cmd = ('export LC_ALL=C; echo "int main() { return 0; }" | '
       '%s -o %s -c -x %s -Werror %s -' % (
           self.cc, obj, language, ' '.join(flag_list)))
returncode, _, stderr = run_command(cmd, shell=True)
```

After:

```python
env = os.environ.copy()
env['LC_ALL'] = 'C'
argv = [self.cc, '-o', obj, '-c', '-x', language, '-Werror'] + list(flag_list) + ['-']
proc = subprocess.Popen(argv,
                        stdin=subprocess.PIPE,
                        stdout=subprocess.PIPE,
                        stderr=subprocess.PIPE,
                        env=env)
_, stderr = proc.communicate(input=b'int main() { return 0; }\n')
returncode = proc.returncode
if isinstance(stderr, bytes):
    stderr = stderr.decode('utf-8', errors='replace')
```

- Source is now fed through `stdin=PIPE` instead of piped via a shell.
- `LC_ALL=C` is scoped to the child via `env=` instead of `export` in a subshell.
- The temporary `.o` cleanup and `os.close(fd)` move into `try/finally`
  so they run on every exit path, including `Popen` raising.

### `maven._download_jar` / `maven._download_dependency`

Three sites:

| Before | After |
| --- | --- |
| `subprocess.call('%s > %s' % (cmd, log_path), shell=True)` | `with open(log_path, 'w') as logf: subprocess.call(cmd, stdout=logf)` |
| `subprocess.call('%s >> %s' % (cmd, log_path), shell=True)` | `with open(log_path, 'a') as logf: subprocess.call(cmd, stdout=logf)` |
| `subprocess.call(cmd, shell=True)` (cmd ends with `... > log`) | argv list with `-f pom` as two elements + `stdout=open(log, 'w')` |

`cmd` is now a list from construction; `' '.join([...])` + later string
concatenation is gone. `subprocess.list2cmdline(cmd)` is used only for
the debug log printout. stderr continues to propagate to the caller,
matching the previous shell behaviour (the old commands did not
redirect stderr either).

2 files changed, +46/-27.

## What still uses `shell=True` (all intentional)

| Site | Reason |
| --- | --- |
| `backend.py:64` | `'set -o pipefail 2>/dev/null'` — literal probe, no variables. |
| `ninja_runner.py:69,77` | `cmdstr` carries shell redirection (`' > output_file'`) by design. |
| `util.shell()` + `dwp_wrapper.py`, `builtin_tools.py` callers | `util.shell()`'s documented contract is "shell-style command"; callers pass pipelines. |

## Verification

```
$ python3 -m py_compile src/blade/toolchain.py src/blade/maven.py
OK

$ grep -n 'shell=True' src/blade/*.py | grep -v '^.*:.*#'
src/blade/backend.py:64:    ... 'set -o pipefail 2>/dev/null' ...
src/blade/ninja_runner.py:69: Popen(cmdstr, shell=True, stdout=wf, ...)
src/blade/ninja_runner.py:77: Popen(cmdstr, shell=True)
src/blade/util.py:195: ... shell=True)   # util.shell() helper

$ bash src/test/runall.sh
Ran 26 tests in 14.916s
FAILED (failures=9, skipped=3)
# Identical to master's baseline on this macOS environment; the 9
# failures are `clang: error: unsupported option '-static-libgcc'`
# and pre-date this change.
```

Targeted smoke test of the rewritten `filter_cc_flags`:

```
filter_cc_flags(['-O2'])          -> ['-O2']
filter_cc_flags(['-Wzzz'])        -> []          (+ warning: Unrecognized c flags: -Wzzz)
filter_cc_flags(['-O2', '-Wzzz']) -> ['-O2']    (+ warning: Unrecognized c flags: -Wzzz)
```

This exercises the happy path, the pure-unrecognized path, and the
mixed path (confirming `stderr` decoding and the `" option '%s'"`
match still work correctly).

## Related

Follow-up to #1086, #1088, #1089. This closes out the subprocess
argv/shell audit begun in #1086.
