### PR TITLE
fix(v3): use python3 (overridable) in py_binary shell bootstrap

### DIFF
--- a/src/blade/builtin_tools.py
+++ b/src/blade/builtin_tools.py
@@ -560,8 +560,16 @@ def generate_python_binary(pybin, basedir, exclusions, mainentry, args):
         zip_content = f.read()
     # Insert bootstrap before zip, it is also a valid zip file.
     # unzip will seek actually start until meet the zip magic number.
+    #
+    # The interpreter defaults to python3 because many modern systems
+    # (macOS, recent Debian/Ubuntu) ship only `python3` and not a bare
+    # `python`. BLADE_PYTHON_INTERPRETER, if set, wins — it's the same
+    # escape hatch the top-level blade launcher honours when the host's
+    # default python3 is too old (see blade._check_python).
     bootstrap = ('#!/bin/sh\n\n'
-                 'PYTHONPATH="$0:$PYTHONPATH" exec python -m "%s" "$@"\n') % mainentry
+                 'PYTHONPATH="$0:$PYTHONPATH" '
+                 'exec "${BLADE_PYTHON_INTERPRETER:-python3}" '
+                 '-m "%s" "$@"\n') % mainentry
     with open(pybin, 'wb') as f:
         f.write(bootstrap.encode('utf-8'))
         f.write(zip_content)

