### PR TITLE
feat(v3): type-annotate CcTarget.__init__

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -34,7 +34,12 @@ from blade.version import LooseVersion as version_parse
 
 
 # See https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html#Overall-Options
-_SOURCE_FILE_EXTS = {'c', 'cc', 'cp', 'cxx', 'cpp', 'CPP', 'c++', 'C', 's', 'S', 'asm'}
+# _SOURCE_FILE_EXTS is a tuple (not a set) so it fits the Sequence[str] shape
+# callers expect; it is only ever consumed as the resolved default for the
+# `src_exts=` parameter, and ordering has no semantic effect.
+_SOURCE_FILE_EXTS: 'tuple[str, ...]' = ('c', 'cc', 'cp', 'cxx', 'cpp', 'CPP', 'c++', 'C', 's', 'S', 'asm')
+# _HEADER_FILE_EXTS stays a set because it is consumed by `in` membership
+# checks in :func:`is_header_file`, which benefit from O(1) lookup.
 _HEADER_FILE_EXTS = {'h', 'hh', 'H', 'hp', 'hpp', 'hxx', 'HPP', 'h++', 'inc', 'inl', 'tcc'}
 
 
@@ -160,23 +165,23 @@ class CcTarget(Target):
     """
 
     def __init__(self,
-                 name,
-                 type,
-                 srcs,
-                 deps,
-                 visibility,
-                 tags,
-                 warning,
-                 defs,
-                 incs,
-                 export_incs,
-                 optimize,
-                 linkflags,
-                 extra_cppflags,
-                 extra_linkflags,
-                 kwargs,
-                 src_exts=_SOURCE_FILE_EXTS,
-                 cmd=''):
+                 name: str,
+                 type: str,
+                 srcs: 'list[str]',
+                 deps: 'list[str]',
+                 visibility: 'list[str] | None',
+                 tags: 'list[str]',
+                 warning: str,
+                 defs: 'list[str]',
+                 incs: 'list[str]',
+                 export_incs: 'list[str]',
+                 optimize: 'list[str] | None',
+                 linkflags: 'list[str] | None',
+                 extra_cppflags: 'list[str]',
+                 extra_linkflags: 'list[str]',
+                 kwargs: 'dict[str, object]',
+                 src_exts: 'list[str] | None' = None,
+                 cmd: str = ''):
         """Init method.
 
         Init the cc target.
@@ -196,6 +201,14 @@ class CcTarget(Target):
         srcs = [src for src in srcs if not is_header_file(src)]
         deps = var_to_list(deps)
         self.cmd = cmd
+
+        # src_exts=None means "caller did not override" and we fall back to
+        # the cc source-extension set. Rule entries that deliberately want an
+        # empty extension list (e.g. resource_library, which synthesizes its
+        # own .c/.h) should pass src_exts=None explicitly; passing a real list
+        # overrides the default (see cu_targets.CuTarget).
+        if src_exts is None:
+            src_exts = list(_SOURCE_FILE_EXTS)
 
         super().__init__(
                 name=name,

--- a/src/blade/cu_targets.py
+++ b/src/blade/cu_targets.py
@@ -22,7 +22,9 @@ from blade.util import var_to_list
 
 
 # See https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#supported-input-file-suffixes
-_SOURCE_FILE_EXTS = {'cu', 'c', 'cc', 'cxx', 'cpp', 'ptx'}
+# Tuple (not set) for the same reason as cc_targets._SOURCE_FILE_EXTS: used
+# only as the resolved default for CcTarget's `src_exts=` parameter.
+_SOURCE_FILE_EXTS: 'tuple[str, ...]' = ('cu', 'c', 'cc', 'cxx', 'cpp', 'ptx')
 
 
 class CuTarget(CcTarget):
@@ -68,7 +70,7 @@ class CuTarget(CcTarget):
                 extra_cppflags=extra_cppflags,
                 extra_linkflags=extra_linkflags,
                 kwargs=kwargs,
-                src_exts=_SOURCE_FILE_EXTS,
+                src_exts=list(_SOURCE_FILE_EXTS),
                 cmd='')
         self.cuda_path = self._get_cuda_path(cuda_path)
         self.attr['extra_cuflags'] = var_to_list(extra_cuflags)

--- a/src/blade/resource_library_target.py
+++ b/src/blade/resource_library_target.py
@@ -36,7 +36,7 @@ class ResourceLibrary(cc_targets.CcTarget):
                 name=name,
                 type='resource_library',
                 srcs=srcs,
-                src_exts=None,
+                src_exts=[],
                 deps=deps,
                 visibility=visibility,
                 tags=tags,


### PR DESCRIPTION
## Summary

