### PR TITLE
feat(v3): type-annotate prebuilt_cc_library entry and PrebuiltCcLibrary.__init__

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -20,6 +20,7 @@ from blade import build_manager
 from blade import build_rules
 from blade import config
 from blade import inclusion_check
+from blade.blade_types import StrOrListOpt
 from blade.constants import HEAP_CHECK_VALUES
 from blade.target import Target
 from blade.util import (
@@ -907,19 +908,26 @@ class PrebuiltCcLibrary(CcTarget):
     """
 
     def __init__(self,
-                 name,
-                 deps,
-                 hdrs,
-                 visibility,
-                 tags,
-                 export_incs,
-                 libpath_pattern,
-                 link_all_symbols,
-                 binary_link_only,
-                 deprecated,
-                 kwargs):
+                 name: 'str | None',
+                 deps: 'StrOrListOpt',
+                 hdrs: 'StrOrListOpt',
+                 visibility: 'StrOrListOpt',
+                 tags: 'StrOrListOpt',
+                 export_incs: 'StrOrListOpt',
+                 libpath_pattern: 'str | None',
+                 link_all_symbols: bool,
+                 binary_link_only: bool,
+                 deprecated: bool,
+                 kwargs: 'dict[str, object]'):
         """Init method."""
         # pylint: disable=too-many-locals
+        # Normalize the BUILD-file-friendly StrOrList unions once, right at
+        # the top; everything below (including CcTarget.__init__) sees the
+        # layer-2 `list[str]` / `list[str] | None` shape.
+        deps = var_to_list(deps)
+        tags = var_to_list(tags)
+        export_incs = var_to_list(export_incs)
+        visibility = var_to_list_or_none(visibility)
         super().__init__(
                 name=name,
                 type='prebuilt_cc_library',
@@ -1049,17 +1057,17 @@ class PrebuiltCcLibrary(CcTarget):
 
 
 def prebuilt_cc_library(
-        name,
-        deps=None,
-        visibility=None,
-        tags=None,
-        export_incs=None,
-        hdrs=None,
-        libpath_pattern=None,
-        link_all_symbols=False,
-        binary_link_only=False,
-        deprecated=False,
-        **kwargs):
+        name: 'str | None' = None,
+        deps: 'StrOrListOpt' = None,
+        visibility: 'StrOrListOpt' = None,
+        tags: 'StrOrListOpt' = None,
+        export_incs: 'StrOrListOpt' = None,
+        hdrs: 'StrOrListOpt' = None,
+        libpath_pattern: 'str | None' = None,
+        link_all_symbols: bool = False,
+        binary_link_only: bool = False,
+        deprecated: bool = False,
+        **kwargs: object):
     """prebuilt_cc_library rule"""
     target = PrebuiltCcLibrary(
             name=name,


### PR DESCRIPTION
## Summary

Second rule-entry module to follow the type-annotation pattern established by #1108 (`resource_library`). Scope is strictly `prebuilt_cc_library` (entry) and `PrebuiltCcLibrary.__init__` inside the already-big `cc_targets.py` — no base-class cascade this time (PRs #1106/#1107/#1108 already widened `Target`/`CcTarget.__init__` and `name: str | None`).

## Layered types

### Outer (rule entry) — `prebuilt_cc_library(...)`

| Param | Was | Now |
|---|---|---|
| `name` | *(required, no default)* | `str \| None = None` |
| `deps` / `visibility` / `tags` / `export_incs` / `hdrs` | `=None` untyped | `StrOrListOpt = None` |
| `libpath_pattern` | `=None` | `str \| None = None` |
| `link_all_symbols` / `binary_link_only` / `deprecated` | `=False` | `bool = False` |
| `**kwargs` | untyped | `**kwargs: object` |

Note on `name`: this aligns the entry with the repo-wide rule-entry convention (the 19 rule entries uniformly use `name=None` so that "BUILD file forgot `name=`" is deferred to `Target.__init__`'s single, friendly `console.fatal('Missing "name"')` diagnostic rather than an arg-count `TypeError`). Three other entries in this file (`cc_library`, `foreign_cc_library`, `cc_plugin`) are still missing the default — intentionally left for their own PRs.

### Middle (class) — `PrebuiltCcLibrary.__init__`

- list-ish params typed `StrOrListOpt` (matches entry forwarding + intra-layer callers); `libpath_pattern: str | None`; flags `bool`; `kwargs: dict[str, object]`.
- One normalize hop at the top of the body:
  ```python
  deps = var_to_list(deps)
  tags = var_to_list(tags)
  export_incs = var_to_list(export_incs)
  visibility = var_to_list_or_none(visibility)
  ```
  After this line, `super().__init__(...)` (i.e. `CcTarget.__init__`) and all the `self.*` writes see the layer-2 `list[str]` / `list[str] | None` shape. `visibility` keeps its None-sentinel (distinct from `[]`).
- `hdrs` is forwarded unchanged to `self._set_hdrs(...)` which already handles `None` / `str` / `list[str]` internally.

### Inner

Not touched — this PR adds no new inner-layer reach.

## Runtime behaviour delta

Entry `prebuilt_cc_library(...)` did not normalize before; `PrebuiltCcLibrary.__init__` forwarded raw values into `CcTarget.__init__`, which also didn't normalize `visibility`/`tags`, leaving it to `Target.__init__`'s defensive `var_to_list` at the very top.

After this PR, normalization happens **earlier** in the exact same call chain, with the same `var_to_list` / `var_to_list_or_none` semantics. No sentinel flip ([[memory:q6i8rt7e]] #10 warning: "mid-layer sentinel 翻转是 pyright 盲区" — this PR is specifically **not** one of those cases, but e2e run below still confirmed).

## Verification

| Check | Result |
|---|---|
| `pyright` | 0 errors, 113 warnings (unchanged) |
| Unit tests | 49/49 pass |
| E2E integration (`src/test/runall.sh`) | 26 run, 9 fail = macOS baseline (link-time, unrelated); matches recorded baseline |

CI ubuntu-22.04 is the authoritative green gate.

## Follow-ups

- PR-v3-14: annotate `foreign_cc_library` entry + `ForeignCcLibrary.__init__` (same file, same pattern).
- PR-v3-15+: the four big cc entries (`cc_library` / `cc_binary` / `cc_test` / `cc_plugin`). These will need `StrOrList` as well (for required `srcs`-style params) — will re-introduce the `StrOrList` import at that point.

## Diff

```
 src/blade/cc_targets.py | 52 ++++++++++++++++++++++++++++++-----------------
 1 file changed, 30 insertions(+), 22 deletions(-)
```
