### PR TITLE
refactor(v3): extract ScalaTest._apply_scalatest_libs_from_config helper

### DIFF
--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -876,8 +876,10 @@ class JavaTest(JavaBinary):
         ``java_test_config(junit_libs=[...])``.
 
         This mirrors what cc_test does with ``cc_test_config.dynamic_link``
-        + gtest, and what scala_test already does with
-        ``scala_test_config.scalatest_libs`` (see scala_targets.py).
+        + gtest, and what scala_test does with
+        ``scala_test_config.scalatest_libs`` (see
+        ``ScalaTest._apply_scalatest_libs_from_config`` in
+        ``scala_targets.py``).
 
         Until this hook was added, ``junit_libs`` was a well-known but
         inert config key: accepted by the schema in config.py but

--- a/src/blade/scala_targets.py
+++ b/src/blade/scala_targets.py
@@ -14,7 +14,6 @@ import os
 from blade import build_manager
 from blade import build_rules
 from blade import config
-from blade import console
 from blade.java_targets import JavaTargetMixIn
 from blade.target import Target
 from blade.util import var_to_list
@@ -225,11 +224,43 @@ class ScalaTest(ScalaFatLibrary):
         if not self.srcs:
             self.warning('Empty scala test sources.')
 
+        self._apply_scalatest_libs_from_config()
+
+    def _apply_scalatest_libs_from_config(self):
+        """Auto-inject the ScalaTest runtime declared by the workspace's
+        ``scala_test_config(scalatest_libs=[...])``.
+
+        Symmetric to ``JavaTest._apply_junit_libs_from_config`` in
+        ``java_targets.py``; the two hooks exist for the same reason
+        (turn a well-known config key into real implicit-deps
+        injection so BUILD files don't have to repeat the runtime
+        dep on every test target) and share the same three-branch
+        contract:
+
+        * ``scalatest_libs`` non-empty → forward the list as a whole
+          to ``Target._add_implicit_library``, which handles label
+          unification and dedup against the target's own ``deps``.
+        * ``scalatest_libs`` is ``[]`` or missing (``None``) → emit
+          one target-attributed warning pointing at the config key,
+          and make no implicit-library call. Workspaces that prefer
+          per-target explicit ``deps`` keep working, and users see
+          an actionable message for the misconfiguration case.
+
+        Kept as its own method, rather than inlined into ``__init__``,
+        so unit tests can cover all three branches without having to
+        construct a full ``ScalaTest`` instance against the build
+        manager, and so a future ``gtest_libs`` / similar helper has
+        an obvious template to copy.
+        """
         scalatest_libs = config.get_item('scala_test_config', 'scalatest_libs')
         if scalatest_libs:
             self._add_implicit_library(scalatest_libs)
         else:
-            console.warning('Config: "scala_test_config.scalatest_libs" is not configured')
+            self.warning(
+                'Config: "scala_test_config.scalatest_libs" is not configured; '
+                'scala_test targets must list their ScalaTest runtime in `deps` '
+                'explicitly. See `blade dump --config` for the current value.'
+            )
 
     def generate(self):
         if not self.srcs:

