### PR TITLE
fix(v3): cc vendor detection and python interpreter override

### DIFF
--- a/blade
+++ b/blade
@@ -65,9 +65,49 @@ function _full_real_path() {
     return 0
 }
 
+# Return 0 and echo the interpreter if "$1" is a single executable on PATH
+# whose `-V` reports Python >= 3.10. Return 1 otherwise (silently).
+# Multi-word values (e.g. "python -m coverage run ...") are intentionally
+# rejected so that the full-command form stays routed through the final
+# ${BLADE_PYTHON_INTERPRETER:-$python} fallback at the bottom of this
+# script rather than being executed with a bare `-V`.
+function _probe_python() {
+    local candidate="$1"
+    [ -n "$candidate" ] || return 1
+    # Single-word check: reject if the value contains whitespace.
+    case "$candidate" in
+        *[[:space:]]*) return 1 ;;
+    esac
+    command -v "$candidate" &> /dev/null || return 1
+
+    local ver major rest minor
+    ver=$("$candidate" -V 2>&1 | sed 's/Python //g')
+    major=${ver%%.*}
+    rest=${ver#*.}
+    minor=${rest%%.*}
+    [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ ]] || return 1
+    if (( major > 3 )) || (( major == 3 && minor >= 10 )); then
+        echo "$candidate"
+        return 0
+    fi
+    return 1
+}
+
 # Check the python version at first, exit blade when python
 # version is under 3.10.
 function _check_python() {
+    # Honor BLADE_PYTHON_INTERPRETER when it names a single executable that
+    # already satisfies the version requirement. This lets users point blade
+    # at e.g. /opt/homebrew/bin/python3.12 without having to shadow the
+    # system python3 on PATH. Multi-word values (coverage wrappers etc.)
+    # silently fall through to auto-detection and are re-applied at the
+    # final `${BLADE_PYTHON_INTERPRETER:-$python}` invocation below.
+    local override
+    if override=$(_probe_python "${BLADE_PYTHON_INTERPRETER:-}"); then
+        echo "$override"
+        return 0
+    fi
+
     local python=""
     if command -v python3 &> /dev/null; then
         python="python3"

--- a/src/blade/toolchain.py
+++ b/src/blade/toolchain.py
@@ -112,6 +112,7 @@ class ToolChain(object):
         self.ld = self._get_cc_command('LD', 'g++')
         self.cc_version = self._get_cc_version()
         self.ar = self._get_cc_command('AR', 'ar')
+        self._cc_vendor = self._detect_cc_vendor()
 
     @staticmethod
     def _get_cc_command(env, default):
@@ -127,6 +128,36 @@ class ToolChain(object):
         if not version:
             console.fatal('Failed to obtain cc toolchain.')
         return version
+
+    def _detect_cc_vendor(self):
+        """Identify the cc vendor by querying the compiler itself.
+
+        Returns one of:
+          - 'clang'        : LLVM/Clang (including Apple Clang that masquerades as
+                             /usr/bin/gcc on macOS).
+          - 'gcc'          : Real GNU GCC.
+          - 'unknown'      : Detection failed. Callers treating a specific vendor
+                             as a precondition should take the conservative path.
+
+        Rationale: Relying on substring matching against the `cc` command name is
+        unreliable. On macOS `gcc` is typically an alias for Apple Clang, and
+        user-set CC/CXX may be an absolute path or a wrapper whose name reveals
+        nothing about the underlying vendor.
+        """
+        returncode, stdout, stderr = run_command([self.cc, '--version'])
+        if returncode != 0:
+            return 'unknown'
+        # `--version` output typically goes to stdout, but some wrappers emit on
+        # stderr. Concatenate both and lower-case for robust matching.
+        text = ((stdout or '') + '\n' + (stderr or '')).lower()
+        if 'clang' in text:
+            return 'clang'
+        # Match 'gcc ', '(gcc)', 'gnu c' etc., but only after we've ruled out
+        # clang (Apple Clang banner contains neither, upstream Clang shows
+        # 'clang version ...').
+        if 'gcc' in text or 'free software foundation' in text:
+            return 'gcc'
+        return 'unknown'
 
     @staticmethod
     def get_cc_target_arch():
@@ -150,8 +181,12 @@ class ToolChain(object):
         return self.ar
 
     def cc_is(self, vendor):
-        """Is cc is used for C/C++ compilation match vendor."""
-        return vendor in self.cc
+        """Return whether the detected cc vendor equals the given vendor.
+
+        The comparison is an exact match against the result of
+        `_detect_cc_vendor()` (one of 'clang', 'gcc', 'unknown').
+        """
+        return vendor == self._cc_vendor
 
     def filter_cc_flags(self, flag_list, language='c'):
         """Filter out the unrecognized compilation flags."""

--- a/src/tests/unit/__init__.py
+++ b/src/tests/unit/__init__.py
@@ -1,0 +1,2 @@
+# Package marker so that `python -m unittest discover -s src/tests/unit`
+# and its siblings work without needing PEP 420 namespace semantics.

--- a/src/tests/unit/runall.sh
+++ b/src/tests/unit/runall.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Run every unit test under src/tests/unit/.
+#
+# Unit tests here are pure-Python (no subprocess, no real blade launcher,
+# no testdata/). They mock out run_command and exercise logic in isolation,
+# and thus run on any machine that has Python >= 3.10.
+#
+# The older integration tests in src/test/ are NOT driven by this script;
+# use src/test/runall.sh for those.
+
+set -eu
+
+here=$(cd "$(dirname "$0")" && pwd)
+repo_root=$(cd "$here/../.." && pwd)
+
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON=${PYTHON:-python3}
+else
+    PYTHON=${PYTHON:-python}
+fi
+
+export PYTHONPATH="$repo_root/src${PYTHONPATH:+:$PYTHONPATH}"
+
+exec "$PYTHON" -m unittest discover -s "$here" -p '*_test.py' -v

--- a/src/tests/unit/toolchain_test.py
+++ b/src/tests/unit/toolchain_test.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Unit tests for blade.toolchain.
+
+"""Unit tests for the ToolChain helper.
+
+These tests mock out :func:`blade.util.run_command` so that the tests run on
+any host without requiring a real compiler, and without caring about the
+quirks of whichever vendor `gcc` happens to resolve to on the current
+machine. The point is to pin down the pure decision logic of
+``ToolChain.cc_is`` / ``ToolChain._detect_cc_vendor`` so that future changes
+cannot silently regress the cross-vendor behaviour.
+"""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+# Make ``import blade.*`` resolve against the in-tree sources without
+# requiring blade to be installed.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import toolchain  # noqa: E402  (sys.path tweak above)
+
+
+# Representative banner lines copied from real compiler invocations.
+_APPLE_CLANG_BANNER = (
+    'Apple clang version 14.0.3 (clang-1403.0.22.14.1)\n'
+    'Target: arm64-apple-darwin22.6.0\n'
+)
+_UPSTREAM_CLANG_BANNER = (
+    'clang version 17.0.6\n'
+    'Target: x86_64-pc-linux-gnu\n'
+)
+_GCC_BANNER = (
+    'gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0\n'
+    'Copyright (C) 2021 Free Software Foundation, Inc.\n'
+)
+_UNKNOWN_BANNER = 'Some hypothetical HPC compiler v9.9\n'
+
+
+def _make_run_command(version_stdout, version_ok=True, dumpversion='14.0.3'):
+    """Build a fake ``run_command`` dispatcher keyed on the argv shape."""
+
+    def fake_run_command(argv, *args, **kwargs):
+        # ToolChain calls run_command with (cc_path, '-dumpversion') and
+        # (cc_path, '--version'); nothing else in __init__.
+        if '-dumpversion' in argv:
+            return (0, dumpversion, '')
+        if '--version' in argv:
+            rc = 0 if version_ok else 1
+            return (rc, version_stdout, '')
+        raise AssertionError('unexpected run_command argv: %r' % (argv,))
+
+    return fake_run_command
+
+
+class DetectCcVendorTest(unittest.TestCase):
+    """Cover every branch of ToolChain._detect_cc_vendor."""
+
+    def _build_toolchain(self, fake):
+        with mock.patch.object(toolchain, 'run_command', side_effect=fake):
+            return toolchain.ToolChain()
+
+    def test_apple_clang_is_detected_as_clang(self):
+        tc = self._build_toolchain(_make_run_command(_APPLE_CLANG_BANNER))
+        self.assertEqual(tc._cc_vendor, 'clang')
+        self.assertTrue(tc.cc_is('clang'))
+        # Regression pin: Apple's `gcc` is Clang; cc_is('gcc') must NOT match.
+        self.assertFalse(tc.cc_is('gcc'))
+
+    def test_upstream_clang_is_detected_as_clang(self):
+        tc = self._build_toolchain(_make_run_command(_UPSTREAM_CLANG_BANNER))
+        self.assertEqual(tc._cc_vendor, 'clang')
+
+    def test_real_gcc_is_detected_as_gcc(self):
+        tc = self._build_toolchain(_make_run_command(_GCC_BANNER))
+        self.assertEqual(tc._cc_vendor, 'gcc')
+        self.assertTrue(tc.cc_is('gcc'))
+        self.assertFalse(tc.cc_is('clang'))
+
+    def test_unknown_banner_maps_to_unknown(self):
+        tc = self._build_toolchain(_make_run_command(_UNKNOWN_BANNER))
+        self.assertEqual(tc._cc_vendor, 'unknown')
+        # Any vendor query against 'unknown' must be False so that callers
+        # take the conservative branch.
+        self.assertFalse(tc.cc_is('gcc'))
+        self.assertFalse(tc.cc_is('clang'))
+
+    def test_version_probe_failure_maps_to_unknown(self):
+        tc = self._build_toolchain(
+            _make_run_command(_GCC_BANNER, version_ok=False))
+        self.assertEqual(tc._cc_vendor, 'unknown')
+        self.assertFalse(tc.cc_is('gcc'))
+
+
+class CcIsStrictEqualityTest(unittest.TestCase):
+    """Pin cc_is semantics: exact match, no substring tricks."""
+
+    def test_cc_is_rejects_partial_matches(self):
+        # Directly construct a fake ToolChain without touching subprocess,
+        # to exercise cc_is in isolation.
+        tc = toolchain.ToolChain.__new__(toolchain.ToolChain)
+        tc._cc_vendor = 'clang'
+        self.assertTrue(tc.cc_is('clang'))
+        self.assertFalse(tc.cc_is('clan'))
+        self.assertFalse(tc.cc_is('clang++'))
+        self.assertFalse(tc.cc_is(''))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Two independent bugs surfaced while bringing up the `v3` branch on macOS;
both have the same root cause shape (string-matching a tool name instead
of asking the tool what it is) and are fixed here together.

### Bug 1 — `ToolChain.cc_is()` misclassified Apple Clang as GCC

`ToolChain.cc_is(vendor)` used to return `vendor in self.cc`, i.e. it
treated the `cc` command name as a proxy for the vendor. On macOS the
default CC is `/usr/bin/gcc`, which is an alias for Apple Clang, so
`cc_is('gcc')` returned `True` and
`_generate_cc_binary_link_flags()` then injected `-static-libgcc
-static-libstdc++` into every link line — flags Apple's linker does
not accept.

**Fix** (`src/blade/toolchain.py`): probe the compiler itself at
`ToolChain` construction time via `--version`, cache the result in
`self._cc_vendor` (`'clang'` / `'gcc'` / `'unknown'`), and reduce
`cc_is()` to a strict equality check. Detection failures map to
`'unknown'` so callers keying on a specific vendor take the
conservative branch.

The only existing call site — `cc_targets._generate_cc_binary_link_flags`
— continues to express exactly what that code meant to express.

### Bug 2 — `$BLADE_PYTHON_INTERPRETER` silently ignored by `_check_python`

The launcher probed PATH for `python3` / `python`, enforced the
`>= 3.10` floor against whichever it found, and *then* dispatched to
`${BLADE_PYTHON_INTERPRETER:-$python}`. On systems whose default
`python3` is older than 3.10 (macOS Monterey ships 3.9.6), blade
aborted with a fatal before ever consulting `BLADE_PYTHON_INTERPRETER`,
even when it pointed at a valid 3.12 interpreter.

**Fix** (`blade`): factor a `_probe_python` helper that honours the
override when it names a single executable resolvable via `command -v`
whose `-V` reports `>= 3.10`, and consult it first in `_check_python`.
Multi-word values (notably `src/test/run.sh`'s coverage wrapper
`"python3 -m coverage run --source=..."`) intentionally fall through
to PATH-based auto-detection for `_check_python`'s own use; the full
wrapper form is still re-applied at the final
`${BLADE_PYTHON_INTERPRETER:-$python}` invocation.

## Verification

### Real-world smoke test on macOS (system `python3` is 3.9.6)

| Case | `BLADE_PYTHON_INTERPRETER` | Observed behaviour | Expected |
|---|---|---|---|
| baseline | *(unset)* | fatal: please upgrade to 3.10+ | ✅ unchanged |
| happy path | `/opt/homebrew/bin/python3.12` | echoes `/opt/homebrew/bin/python3.12`, launcher proceeds | ✅ new behaviour |
| coverage wrapper | `python3 -m coverage run` | falls through to PATH-based detection | ✅ wrapper path preserved for integration tests |
| typo / nonexistent | `/nonexistent/python42` | falls through | ✅ no lock-out |

End-to-end, `BLADE_PYTHON_INTERPRETER=/opt/homebrew/bin/python3.12 ./blade --version`
prints `blade (developing, unversioned)` — i.e. the new `_check_python`
hands control to blade.py cleanly.

### Unit tests (`src/tests/unit/toolchain_test.py`)

Six new tests pin the decision logic of `cc_is` / `_detect_cc_vendor`.
They mock `run_command`, so they need neither a real compiler nor a
real `blade` run:

```
$ PYTHONPATH=src python3.12 -m unittest discover -s src/tests/unit -v
test_cc_is_rejects_partial_matches (CcIsStrictEqualityTest) ... ok
test_apple_clang_is_detected_as_clang (DetectCcVendorTest) ... ok
test_real_gcc_is_detected_as_gcc (DetectCcVendorTest) ... ok
test_unknown_banner_maps_to_unknown (DetectCcVendorTest) ... ok
test_upstream_clang_is_detected_as_clang (DetectCcVendorTest) ... ok
test_version_probe_failure_maps_to_unknown (DetectCcVendorTest) ... ok
----------------------------------------------------------------------
Ran 6 tests in 0.001s
OK
```

The tests pin, among others, that Apple Clang (banner `Apple clang
version ...`) is classified as `'clang'` **and not** `'gcc'`, which is
exactly the Bug 1 regression.

## Scope notes / follow-ups

- `src/tests/unit/` is new; existing `src/test/` continues to hold the
  integration-test suite (`blade_main_test.py` + `testdata/`). The two
  coexist for now. A later refactor may fold both under
  `src/test/{unit,integration}/`.
- **This PR intentionally does not wire the new unit tests into CI.**
  That lives in the next PR (`PR-v3-4`, pyright-on-CI) which will
  touch `.github/workflows/ci.yml` anyway.
- Merge strategy: **rebase** — the three commits are independently
  meaningful and each could be cherry-picked to `2.x` on its own.

## Commits

- `44d6fe5` fix(v3): detect cc vendor by querying compiler `--version`
- `fbc040e` fix(v3): honor `$BLADE_PYTHON_INTERPRETER` in launcher `_check_python`
- `ee665f4` test(v3): add unit tests for ToolChain cc vendor detection
