### PR TITLE
fix(v3): treat test_timeout=0 as unlimited, not "zero seconds"

### DIFF
--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -51,7 +51,9 @@ class BladeConfig(object):
                 'duplicated_source_action': 'warning',
                 'duplicated_source_action__help__': "Can be 'warning', 'error', 'none'",
                 'test_timeout': 0,
-                'test_timeout__help__': 'In seconds',
+                'test_timeout__help__':
+                    'Per-test timeout in seconds. 0 (default) or any '
+                    'non-positive value means unlimited.',
                 'test_related_envs__help__':
                     'Environment variables which need to see whether changed before incremental '
                     'testing. regex is allowed',

--- a/src/blade/test_scheduler.py
+++ b/src/blade/test_scheduler.py
@@ -84,11 +84,17 @@ class WorkerThread(threading.Thread):
         This method simply checks job timeout and returns immediately.
         The caller should invoke this method repeatedly so that a job
         which takes a very long time would be timeout sooner or later.
+
+        A `job_timeout` of 0 (or any non-positive value) means *unlimited*,
+        matching the documented semantics of `global_config.test_timeout`.
+        Without this guard the expression `start_time + 0 < now` is true on
+        every tick after the first second, which would SIGTERM every running
+        test as soon as the scheduler's 1s polling loop wakes up.
         """
         try:
             self.job_lock.acquire()
             if (not self.job_is_timeout and self.job_start_time and
-                    self.job_timeout is not None and
+                    self.job_timeout is not None and self.job_timeout > 0 and
                     self.job_name and self.job_process is not None):
                 if self.job_start_time + self.job_timeout < now:
                     self.job_is_timeout = True
@@ -255,7 +261,13 @@ class TestScheduler(object):
                 dead_threads = []
                 for t in threads:
                     if t.is_alive():
-                        if test_timeout is not None:
+                        # 0 (or any non-positive value) means "unlimited",
+                        # matching the documented semantics of
+                        # global_config.test_timeout. The inner check in
+                        # check_job_timeout is also guarded, but skipping the
+                        # call here avoids touching the per-thread lock on
+                        # every tick when no timeout is configured.
+                        if test_timeout is not None and test_timeout > 0:
                             t.check_job_timeout(now)
                     else:
                         dead_threads.append(t)

--- a/src/tests/unit/test_scheduler_test.py
+++ b/src/tests/unit/test_scheduler_test.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Unit tests for blade.test_scheduler.
+
+"""Unit tests for the test scheduler's timeout logic.
+
+These tests pin down the documented semantics of
+``global_config.test_timeout``: a value of 0 (or any non-positive value)
+means *unlimited*, not "zero seconds". Without this contract the
+scheduler's 1-second polling loop SIGTERMs every test as soon as it wakes
+up, which is how it silently killed the java_basic smoke suite (JVM
+startup happens to land on the second-boundary) while letting faster
+cc_basic / py_basic tests escape because their subprocesses exited before
+the first tick.
+"""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+# Make ``import blade.*`` resolve against the in-tree sources without
+# requiring blade to be installed.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import test_scheduler  # noqa: E402  (sys.path tweak above)
+
+
+def _make_worker(timeout, start_time=1000.0):
+    """Build a WorkerThread pre-seeded with a fake running job.
+
+    We bypass __init__ so the test does not need a real Queue/handler; we
+    only care about the per-job bookkeeping that check_job_timeout reads.
+    The job_process is a Mock so we can assert whether terminate() was
+    called.
+    """
+    t = test_scheduler.WorkerThread.__new__(test_scheduler.WorkerThread)
+    # Fields touched by check_job_timeout / set_job_data.
+    import threading
+    t.job_lock = threading.Lock()
+    t.job_is_timeout = False
+    t.job_start_time = start_time
+    t.job_timeout = timeout
+    t.job_name = 'some/target:test'
+    t.job_process = mock.Mock()
+    return t
+
+
+def _terminate_mock(t):
+    """Return the Mock for t.job_process.terminate, narrowed for pyright.
+
+    ``WorkerThread.job_process`` is typed as Optional since it is reset to
+    None by cleanup_job, but in these tests we always seed it with a Mock,
+    so the assertions below are safe.
+    """
+    assert t.job_process is not None
+    return t.job_process.terminate
+
+
+class CheckJobTimeoutTest(unittest.TestCase):
+    """Cover the timeout=0-means-unlimited contract at the worker level."""
+
+    def test_zero_timeout_never_fires_even_far_in_the_future(self):
+        # Regression pin: before the fix, `start_time + 0 < now` was True
+        # for any now > start_time, so the very next scheduler tick (1s
+        # later) would SIGTERM every running test.
+        t = _make_worker(timeout=0, start_time=1000.0)
+        t.check_job_timeout(now=1_000_000.0)  # 11+ days later
+        self.assertFalse(t.job_is_timeout)
+        _terminate_mock(t).assert_not_called()
+
+    def test_negative_timeout_is_also_unlimited(self):
+        # Defensive: any non-positive value means unlimited, so a
+        # hand-edited BLADE config with a negative number should not
+        # brick testing either.
+        t = _make_worker(timeout=-5, start_time=1000.0)
+        t.check_job_timeout(now=1_000_000.0)
+        self.assertFalse(t.job_is_timeout)
+        _terminate_mock(t).assert_not_called()
+
+    def test_none_timeout_never_fires(self):
+        # The caller in _wait_worker_threads is guarded, but belt-and-braces:
+        # a None slipping through here must not crash or fire.
+        t = _make_worker(timeout=None, start_time=1000.0)
+        t.check_job_timeout(now=1_000_000.0)
+        self.assertFalse(t.job_is_timeout)
+        _terminate_mock(t).assert_not_called()
+
+    def test_positive_timeout_fires_when_elapsed(self):
+        # Sanity: the timeout machinery still works for finite limits.
+        t = _make_worker(timeout=10, start_time=1000.0)
+        t.check_job_timeout(now=1020.0)  # 20s elapsed, exceeds 10s
+        self.assertTrue(t.job_is_timeout)
+        _terminate_mock(t).assert_called_once()
+
+    def test_positive_timeout_does_not_fire_before_elapsed(self):
+        t = _make_worker(timeout=10, start_time=1000.0)
+        t.check_job_timeout(now=1005.0)  # only 5s in
+        self.assertFalse(t.job_is_timeout)
+        _terminate_mock(t).assert_not_called()
+
+    def test_already_timed_out_job_is_not_terminated_twice(self):
+        # If the scheduler ticks again after a timeout was fired, we must
+        # not re-terminate (the process may already be gone / reaped).
+        t = _make_worker(timeout=10, start_time=1000.0)
+        t.job_is_timeout = True  # pretend a previous tick already fired
+        t.check_job_timeout(now=1020.0)
+        _terminate_mock(t).assert_not_called()
+
+
+class ConfigDefaultTest(unittest.TestCase):
+    """Pin the default value so the scheduler fix stays coherent with config."""
+
+    def test_default_test_timeout_is_zero(self):
+        # If someone changes the default to a small positive number later,
+        # the scheduler-level fix (0 == unlimited) still holds, but the
+        # surprise factor goes up: fail loud so a reviewer re-examines the
+        # contract.
+        from blade import config
+        c = config.BladeConfig()
+        self.assertEqual(c.configs['global_config']['test_timeout'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Treat `global_config.test_timeout = 0` as **unlimited** instead of "zero
seconds". Without this, the scheduler's 1-second polling loop SIGTERMs
every running test exactly one poll-cycle after it starts.

## Problem

`TestScheduler._wait_worker_threads` calls `check_job_timeout(now)` for
each live worker whenever `test_timeout is not None`. The documented
default in `global_config` is `0`, which is of course not `None`, so the
inner check

```python
if self.job_start_time + self.job_timeout < now:
    ...terminate()
```

reduces to `start_time + 0 < now`, which is true on the very first tick
after the job is scheduled. The effect: any test that is still alive
when the scheduler's 1s `time.sleep` wakes up gets SIGTERMed.

## Why we did not notice earlier

* `cc_basic` and `py_basic` subprocesses exit in well under 1s, so by
  the time the scheduler's first tick wakes up they are already in the
  `dead_threads` branch and `check_job_timeout` is never called.
* `java_basic` (being added in [blade-build/blade-test](https://github.com/blade-build/blade-test)
  as the next e2e-smoke fixture) happens to straddle the 1s boundary:
  JVM startup + classload + JUnitCore on a cold macOS host lands just
  past the tick, so the suite got killed with `//...:greeter_test: TIMEOUT`
  (exit `SIGTERM:-15`, cost 1.01s) despite the actual JUnit run finishing
  in ~0.006s.

This is the third existing-bug that the sidecar smoke-suite strategy
has surfaced, after #1096 (`python` vs `python3` in `py_binary`
launcher) and #1098 (missing flex/bison/protoc in `e2e-smoke` job).

## Fix

1. `WorkerThread.check_job_timeout`: guard with `job_timeout > 0` so
   that `0` (and any non-positive value, including a hand-edited
   negative) means unlimited. Docstring updated with the rationale.
2. `TestScheduler._wait_worker_threads`: skip the per-thread call
   entirely when `test_timeout` is `0` / non-positive / `None`. Avoids
   taking the per-thread lock on every tick when no timeout is
   configured.
3. `config.py`: rewrite `test_timeout__help__` so the 0-means-unlimited
   contract is discoverable by anyone running `blade dump --config`.

## Tests

New `src/tests/unit/test_scheduler_test.py` (7 cases) pins:
- zero / negative / `None` never fires, no matter how far in the future
  `now` is;
- a positive timeout fires when elapsed, and does not fire before;
- an already-timed-out worker is not terminated twice (tick idempotence);
- the documented default of `global_config.test_timeout` is `0`, so if
  someone changes the default later they are forced to revisit this
  contract.

```
$ bash src/tests/unit/runall.sh
Ran 18 tests in 0.006s
OK
```

```
$ pyright
errors=0, warnings=113, informations=0   (unchanged from v3 HEAD)
```

## End-to-end verification

Locally, against `blade-test` with the pending `java_basic` suite:

| suite       | before           | after             |
|-------------|------------------|-------------------|
| cc_basic    | green (~0.1s)    | green (~0.1s)     |
| py_basic    | green (~0.1s)    | green (~0.1s)     |
| java_basic  | **TIMEOUT 1.01s**| **green, ~0.13s** |

```
Blade(notice): Total 3 tests, 3 scheduled, 3 passed.
Blade(notice): Trend: 1 repaired.
Blade(notice): All 3 tests passed!
```

## Out of scope

- Adding per-target `test_timeout` override (currently there is none;
  every target inherits from `global_config`). This can come later if
  somebody actually needs a tighter cap for a flaky test.
- The `java_basic` suite itself: it will be added in a follow-up
  `blade-test` PR once this one lands, together with a blade-build PR
  that wires `java_test_config.junit_libs` into `JavaTest`'s implicit
  deps (currently the config key is declared in the schema but inert).

## Commit

Single commit: `fix(v3): treat test_timeout=0 as unlimited, not "zero seconds"`.
