### PR TITLE
chore(v3): install flex/bison/protoc in e2e-smoke job

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -98,6 +98,15 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y ninja-build
+    - name: Install e2e toolchain (flex/bison/protoc)
+      # Pre-install toolchains required by the upcoming blade-test suites
+      # migrated from blade-build/example/: lex_yacc needs flex + bison,
+      # proto_basic needs protoc + libprotobuf-dev, py_proto additionally
+      # needs python3-protobuf at runtime. These packages are idempotent
+      # no-ops for suites that do not consume them, so installing them
+      # ahead of the suite PRs keeps later commits focused.
+      run: |
+        sudo apt-get install -y flex bison protobuf-compiler libprotobuf-dev python3-protobuf
     - name: Install googletest at BLADE_ROOT-expected prefix
       # blade-test/BLADE_ROOT points cc search paths at
       # /usr/local/opt/googletest/{include,lib} on Linux. Ubuntu's


### PR DESCRIPTION
## Summary

Pre-install the toolchains needed by the next batch of `blade-test` suites
migrated from the retired `blade-build/example/` tree:

| Package | Suite that will need it |
| --- | --- |
| `flex` + `bison` | `suites/lex_yacc` (lex/yacc compiler) |
| `protobuf-compiler` | `suites/proto_basic`, `suites/py_proto` (`protoc`) |
| `libprotobuf-dev` | `suites/proto_basic` (cc side link `-lprotobuf`) |
| `python3-protobuf` | `suites/py_proto` (runtime `import google.protobuf.*`) |

## Why install them now, before the suite PRs land?

Following the **M1'** strategy agreed during the v3 triage:

1. Toolchain lives in `blade-build` (this repo), suites live in `blade-test`.
2. The `e2e-smoke` job clones `blade-test` master at run time, so the moment a
   new suite lands in `blade-test` master it becomes exercised by the required
   `E2E smoke (blade-test)` check here.
3. If we bundled toolchain install with the suite PR, every suite PR on the
   `blade-test` side would **flip this required check red for the duration it
   takes to merge a paired `blade-build` PR**. Landing toolchain first in a
   separate, trivially-reviewable PR avoids that window entirely.

## Is this change safe for current suites?

Yes. The existing `cc_basic` / `java_basic` / `py_basic` suites do not consume
any of these packages; installing them is an idempotent no-op for those
suites. The only observable effect is ~10 seconds of extra `apt install` time
on `ubuntu-22.04`.

## Risk / backout

- **Blast radius**: `e2e-smoke` job only. `integration-tests`, `unit-tests`,
  `pyright` jobs are untouched.
- **Backout**: revert this single commit; no data / no schema change.

## Checklist

- [x] workflow YAML validated locally (`diff` is a single additive step)
- [x] step inserted between `Install ninja` and `Install googletest`, matching
      the existing `apt-get install -y ...` pattern
- [x] `apt-get update` already run by the preceding `Install ninja` step, so
      this step reuses the cached package index
- [x] no change to `cc_basic` / `java_basic` / `py_basic` behaviour