--- a/src/tests/unit/builtin_tools_test.py
+++ b/src/tests/unit/builtin_tools_test.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Unit tests for blade.builtin_tools pybinary bootstrap generation.
+
+"""Pin the shell bootstrap that blade prepends to every py_binary / py_test.
+
+The bootstrap is a `#!/bin/sh` script that lives at the head of the final
+zip-appended executable. It must:
+
+1. Invoke an interpreter that actually exists on the host. Modern systems
+   (macOS, recent Debian/Ubuntu) ship only ``python3``; a hardcoded
+   ``python`` invocation fails with ``exec: python: not found`` at test
+   time — a silent, runtime-only regression.
+2. Respect ``$BLADE_PYTHON_INTERPRETER`` so users whose default python3
+   is older than 3.10 (or who need a specific virtualenv) can override
+   just the downstream py_binary execution the same way they already
+   override blade's own launcher (see ``blade._check_python``).
+3. Forward ``"$@"`` to the module so test args / binary flags reach the
+   user's code intact.
+
+The test writes the bootstrap-carrying pybin to a real file and reads it
+back as text — byte-for-byte. That's deliberate: the bootstrap is what
+``/bin/sh`` is going to parse at runtime, so there is no safer unit than
+the exact bytes on disk.
+"""
+
+import os
+import stat
+import sys
+import tempfile
+import unittest
+
+# Make ``import blade.*`` resolve against the in-tree sources without
+# requiring blade to be installed.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import builtin_tools  # noqa: E402  (sys.path tweak above)
+
+
+def _make_minimal_pylib(pylib_path, src_path, base_dir):
+    """Write a minimal .pylib descriptor pointing at *src_path*.
+
+    A .pylib is not a zip — it is a Python literal (consumed via ``eval``
+    by ``_pybin_add_pylib``) of the form::
+
+        {'base_dir': '<relative base>', 'srcs': [(src_abs, md5), ...]}
+
+    For bootstrap-generation tests we do not care what's inside the
+    source; we only need ``generate_python_binary`` to stream through
+    without crashing so that the bootstrap bytes get prepended.
+    """
+    payload = {
+        'base_dir': base_dir,
+        'srcs': [(src_path, '0' * 32)],
+    }
+    with open(pylib_path, 'w', encoding='utf-8') as f:
+        f.write(repr(payload))
+
+
+class GeneratePythonBinaryBootstrapTest(unittest.TestCase):
+    """Pin the shell header that wraps every py_binary / py_test."""
+
+    def _build_pybin(self, mainentry, tmpdir):
+        # The source file has to actually exist — _pybin_add_pylib uses
+        # pybin_zip.write(libsrc, arcname) to copy it in.
+        src = os.path.join(tmpdir, 'app', 'main.py')
+        os.makedirs(os.path.dirname(src), exist_ok=True)
+        with open(src, 'w', encoding='utf-8') as f:
+            f.write('def run():\n    pass\n')
+
+        pylib = os.path.join(tmpdir, 'app.pylib')
+        _make_minimal_pylib(pylib, src_path=src, base_dir=tmpdir)
+
+        # Use a name that does not collide with the ``app/`` source dir.
+        pybin = os.path.join(tmpdir, 'bin')
+        # generate_python_binary signature:
+        #   (pybin, basedir, exclusions_csv, mainentry, args)
+        # where args is the list of .pylib / .egg / .whl inputs.
+        builtin_tools.generate_python_binary(
+            pybin, '', '', mainentry, [pylib])
+        return pybin
+
+    def _read_bootstrap(self, pybin):
+        """Return the #!/bin/sh header (everything before the zip magic)."""
+        with open(pybin, 'rb') as f:
+            blob = f.read()
+        # The zip segment starts at the first PK\x03\x04 local-file header.
+        zip_start = blob.find(b'PK\x03\x04')
+        self.assertNotEqual(
+            zip_start, -1, 'expected a zip segment after the sh bootstrap')
+        return blob[:zip_start].decode('utf-8')
+
+    def test_bootstrap_uses_python3_not_bare_python(self):
+        """Regression pin: hardcoding ``python`` breaks on macOS & modern Debian.
+
+        The old bootstrap read ``exec python -m "..."`` and failed at
+        runtime on any host where only ``python3`` is on PATH. The fix is
+        to default to ``python3``; this test guards the default so a
+        well-meaning refactor cannot silently reintroduce the bug.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pybin = self._build_pybin('app.main', tmpdir)
+            bootstrap = self._read_bootstrap(pybin)
+        self.assertIn('python3', bootstrap)
+        # The exact token ``exec python `` (with a trailing space) is what
+        # /bin/sh would resolve against PATH; make sure the naked form is
+        # not present.
+        self.assertNotIn('exec python ', bootstrap)
+        self.assertNotIn('exec python\t', bootstrap)
+
+    def test_bootstrap_honours_blade_python_interpreter(self):
+        """Users can pin a specific interpreter without patching blade.
+
+        Mirrors the escape hatch the top-level ``blade`` launcher already
+        offers via ``BLADE_PYTHON_INTERPRETER`` when the host default
+        python3 is too old.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pybin = self._build_pybin('app.main', tmpdir)
+            bootstrap = self._read_bootstrap(pybin)
+        # The indirection syntax must be ${VAR:-default}, not $VAR (which
+        # would break when the env var is unset) nor ${VAR-default}
+        # (which would keep an accidental empty string).
+        self.assertIn('${BLADE_PYTHON_INTERPRETER:-python3}', bootstrap)
+
+    def test_bootstrap_preserves_mainentry_and_forwards_argv(self):
+        """Entry point and ``"$@"`` must survive the fix verbatim."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pybin = self._build_pybin('suites.py_basic.greeter_test', tmpdir)
+            bootstrap = self._read_bootstrap(pybin)
+        self.assertIn('-m "suites.py_basic.greeter_test"', bootstrap)
+        self.assertIn('"$@"', bootstrap)
+        # PYTHONPATH prepend is what lets the zip-embedded modules import.
+        self.assertIn('PYTHONPATH="$0:$PYTHONPATH"', bootstrap)
+
+    def test_bootstrap_starts_with_posix_shebang(self):
+        """The bootstrap is parsed by /bin/sh, not bash. Pin the shebang."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pybin = self._build_pybin('app.main', tmpdir)
+            with open(pybin, 'rb') as f:
+                head = f.read(16)
+        self.assertTrue(
+            head.startswith(b'#!/bin/sh\n'),
+            'unexpected shebang bytes: %r' % head)
+
+    def test_generated_pybin_is_executable(self):
+        """Blade marks the generated file 0755; regression-pin it."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pybin = self._build_pybin('app.main', tmpdir)
+            mode = stat.S_IMODE(os.stat(pybin).st_mode)
+        self.assertTrue(mode & stat.S_IXUSR, 'owner exec bit missing: %o' % mode)
+        self.assertTrue(mode & stat.S_IXGRP, 'group exec bit missing: %o' % mode)
+        self.assertTrue(mode & stat.S_IXOTH, 'other exec bit missing: %o' % mode)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

v3 py_binary / py_test launchers begin with a `#!/bin/sh` bootstrap
that currently hardcodes `exec python -m "..." "$@"`. That fails on
modern systems where only `python3` exists on PATH (macOS 12+,
Debian 12, Ubuntu 22.04+):

```
/path/to/target: line 3: exec: python: not found
```

This PR switches the bootstrap to

```sh
exec "${BLADE_PYTHON_INTERPRETER:-python3}" -m "..." "$@"
```

so it (a) defaults to `python3` (the interpreter that actually
exists on contemporary hosts), and (b) honours the same
`BLADE_PYTHON_INTERPRETER` env var the top-level `blade` launcher
already uses — one override covers both blade itself and every
py_* target it produces.

## How it was found

Standing up the `py_basic` smoke suite (`py_library` + `py_test`)
in the `blade-build/blade-test` sidecar repo. The trivial suite
built cleanly on v3 but every generated `py_test` exec-failed at
line 3 with exit 127. Existing fleets rarely hit this because they
tend to deploy on hosts with a `python` shim, but any fresh macOS
or modern Debian/Ubuntu machine reproduces it immediately.

## Tests

New: `src/tests/unit/builtin_tools_test.py`, 5 test cases pinning
the bootstrap's behaviour:

1. `python3` is the default (no bare `exec python ` remains).
2. `${BLADE_PYTHON_INTERPRETER:-python3}` indirection syntax is
   present (not `$VAR` / `${VAR-default}`, which would both behave
   subtly wrong on empty/unset).
3. `-m "<mainentry>"` and `"$@"` survive, `PYTHONPATH="$0:..."`
   prepend survives.
4. Shebang is `#!/bin/sh\n` (not `#!/bin/bash`).
5. Generated pybin has 0755 executable bits (regression pin from
   the existing `os.chmod(pybin, 0o755)` contract).

The tests construct a minimal `.pylib` (a repr-serialised
`{'base_dir', 'srcs': [(path, md5)]}` dict, which is what
`_pybin_add_pylib` eval-reads at runtime), call
`generate_python_binary` directly, then read the bootstrap bytes
back from the generated file. No subprocess, no real compiler,
runs on any Python >= 3.10 host.

## Validation

Local, darwin/arm64 + python 3.12.13:

- `python3 -m unittest discover src/tests/unit -p '*_test.py'`:
  **11/11 OK** (5 new + 6 existing toolchain tests, unchanged).
- pyright on the two touched files: **0 errors, 0 warnings**.
- pyright whole tree: **0 errors, 113 warnings** — identical to
  the v3 baseline, no new noise.
- End-to-end against `blade-test`'s new (not-yet-merged) `py_basic`
  suite: `greeter_test` **2/2 tests PASSED**, marked `repaired` by
  blade because the same target had failed on v3 prior to this
  patch.

## Scope

Intentionally narrow: one-line behavioural change + comment +
focused unit test file. No refactor of surrounding code, no change
to `py_binary` / `py_test` semantics beyond the interpreter
resolution.

## Follow-up

Once this merges, `blade-build/blade-test` will open its own PR
adding the `suites/py_basic/` smoke suite that motivated the fix,
so the CI contract between the two repos exercises `py_library` +
`py_test` on every push going forward — the same pattern the
existing `cc_basic` suite already provides for C/C++.
