### PR TITLE
fix(v3): emit macOS-compatible -force_load for link_all_symbols targets

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -13,6 +13,7 @@ of all of the cc targets, like cc_library, cc_binary.
 
 
 import os
+import sys
 from string import Template
 
 from blade import build_manager
@@ -433,10 +434,24 @@ class CcTarget(Target):
         return linkflags
 
     def _generate_link_all_symbols_link_flags(self, libs):
-        """Generate link flags for libraries which should be linked with all symbols."""
-        if libs:
-            return ['-Wl,--whole-archive'] + libs + ['-Wl,--no-whole-archive']
-        return []
+        """Generate link flags for libraries which should be linked with all symbols.
+
+        Platform-aware because the GNU ld spelling
+        ``-Wl,--whole-archive ... --no-whole-archive`` is rejected by Apple's
+        ld64 / ld-prime with ``ld: unknown option: --whole-archive``. macOS
+        uses Mach-O rather than ELF and has no GNU-ld port (Homebrew's
+        binutils formula explicitly doesn't install ``ld`` on Darwin), so
+        every Mac toolchain — Apple Clang, Homebrew GCC, Homebrew LLVM's
+        default driver — eventually hands off to ld64. Emit the Apple
+        equivalent ``-Wl,-force_load,<archive>`` once per archive on Darwin
+        instead; leave all other platforms (Linux with GNU ld / gold / lld /
+        mold, *BSD, etc.) on the original spelling.
+        """
+        if not libs:
+            return []
+        if sys.platform == 'darwin':
+            return ['-Wl,-force_load,' + lib for lib in libs]
+        return ['-Wl,--whole-archive'] + libs + ['-Wl,--no-whole-archive']
 
     def _dynamic_dependencies(self):
         """

--- a/src/tests/unit/cc_targets_test.py
+++ b/src/tests/unit/cc_targets_test.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Unit tests for blade.cc_targets._generate_link_all_symbols_link_flags.
+
+"""Unit tests for CcTarget._generate_link_all_symbols_link_flags.
+
+The method emits linker flags that force every symbol of a static archive
+to be pulled in — the idiom protoc-generated code relies on for descriptor
+registration (proto_library sets ``link_all_symbols=True`` unconditionally),
+and which thrift_library / fbthrift_library / lex_yacc_target reach for
+the same way.
+
+The flag spelling is platform-sensitive:
+
+* GNU ld / gold / lld / mold, plus every BSD with a GNU-ld-compatible
+  linker, speak ``-Wl,--whole-archive ... -Wl,--no-whole-archive``.
+* Apple's ld64 / ld-prime — the only linker available to any macOS
+  toolchain (Apple Clang, Homebrew GCC, Homebrew LLVM) because Mach-O
+  has no GNU-ld port — rejects that spelling outright and needs
+  ``-Wl,-force_load,<archive>`` once per archive instead.
+
+These tests pin the branch selection so that a regression back to a
+hard-coded GNU spelling immediately fails on Darwin CI (and vice versa).
+"""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+# Make ``import blade.*`` resolve against the in-tree sources without
+# requiring blade to be installed.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import cc_targets  # noqa: E402  (sys.path tweak above)
+
+
+def _bare_cc_target():
+    """Build a ``CcTarget`` instance bypassing __init__.
+
+    The flag-generation logic under test reads nothing from ``self``,
+    so we avoid the cost and dependencies of a full target construction.
+    """
+    return cc_targets.CcTarget.__new__(cc_targets.CcTarget)
+
+
+class GenerateLinkAllSymbolsLinkFlagsTest(unittest.TestCase):
+    """Cover every branch of the emitter."""
+
+    def test_empty_input_returns_empty_regardless_of_platform(self):
+        target = _bare_cc_target()
+        # Emitter must short-circuit before consulting the platform so
+        # that callers with no whole-archive libs don't accidentally
+        # inject stray flags.
+        with mock.patch.object(cc_targets.sys, 'platform', 'linux'):
+            self.assertEqual([], target._generate_link_all_symbols_link_flags([]))
+        with mock.patch.object(cc_targets.sys, 'platform', 'darwin'):
+            self.assertEqual([], target._generate_link_all_symbols_link_flags([]))
+
+    def test_linux_emits_gnu_whole_archive_pair(self):
+        target = _bare_cc_target()
+        libs = [
+            'build64_release/suites/proto_basic/libcontact_proto.a',
+            'build64_release/suites/thrift_basic/libping.a',
+        ]
+        with mock.patch.object(cc_targets.sys, 'platform', 'linux'):
+            flags = target._generate_link_all_symbols_link_flags(libs)
+        self.assertEqual(
+            ['-Wl,--whole-archive'] + libs + ['-Wl,--no-whole-archive'],
+            flags,
+        )
+
+    def test_darwin_emits_one_force_load_per_archive(self):
+        target = _bare_cc_target()
+        libs = [
+            'build64_release/suites/proto_basic/libcontact_proto.a',
+            'build64_release/suites/thrift_basic/libping.a',
+        ]
+        with mock.patch.object(cc_targets.sys, 'platform', 'darwin'):
+            flags = target._generate_link_all_symbols_link_flags(libs)
+        # One flag per archive, preserving order — link ordering matters
+        # for symbol resolution and we must not silently collapse it.
+        self.assertEqual(
+            [
+                '-Wl,-force_load,build64_release/suites/proto_basic/libcontact_proto.a',
+                '-Wl,-force_load,build64_release/suites/thrift_basic/libping.a',
+            ],
+            flags,
+        )
+
+    def test_darwin_does_not_emit_gnu_whole_archive(self):
+        # Regression pin: ld64 errors out with ``ld: unknown option:
+        # --whole-archive`` if the GNU spelling leaks into the Darwin
+        # branch. This test guards that boundary explicitly.
+        target = _bare_cc_target()
+        with mock.patch.object(cc_targets.sys, 'platform', 'darwin'):
+            flags = target._generate_link_all_symbols_link_flags(['a.a'])
+        joined = ' '.join(flags)
+        self.assertNotIn('--whole-archive', joined)
+        self.assertNotIn('--no-whole-archive', joined)
+
+    def test_linux_single_lib_is_wrapped_once(self):
+        target = _bare_cc_target()
+        with mock.patch.object(cc_targets.sys, 'platform', 'linux'):
+            flags = target._generate_link_all_symbols_link_flags(['x.a'])
+        self.assertEqual(
+            ['-Wl,--whole-archive', 'x.a', '-Wl,--no-whole-archive'],
+            flags,
+        )
+
+    def test_unknown_platform_falls_back_to_gnu_spelling(self):
+        # Anything other than Darwin keeps the GNU spelling — this is
+        # the safe default for the long tail of Linux-like platforms
+        # (``linux``, ``linux2``, ``freebsd14``, ``openbsd7``, ...).
+        target = _bare_cc_target()
+        for platform_value in ('linux', 'linux2', 'freebsd14', 'openbsd7'):
+            with mock.patch.object(cc_targets.sys, 'platform', platform_value):
+                flags = target._generate_link_all_symbols_link_flags(['y.a'])
+            self.assertEqual(
+                ['-Wl,--whole-archive', 'y.a', '-Wl,--no-whole-archive'],
+                flags,
+                msg='regressed on sys.platform=%r' % platform_value,
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

blade's whole-archive emitter hard-coded GNU ld's spelling
`-Wl,--whole-archive ... -Wl,--no-whole-archive`. Apple's **ld64 /
ld-prime** — the only linker available to **any** macOS toolchain,
because Mach-O has no GNU-ld port (Homebrew's `binutils` formula
explicitly doesn't install `ld` on Darwin) — rejects that outright:

```
ld: unknown option: --whole-archive
clang: error: linker command failed with exit code 1
```

This affects every target type that sets `link_all_symbols=True`:

- `proto_library` — unconditional, needed for protoc's descriptor registration
- `thrift_library`, `fbthrift_library`
- `lex_yacc_target`
- Any `cc_library` / `cc_binary` dep that opts in explicitly

As a practical matter, **macOS users couldn't link any binary that
reached through a `proto_library` or `thrift_library`**. Linux CI
stays green because GNU ld / gold / lld / mold all accept the
original spelling, so the bug went un-noticed until blade-test
exercised it on a real Mac host.

## Fix

Branch on `sys.platform == 'darwin'` and emit one
`-Wl,-force_load,<archive>` per archive — the Apple equivalent, with
per-archive granularity preserved. Leave every other platform on the
original GNU spelling. The empty-libs short-circuit still runs before
the platform check so callers with no whole-archive libs are
unaffected.

The Darwin / non-Darwin split is correct irrespective of compiler
front-end: Apple Clang, Homebrew GCC, and Homebrew LLVM all hand off
to ld64, because GNU ld has no Mach-O target.

## Why `sys.platform` and not `platform.system()`?

`sys.platform` is a stdlib constant already frozen at interpreter
start — no subprocess, no extra import, trivially monkey-patchable in
unit tests. `platform.system()` would work equally well semantically;
`sys` is just the path of least resistance.

## Verification

- **New unit test** `src/tests/unit/cc_targets_test.py` (6 tests)
  pins both platform branches by monkey-patching
  `cc_targets.sys.platform`, including a regression guard asserting
  that the GNU spelling must **not** leak into the Darwin branch.
- **Full unit suite**: 24/24 passing (18 pre-existing + 6 new).
- **pyright**: 0 errors, 113 warnings (unchanged from baseline).
- **End-to-end on macOS arm64** (Apple Clang + Homebrew protoc 33 +
  libprotobuf.dylib): `blade test //suites/proto_basic/...` in the
  sibling blade-test workspace builds and passes 3/3 tests. The same
  command previously failed at link time with `ld: unknown option:
  --whole-archive`.
- **Linux e2e-smoke** (CI): no spelling change on that branch, so
  behaviour is byte-for-byte identical.

## Discovery credit

Uncovered by the upcoming blade-test `proto_basic` suite (suite #4 in
the blade-test example-migration series) on macOS host. Same fix
unblocks the planned thrift / lex_yacc / fbthrift suites.

## Risk

Low. The change is confined to a single private helper; its only
callers are three flag-concatenation sites in cc_targets.py and
cu_targets.py, all of which feed the result directly into a linker
command line. The non-Darwin branch is identical to the prior
behaviour, and the Darwin branch was exercised end-to-end on a real
Mac. No config surface, no new deps.
