### PR TITLE
chore(v3): drop redundant `from __future__ import annotations` in blade_types

### DIFF
--- a/src/blade/blade_types.py
+++ b/src/blade/blade_types.py
@@ -29,8 +29,6 @@ Layering
 `StrOrList` should therefore only appear in rule-entry function signatures.
 """
 
-from __future__ import annotations
-
 from typing import Optional, Union
 
 # A BUILD-file-friendly string-or-list-of-strings union.


### PR DESCRIPTION
## Summary

`src/blade/blade_types.py` contains only **module-level assignments**:

```python
StrOrList    = Union[str, list[str]]
StrOrListOpt = Optional[StrOrList]
```

No function signatures, no variable annotations. Since `from __future__ import annotations` (PEP 563) only affects annotation-position expressions, it has zero effect in this module.

## Why it's also unnecessary on v3's target interpreter

The RHS uses three constructs:

| Expression | Runtime status on Py 3.10+ |
|---|---|
| `Union[...]` | ✅ `typing.Union` is a runtime value |
| `Optional[...]` | ✅ same |
| `list[str]` | ✅ native subscripting since Py 3.9 (PEP 585); v3 requires ≥ 3.10 |

So the future import is redundant **twice over**: wrong layer *and* unnecessary on the target interpreter.

## Safety

- **No runtime behaviour change** — removing a no-op import.
- Both callers (`util.py`, `resource_library_target.py`) use **string-form forward refs** (`'StrOrListOpt'`, `'StrOrList'`), so they'd be unaffected even if the removal did matter.

## Verification

| Check | Result |
|---|---|
| `pyright` | 0 errors, 113 warnings (unchanged) |
| Unit tests | 49/49 passed |

Skipping E2E smoke here: this is a source-only no-op with no import-graph or runtime reachability change (unlike sentinel widens). If CI's E2E smoke disagrees, I'll of course investigate.

## Diff

```
 src/blade/blade_types.py | 2 --
 1 file changed, 2 deletions(-)
```