Continues the v3 type-layer rollout started by #1106 (`Target.__init__`). `CcTarget` is the common base of seven rule classes (`cc_library` / `cc_binary` / `cc_plugin` / `cc_test` / `prebuilt_cc_library` / `foreign_cc_library` / `resource_library`), so annotating its `__init__` is the natural second step.

## Signature

Per the [v3 middle-layer contract](https://github.com/blade-build/blade-build/pull/1106):

| Parameter | Type |
|---|---|
| `name` / `type` / `warning` | `str` |
| `srcs` / `deps` / `tags` / `defs` / `incs` / `export_incs` / `extra_cppflags` / `extra_linkflags` | `list[str]` |
| `visibility` / `optimize` / `linkflags` | `list[str] \| None` |
| `kwargs` | `dict[str, object]` |
| `src_exts` | `list[str] \| None = None` |
| `cmd` | `str = ''` |

## Call-site changes

Three small, related changes forced by the new signature — all rooted in the previous `src_exts=_SOURCE_FILE_EXTS` default being a `set[str]` (which pyright correctly refuses to collapse to `list[str]`):

### 1. `cc_targets._SOURCE_FILE_EXTS` : `set` → `tuple[str, ...]`
Only ever used as the resolved default for `src_exts=`; ordering doesn't matter and losing O(1) membership lookup is irrelevant. Kept a comment explaining why the neighbouring `_HEADER_FILE_EXTS` stays a `set` (it **is** used for `in` checks in `is_header_file`).

### 2. `cu_targets._SOURCE_FILE_EXTS` : same
Its single call site in `CuTarget.__init__` now materializes it with `list(_SOURCE_FILE_EXTS)` before forwarding.

### 3. `ResourceLibrary.__init__` : `src_exts=None` → `src_exts=[]`
`ResourceLibrary.srcs` are arbitrary resource files (`.html`, `.js`, ...), not C sources, so it deliberately wants to skip source-extension validation. Previously this was expressed as `src_exts=None`, which flowed through `var_to_list(None)` → `[]` → `if not exts: continue` in `_check_sources`. 

With the new signature, **`None` changes meaning** to "use the `CcTarget` default", so the explicit opt-out is now `src_exts=[]`. Same call-site-fix pattern PR #1106 used for `MavenJar` / `PackageTarget`.

## Worth calling out: pyright alone did **not** catch this

Change (3) is the interesting one. pyright was perfectly happy — `None` is a legal value for `src_exts: list[str] | None`. It was the **E2E integration suite** that flagged the regression: `dump_test.testDumpCompdb` / `testDumpTargets` started failing with

```
static_resource: Invalid source file name: "forms.js", must ends with
['c', 'cc', 'cp', 'cxx', 'cpp', 'CPP', 'c++', 'C', 's', 'S', 'asm']
```

because the sentinel meaning of `None` had silently flipped from "skip validation" (old behavior, via empty-list short-circuit in `_check_sources`) to "use `_SOURCE_FILE_EXTS`" (new behavior, via the default resolver I added in `CcTarget.__init__`).

This is exactly the scenario that the "[Re-read every new pyright error](https://github.com/chen3feng/agent-skills/pull/26) + [E2E smoke suite reveals upstream bugs](https://github.com/chen3feng/agent-skills/blob/master/skills/sidecar-smoke-suite-reveals-upstream-bugs/SKILL.md)" skills warn about: pyright only narrows *type-level* inputs; it cannot diagnose that a `None` sentinel changed runtime *meaning*. The E2E suite (PR #1095) earned its keep again.

## Verification

| Check | Result |
|---|---|
| `pyright` | **0 errors**, 113 warnings (unchanged warning count) |
| Unit tests (`unittest discover -s src/tests/unit`) | **49/49 passed** (no new tests in this PR) |
| Integration (`bash src/test/runall.sh`) | 9 failures == v3 macOS baseline (link-time, unrelated) |
| E2E smoke (blade-test) | Verified by the regression itself being caught and fixed; CI will re-confirm. |

## Diff size

```
 src/blade/cc_targets.py              | 49 ++++++++++++++++++++++++------------
 src/blade/cu_targets.py              |  6 +++--
 src/blade/resource_library_target.py |  2 +-
 3 files changed, 36 insertions(+), 21 deletions(-)
```

## What's next (PR-v3-12+)

Annotate the rule-entry functions, one file per PR, starting from the leaves:

- `resource_library_target.py` (single class, ~100 lines)
- `prebuild_cc_library_target.py`
- `foreign_cc_library_target.py`
- `cc_targets.py` (cc_library / cc_binary / cc_plugin / cc_test rule entries)
- `cu_targets.py`

Each of those will add `StrOrList` / `StrOrListOpt` to the rule-entry signatures and type-annotate the subclass `__init__`s (which are mostly mechanical forwarding).
