### PR TITLE
fix(v3): auto-inject java_test_config.junit_libs into java_test deps

### DIFF
--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -200,6 +200,12 @@ class BladeConfig(object):
             'java_test_config': {
                 '__help__': 'Java Test Configuration',
                 'junit_libs': [],
+                'junit_libs__help__':
+                    'Labels of the JUnit runtime libraries to auto-inject '
+                    'into every java_test target (mirrors cc_test_config '
+                    'gtest_libs / scala_test_config scalatest_libs). Empty '
+                    'list means "no auto-injection"; each java_test must '
+                    'then list its JUnit runtime in `deps` explicitly.',
                 'jacoco_home': '',
             },
 

--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -869,6 +869,35 @@ class JavaTest(JavaBinary):
         self.type = 'java_test'
         self.attr['testdata'] = var_to_list(testdata)
         self._add_tags('type:test')
+        self._apply_junit_libs_from_config()
+
+    def _apply_junit_libs_from_config(self):
+        """Auto-inject the JUnit runtime declared by the workspace's
+        ``java_test_config(junit_libs=[...])``.
+
+        This mirrors what cc_test does with ``cc_test_config.dynamic_link``
+        + gtest, and what scala_test already does with
+        ``scala_test_config.scalatest_libs`` (see scala_targets.py).
+
+        Until this hook was added, ``junit_libs`` was a well-known but
+        inert config key: accepted by the schema in config.py but
+        consumed nowhere, forcing every ``java_test`` BUILD file to
+        repeat the junit dep by hand.
+
+        Kept as its own method, rather than inlined into ``__init__``,
+        so unit tests can exercise the three branches (configured /
+        empty / missing) without having to construct a full
+        ``JavaTest`` instance against the build manager.
+        """
+        junit_libs = config.get_item('java_test_config', 'junit_libs')
+        if junit_libs:
+            self._add_implicit_library(junit_libs)
+        else:
+            self.warning(
+                'Config: "java_test_config.junit_libs" is not configured; '
+                'java_test targets must list their JUnit runtime in `deps` '
+                'explicitly. See `blade dump --config` for the current value.'
+            )
 
     def _java_test_vars(self):
         vars = {

--- a/src/tests/unit/java_targets_test.py
+++ b/src/tests/unit/java_targets_test.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Unit tests for blade.java_targets.JavaTest._apply_junit_libs_from_config.
+
+"""Unit tests for JavaTest's `java_test_config.junit_libs` auto-injection.
+
+The hook turns the ``java_test_config(junit_libs=[...])`` config key
+from an inert schema entry into a real implicit-deps injection point,
+so every ``java_test`` target in a workspace automatically pulls its
+JUnit runtime out of the workspace-level config instead of repeating
+`//thirdparty/junit:junit` in every BUILD file.
+
+What we pin here:
+
+* When ``junit_libs`` is non-empty, every label is forwarded to
+  ``Target._add_implicit_library`` in order.
+* When ``junit_libs`` is empty (the default, or an explicit ``[]``),
+  the target emits a single warning pointing at the config key and
+  calls ``_add_implicit_library`` zero times — so workspaces that
+  prefer per-target explicit `deps` keep working.
+* We do *not* construct a real ``JavaTest`` (that would need the
+  full build manager / workspace). Instead we
+  ``JavaTest.__new__(JavaTest)`` a bare instance and stub the two
+  collaborators the method touches: ``config.get_item`` and
+  ``self._add_implicit_library`` / ``self.warning``. This keeps the
+  test sharply focused on the injection contract.
+"""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+# Make ``import blade.*`` resolve against the in-tree sources without
+# requiring blade to be installed.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import java_targets  # noqa: E402  (sys.path tweak above)
+
+
+def _bare_java_test():
+    """Build a ``JavaTest`` instance bypassing ``__init__``.
+
+    The hook under test reads nothing from ``self`` other than the
+    two methods we stub below, so we skip the expensive constructor
+    chain that would otherwise require a live build manager / loaded
+    BUILD file / workspace root.
+    """
+    return java_targets.JavaTest.__new__(java_targets.JavaTest)
+
+
+class ApplyJunitLibsFromConfigTest(unittest.TestCase):
+    """Cover every branch of JavaTest._apply_junit_libs_from_config."""
+
+    def test_configured_libs_are_forwarded_to_add_implicit_library(self):
+        """The happy path: `java_test_config.junit_libs` lists one or
+        more labels and the hook forwards the *list* (not one call per
+        label) to ``_add_implicit_library``.
+
+        Forwarding the list as a whole — matching scala_targets and
+        proto_library_target — keeps ordering deterministic and
+        delegates the per-label unification (''//'' prefixing, ``#``
+        system-lib handling, dedup against ``self.deps``) to the
+        existing ``Target._add_implicit_library`` helper.
+        """
+        target = _bare_java_test()
+        target._add_implicit_library = mock.Mock()
+        target.warning = mock.Mock()
+
+        configured = ['//thirdparty/junit:junit', '//thirdparty/hamcrest:core']
+        with mock.patch.object(java_targets.config, 'get_item', return_value=configured):
+            target._apply_junit_libs_from_config()
+
+        target._add_implicit_library.assert_called_once_with(configured)
+        target.warning.assert_not_called()
+
+    def test_empty_list_warns_and_does_not_inject(self):
+        """The documented default: an empty list means "no auto-
+        injection", and users must list JUnit in ``deps`` explicitly.
+
+        In that case the hook must *not* touch ``_add_implicit_library``
+        (otherwise we'd inject a bogus empty label set and hide the
+        missing-config from users), and it must emit exactly one
+        warning pointing at the config key so blade -v shows something
+        actionable."""
+        target = _bare_java_test()
+        target._add_implicit_library = mock.Mock()
+        target.warning = mock.Mock()
+
+        with mock.patch.object(java_targets.config, 'get_item', return_value=[]):
+            target._apply_junit_libs_from_config()
+
+        target._add_implicit_library.assert_not_called()
+        target.warning.assert_called_once()
+        (warn_msg,), _ = target.warning.call_args
+        self.assertIn('java_test_config.junit_libs', warn_msg)
+
+    def test_none_is_treated_the_same_as_empty(self):
+        """``config.get_item`` returns ``None`` rather than ``[]`` when
+        a user deletes the key entirely from their ``BLADE_ROOT``.
+
+        Both shapes mean "not configured" and must take the same
+        branch — no injection, one warning. Locks in this equivalence
+        so a future refactor doesn't regress one case while preserving
+        the other."""
+        target = _bare_java_test()
+        target._add_implicit_library = mock.Mock()
+        target.warning = mock.Mock()
+
+        with mock.patch.object(java_targets.config, 'get_item', return_value=None):
+            target._apply_junit_libs_from_config()
+
+        target._add_implicit_library.assert_not_called()
+        target.warning.assert_called_once()
+
+    def test_looks_up_the_documented_config_path(self):
+        """Regression pin: the hook must read from
+        ``('java_test_config', 'junit_libs')`` exactly. If somebody
+        later refactors the schema and forgets to update this call
+        site, the hook would silently read ``None`` from a mistyped
+        key and fall through to the warning branch — hiding the bug.
+        This test fails fast on that drift."""
+        target = _bare_java_test()
+        target._add_implicit_library = mock.Mock()
+        target.warning = mock.Mock()
+
+        with mock.patch.object(java_targets.config, 'get_item',
+                               return_value=['//x:y']) as get_item:
+            target._apply_junit_libs_from_config()
+
+        get_item.assert_called_once_with('java_test_config', 'junit_libs')
+
+
+class SchemaTest(unittest.TestCase):
+    """Pin the config schema so the hook has something to read."""
+
+    def test_junit_libs_key_exists_with_empty_default(self):
+        """The key must be declared in ``config.py`` with a list
+        default. If this ever regresses, every workspace would start
+        seeing an AttributeError / KeyError instead of the documented
+        "not configured" warning."""
+        from blade import config as config_mod
+        # Force the module to populate its default schema by reading
+        # a key we know exists.
+        default = config_mod.get_item('java_test_config', 'junit_libs')
+        # The default in schema is []; after a real config load it may
+        # be any list. We only check the shape.
+        self.assertIsInstance(default, list)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Make `java_test_config.junit_libs` actually do what its schema entry
promises: auto-inject the listed JUnit runtime labels into every
`java_test`'s implicit deps, instead of being a silently-ignored
config key.

## Problem

`config.py`'s schema has long declared

```python
'java_test_config': {
    '__help__': 'Java Test Configuration',
    'junit_libs': [],
    'jacoco_home': '',
},
```

but a repo-wide grep for `junit_libs` before this PR returned **one
single hit** — the schema entry itself. Nothing in `java_targets.py`
or anywhere else read the key. Every `java_test` BUILD file had to
list `//thirdparty/junit:junit` (or whatever workspace-local label
vends JUnit) by hand, despite the config key's name and docstring
implying otherwise.

## Fix

1. `java_targets.py::JavaTest.__init__` gains a call to a new helper
   method `_apply_junit_libs_from_config()` at the end of
   construction. The helper:
   - reads `java_test_config.junit_libs` via `config.get_item`,
   - forwards the list to the inherited
     `Target._add_implicit_library(...)` when non-empty (same
     pattern scala_targets / proto_library_target / cu_targets /
     thrift_library / fbthrift_library already use),
   - emits exactly one `self.warning(...)` pointing at the config
     key when the list is missing or empty, so workspaces that
     prefer per-target explicit deps keep working and get an
     actionable diagnostic under `-v`.

   Kept as its own named method (not inlined into `__init__`) so
   unit tests can exercise the three branches without standing up a
   live build manager.

2. `config.py` grows a `junit_libs__help__` doc string so the
   contract is discoverable via `blade dump --config`. Same
   discoverability convention as #1099 applied to `test_timeout`.

3. `src/tests/unit/java_targets_test.py` (new):

   | # | behavior pinned |
   |---|---|
   | 1 | Configured list → forwarded verbatim to `_add_implicit_library`, zero warnings. |
   | 2 | Empty list → no injection, exactly one warning mentioning the full config path. |
   | 3 | `None` takes the same branch as `[]` (guards against users deleting the key from `BLADE_ROOT`). |
   | 4 | Lookup path is exactly `('java_test_config', 'junit_libs')` — pins against schema typos in future refactors. |
   | 5 | Schema pin: `java_test_config.junit_libs` exists with a list default. |

## Why this matches scala_test's existing pattern

`scala_targets.py::ScalaTest.__init__` has done the equivalent for
`scala_test_config.scalatest_libs` for years:

```python
scalatest_libs = config.get_item('scala_test_config', 'scalatest_libs')
if scalatest_libs:
    self._add_implicit_library(scalatest_libs)
else:
    console.warning('Config: "scala_test_config.scalatest_libs" is not configured')
```

This PR brings Java to parity. Two deliberate deviations from the
scala template:

* Uses `self.warning(...)` instead of `console.warning(...)` so the
  warning gets attributed to the specific `java_test` target and
  prefixed with its BUILD-file location — matches
  `JavaTest.__init__`'s existing `self.warning('"target_under_test"
  is deprecated, ...')` call.
* Splits the logic out into `_apply_junit_libs_from_config` for
  testability (the scala version is inlined in `__init__`, which
  requires a live build manager to exercise).

## Verification

### Unit tests
```
$ bash src/tests/unit/runall.sh
Ran 29 tests in 0.006s
OK
```
(24 pre-existing + 5 new, all green.)

### pyright
```
$ pyright  # via .agent/venv-pyright/bin/pyright
errors=0, warnings=113, informations=0   (unchanged from v3 HEAD)
```

### End-to-end against sibling blade-test

macOS arm64, py3.12, sibling blade-test at latest master
(6 suites: cc_basic, java_basic, lex_yacc_basic, proto_basic,
py_basic, resource_basic).

| blade-test state                                     | outcome |
|------------------------------------------------------|---------|
| `BLADE_ROOT` sets `junit_libs=['//thirdparty/junit:junit']`, BUILD has no explicit junit dep | **green** — auto-injected, `JUnit 4.13.2` runs, 2/2 pass |
| `BLADE_ROOT` sets `junit_libs=[]`, BUILD has no explicit junit dep | **red** (javac: `cannot find symbol: assertEquals`) + exactly one warning: `suites/java_basic/BUILD:25: warning: greeter_test: Config: "java_test_config.junit_libs" is not configured; java_test targets must list their JUnit runtime in deps explicitly. See blade dump --config for the current value.` |
| Workspace's real config (junit_libs set), full `//suites/...` | **6/6 green** in 1.98s |

Both directions behave exactly as documented.

## Out of scope / follow-ups

* **blade-test follow-up PR**: drop the explicit
  `//thirdparty/junit:junit` dep from `suites/java_basic/BUILD`
  now that it's redundant. That PR will double as the cross-repo
  e2e test for this one.

* `scala_test_config.scalatest_libs` already works this way — no
  symmetric fix needed.

* Not taking the opportunity to refactor the small cluster of
  "read config → `_add_implicit_library` or warn" sites
  (scala_test, proto, cu, thrift, fbthrift, and now java_test)
  into a shared helper on `Target`. That's a worthwhile cleanup
  but wider in scope than this fix and should go in a separate
  PR once the pattern stabilizes.

## Files

```
src/blade/config.py                  |   8 +++++++-
src/blade/java_targets.py            |  34 +++++++++++++++++++++++++++++++++-
src/tests/unit/java_targets_test.py  | 148 +++++++++++++++++++++++++++++++
3 files changed, 190 insertions(+)
```

## Commit

Single commit: `fix(v3): auto-inject java_test_config.junit_libs into java_test deps`.