--- a/src/tests/unit/scala_targets_test.py
+++ b/src/tests/unit/scala_targets_test.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Unit tests for blade.scala_targets.ScalaTest._apply_scalatest_libs_from_config.
+
+"""Unit tests for ScalaTest's `scala_test_config.scalatest_libs` auto-injection.
+
+The hook is the scala-side twin of
+``JavaTest._apply_junit_libs_from_config``: it turns the
+``scala_test_config(scalatest_libs=[...])`` config key into a real
+implicit-deps injection point, so every ``scala_test`` target in a
+workspace automatically pulls its ScalaTest runtime out of the
+workspace-level config instead of repeating the dep by hand in
+every BUILD file.
+
+What we pin here (must stay in lock-step with
+``java_targets_test.ApplyJunitLibsFromConfigTest``):
+
+* When ``scalatest_libs`` is non-empty, the full list is forwarded
+  to ``Target._add_implicit_library`` in one call — delegating
+  per-label unification/dedup to that existing helper.
+* When ``scalatest_libs`` is empty (``[]``) or missing (``None``),
+  no implicit library is added and exactly one target-attributed
+  warning is emitted, pointing at the config key so ``blade -v``
+  shows something actionable.
+* The hook must query ``config.get_item`` with the exact pair
+  ``('scala_test_config', 'scalatest_libs')`` — a regression pin
+  against future schema-key drift.
+
+We do *not* construct a real ``ScalaTest`` (that would need the
+full build manager / a loaded BUILD file / a workspace root).
+Instead we ``ScalaTest.__new__(ScalaTest)`` a bare instance and
+stub the two collaborators the method touches: the module-level
+``config.get_item`` and the instance-level
+``self._add_implicit_library`` / ``self.warning``. This keeps the
+test sharply focused on the injection contract.
+"""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+# Make ``import blade.*`` resolve against the in-tree sources without
+# requiring blade to be installed.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import scala_targets  # noqa: E402  (sys.path tweak above)
+
+
+def _bare_scala_test():
+    """Build a ``ScalaTest`` instance bypassing ``__init__``.
+
+    The hook under test reads nothing from ``self`` other than the
+    two methods we stub below, so we skip the expensive constructor
+    chain that would otherwise require a live build manager / loaded
+    BUILD file / workspace root.
+    """
+    return scala_targets.ScalaTest.__new__(scala_targets.ScalaTest)
+
+
+class ApplyScalatestLibsFromConfigTest(unittest.TestCase):
+    """Cover every branch of ScalaTest._apply_scalatest_libs_from_config."""
+
+    def test_configured_libs_are_forwarded_to_add_implicit_library(self):
+        """Happy path: the config lists one or more labels, and the
+        hook forwards the *list* (not one call per label) to
+        ``_add_implicit_library``. Matching the java/proto shape keeps
+        ordering deterministic and lets ``Target._add_implicit_library``
+        do the per-label unification / dedup against ``self.deps``.
+        """
+        target = _bare_scala_test()
+        target._add_implicit_library = mock.Mock()
+        target.warning = mock.Mock()
+
+        configured = ['//thirdparty/scalatest:scalatest', '//thirdparty/scalactic:scalactic']
+        with mock.patch.object(scala_targets.config, 'get_item', return_value=configured):
+            target._apply_scalatest_libs_from_config()
+
+        target._add_implicit_library.assert_called_once_with(configured)
+        target.warning.assert_not_called()
+
+    def test_empty_list_warns_and_does_not_inject(self):
+        """Documented default: an empty list means "no auto-injection",
+        users must list ScalaTest in ``deps`` explicitly.
+
+        The hook must *not* touch ``_add_implicit_library`` (otherwise
+        we'd inject a bogus empty label set and hide the missing
+        config from users), and it must emit exactly one
+        target-attributed warning mentioning the config key."""
+        target = _bare_scala_test()
+        target._add_implicit_library = mock.Mock()
+        target.warning = mock.Mock()
+
+        with mock.patch.object(scala_targets.config, 'get_item', return_value=[]):
+            target._apply_scalatest_libs_from_config()
+
+        target._add_implicit_library.assert_not_called()
+        target.warning.assert_called_once()
+        (warn_msg,), _ = target.warning.call_args
+        self.assertIn('scala_test_config.scalatest_libs', warn_msg)
+
+    def test_none_is_treated_the_same_as_empty(self):
+        """``config.get_item`` returns ``None`` rather than ``[]`` when
+        a user deletes the key entirely from their ``BLADE_ROOT``.
+
+        Both shapes mean "not configured" and must take the same
+        branch — no injection, one warning. Locks in this equivalence
+        so a future refactor doesn't regress one case while preserving
+        the other."""
+        target = _bare_scala_test()
+        target._add_implicit_library = mock.Mock()
+        target.warning = mock.Mock()
+
+        with mock.patch.object(scala_targets.config, 'get_item', return_value=None):
+            target._apply_scalatest_libs_from_config()
+
+        target._add_implicit_library.assert_not_called()
+        target.warning.assert_called_once()
+
+    def test_looks_up_the_documented_config_path(self):
+        """Regression pin: the hook must read from
+        ``('scala_test_config', 'scalatest_libs')`` exactly. If
+        somebody later refactors the schema and forgets to update
+        this call site, the hook would silently read ``None`` from a
+        mistyped key and fall through to the warning branch — hiding
+        the bug. This test fails fast on that drift."""
+        target = _bare_scala_test()
+        target._add_implicit_library = mock.Mock()
+        target.warning = mock.Mock()
+
+        with mock.patch.object(scala_targets.config, 'get_item',
+                               return_value=['//x:y']) as get_item:
+            target._apply_scalatest_libs_from_config()
+
+        get_item.assert_called_once_with('scala_test_config', 'scalatest_libs')
+
+
+class SchemaTest(unittest.TestCase):
+    """Pin the config schema so the hook has something to read."""
+
+    def test_scalatest_libs_key_exists_with_empty_default(self):
+        """The key must be declared in ``config.py`` with a list
+        default. If this ever regresses, every workspace would start
+        seeing an AttributeError / KeyError instead of the documented
+        "not configured" warning."""
+        from blade import config as config_mod
+        default = config_mod.get_item('scala_test_config', 'scalatest_libs')
+        # Default in schema is []; after a real config load it may be
+        # any list. Only the shape is part of the contract.
+        self.assertIsInstance(default, list)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Extract the inline ``scalatest_libs`` handling inside
``ScalaTest.__init__`` into a named helper
``_apply_scalatest_libs_from_config()``, mirroring the shape of
``JavaTest._apply_junit_libs_from_config`` landed in #1101.
This is pure shape alignment — the scala side has consumed the
config key correctly all along — but the symmetry pays off in
three ways:

1. The two "config-driven implicit test runtime" hooks now have
   identical docstrings, identical three-branch contracts, and
   identical warning wording. They read as one pattern instead
   of two cousins.
2. Unit-testable: a bare ``ScalaTest.__new__(...)`` instance
   plus mocks for ``_add_implicit_library`` / ``self.warning``
   is enough. 5 new unit tests cover every branch without any
   build manager / BUILD file / workspace root setup.
3. When someone eventually does the equivalent for
   ``cc_test_config.gtest_libs`` (the third member of this
   family), they have an obvious template to copy.

## Change surface

Three files, `+37 / -4` (plus a new test file).

### `src/blade/scala_targets.py`

* **Extract helper.** The five-line block inside
  ``ScalaTest.__init__`` that read
  ``scala_test_config.scalatest_libs`` is moved verbatim (modulo
  the two fixes below) into a new method
  ``_apply_scalatest_libs_from_config()`` with a docstring that
  documents the three-branch contract (configured / empty /
  missing) and cross-references the java twin.
* **Target-attributed warning.** The "not configured" branch now
  uses ``self.warning(...)`` instead of ``console.warning(...)``.
  Every other config-missing warning in ``java_targets.py``
  already uses the target-attributed form, which lets
  ``blade -v`` show which target tripped the diagnostic and
  matches the mocking surface used by the new unit tests. The
  now-unused ``from blade import console`` import is dropped.
* **Actionable warning text.** Message expanded from the terse
  ``'Config: "scala_test_config.scalatest_libs" is not configured'``
  to also tell the user (a) that scala_test targets must list
  the ScalaTest runtime in `deps` explicitly and (b) how to
  inspect the current effective config (`blade dump --config`).
  Byte-for-byte identical to the junit_libs wording from #1101
  apart from the key name.

### `src/blade/java_targets.py`

* Bidirectional cross-reference housekeeping:
  ``JavaTest._apply_junit_libs_from_config`` docstring now
  points at the scala helper by symbol name
  (``ScalaTest._apply_scalatest_libs_from_config``) instead of
  the bare module name, now that it exists as a named symbol.

### `src/tests/unit/scala_targets_test.py` (new, ~150 lines)

One-to-one mirror of the ``junit_libs`` suite from #1101:

| test | pins |
|---|---|
| `test_configured_libs_are_forwarded_to_add_implicit_library` | happy path: list is forwarded whole to `_add_implicit_library` in one call |
| `test_empty_list_warns_and_does_not_inject` | `[]` → no inject + exactly one warning mentioning the key |
| `test_none_is_treated_the_same_as_empty` | `None` (key deleted from `BLADE_ROOT`) takes the same branch as `[]` |
| `test_looks_up_the_documented_config_path` | regression pin: `get_item('scala_test_config', 'scalatest_libs')` |
| `test_scalatest_libs_key_exists_with_empty_default` | schema pin: key exists in `config.py` with list default |

Uses ``ScalaTest.__new__(ScalaTest)`` to skip the constructor
chain (same trick the java test uses), so no build manager /
workspace is required.

## Behavior matrix

Must hold before and after this refactor:

| config.scalatest_libs | `_add_implicit_library` | warning |
|---|---|---|
| `['//x:y', ...]` (configured) | yes, 1×, whole list | no |
| `[]` (declared empty)         | no                  | yes, 1× |
| absent / `None`               | no                  | yes, 1× |

## Verification

macOS arm64, py3.12, working tree is pure v3.

* `PYTHONPATH=src python3 -m unittest discover -s src/tests/unit`
  → **34 tests** pass in 0.006s (29 before + 5 new scala tests).

* `pyright --outputjson` →
  `errors=0 warnings=113 infos=0`. Warning count identical to
  the v3 baseline; no new `# pyright: ignore` pragmas introduced
  by this refactor.

* `git diff --stat` for modified files:
  ```
  src/blade/java_targets.py  |  6 ++++--
  src/blade/scala_targets.py | 35 +++++++++++++++++++++++++++++++++--
  ```

## Why no blade-test side

Unlike the java-side pair (`blade-build#1101` +
`blade-test#8`), no blade-test PR is needed here: we don't have
a `scala_basic` suite yet, and adding one is out of scope for
this refactor. If/when we add one, it can omit the scalatest
dep from `deps` and the suite will immediately double as the
cross-repo e2e for this hook — the same trick `java_basic`
now plays for `junit_libs`.

## Not in scope

* `cc_test_config` / gtest auto-injection: same family, but
  cc_test already has its own longer-standing mechanism
  (`dynamic_link`, `heap_check`, etc.). Unifying that one is a
  separate project.
* The 113 pyright warnings: untouched, will be picked off
  module-by-module by the PR-v3-6+ type-hint sweep, which will
  then re-enable the warning-level rules as errors.
