### PR TITLE
feat(v3): type-annotate foreign_cc_library entry and ForeignCcLibrary.__init__

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1173,22 +1173,31 @@ class ForeignCcLibrary(CcTarget):
     """
 
     def __init__(self,
-                 name,
-                 deps,
-                 install_dir,
-                 hdrs,
-                 hdr_dir,
-                 visibility,
-                 tags,
-                 export_incs,
-                 lib_dir,
-                 has_dynamic,
-                 link_all_symbols,
-                 binary_link_only,
-                 deprecated,
-                 kwargs):
+                 name: 'str | None',
+                 deps: 'StrOrListOpt',
+                 install_dir: str,
+                 hdrs: 'StrOrListOpt',
+                 hdr_dir: str,
+                 visibility: 'StrOrListOpt',
+                 tags: 'StrOrListOpt',
+                 export_incs: 'StrOrListOpt',
+                 lib_dir: str,
+                 has_dynamic: bool,
+                 link_all_symbols: bool,
+                 binary_link_only: bool,
+                 deprecated: bool,
+                 kwargs: 'dict[str, object]'):
         """Init method."""
         # pylint: disable=too-many-locals
+        # Normalize the BUILD-file-friendly StrOrList unions once, right at
+        # the top; everything below (including CcTarget.__init__ and the
+        # hdrs-branch further down) sees layer-2 `list[str]` /
+        # `list[str] | None`.
+        deps = var_to_list(deps)
+        tags = var_to_list(tags)
+        export_incs = var_to_list(export_incs)
+        hdrs = var_to_list(hdrs)
+        visibility = var_to_list_or_none(visibility)
         super().__init__(
                 name=name,
                 type='foreign_cc_library',
@@ -1213,7 +1222,7 @@ class ForeignCcLibrary(CcTarget):
         self._add_tags('lang:cc', 'type:library', 'type:foreign')
 
         if hdrs:
-            hdrs = [os.path.join(install_dir, h) for h in var_to_list(hdrs)]
+            hdrs = [os.path.join(install_dir, h) for h in hdrs]
             declare_hdrs(self, hdrs)
             hdrs = [self._target_file_path(os.path.join(install_dir, h)) for h in hdrs]
             self.attr['generated_hdrs'] = hdrs
@@ -1259,20 +1268,20 @@ class ForeignCcLibrary(CcTarget):
 
 
 def foreign_cc_library(
-        name,
-        install_dir='',
-        lib_dir='lib',
-        hdrs=None,
-        hdr_dir='',
-        export_incs=None,
-        deps=None,
-        has_dynamic=False,
-        link_all_symbols=False,
-        binary_link_only=False,
-        visibility=None,
-        tags=None,
-        deprecated=False,
-        **kwargs):
+        name: 'str | None' = None,
+        install_dir: str = '',
+        lib_dir: str = 'lib',
+        hdrs: 'StrOrListOpt' = None,
+        hdr_dir: str = '',
+        export_incs: 'StrOrListOpt' = None,
+        deps: 'StrOrListOpt' = None,
+        has_dynamic: bool = False,
+        link_all_symbols: bool = False,
+        binary_link_only: bool = False,
+        visibility: 'StrOrListOpt' = None,
+        tags: 'StrOrListOpt' = None,
+        deprecated: bool = False,
+        **kwargs: object):
     """Similar to a prebuilt cc_library, but it is built by a foreign build system,
     such as autotools, cmake, etc.
 


### PR DESCRIPTION
## Summary

Third rule-entry module to follow the type-annotation pattern from #1108 / #1110. Scope: `foreign_cc_library` entry + `ForeignCcLibrary.__init__` inside `cc_targets.py`. Single-file, mechanical, no base-class cascade.

## Layered types

### Outer (rule entry) — `foreign_cc_library(...)`

| Param | Was | Now |
|---|---|---|
| `name` | *(required, no default)* | `str \| None = None` |
| `deps` / `hdrs` / `export_incs` / `visibility` / `tags` | `=None` untyped | `StrOrListOpt = None` |
| `install_dir` / `hdr_dir` | `=''` | `str = ''` |
| `lib_dir` | `='lib'` | `str = 'lib'` |
| `has_dynamic` / `link_all_symbols` / `binary_link_only` / `deprecated` | `=False` | `bool = False` |
| `**kwargs` | untyped | `**kwargs: object` |

The three `*_dir` params are single-value directory strings (empty-string sentinel for "not configured"); they are intentionally `str`, not `StrOrList`.

`name` default added to align with the repo-wide 19-rule-entry convention (defer missing-name to `Target.__init__`'s uniform `console.fatal('Missing "name"')`).

### Middle (class) — `ForeignCcLibrary.__init__`

- list-ish params typed `StrOrListOpt`; `*_dir` `str`; flags `bool`; `kwargs: dict[str, object]`.
- One normalize hop at the top of the body:
  ```python
  deps = var_to_list(deps)
  tags = var_to_list(tags)
  export_incs = var_to_list(export_incs)
  hdrs = var_to_list(hdrs)
  visibility = var_to_list_or_none(visibility)
  ```
  After this, `super().__init__(...)` and the `if hdrs:` branch further down both see layer-2 `list[str]` / `list[str] | None`.
- **Side cleanup**: the `if hdrs:` branch used to do `var_to_list(hdrs)` inline as the iterable of its list-comp. With the top-of-body normalize, that second call is redundant; dropped it. The truthiness semantics of `if hdrs:` are preserved — `var_to_list(None)` and `var_to_list('')` both return `[]` (falsy), matching the pre-normalize behavior where `None` / `''` were directly falsy.

### Inner

Not touched.

## Runtime behaviour delta

Same as #1110: normalize moves one frame earlier in the exact same call chain, with identical `var_to_list` / `var_to_list_or_none` semantics. Not a sentinel flip — not the mid-layer pyright blindspot pattern.

## Verification

| Check | Result |
|---|---|
| `pyright` | 0 errors, 113 warnings (unchanged) |
| Unit tests | 49/49 |
| E2E (`src/test/runall.sh`) | 26 run, 9 fail = macOS baseline (link-time, unrelated) |

## Follow-ups

- PR-v3-15: `cc_benchmark` (smallest remaining in cc_targets.py)
- PR-v3-16+: `cc_plugin`, `cc_binary`, `cc_test`, `cc_library`
- These will need `StrOrList` (non-Opt) once they hit the required `srcs` param; the `StrOrList` import will be re-added in the PR that first needs it.

## Diff

```
 src/blade/cc_targets.py | 46 ++++++++++++++++++++++++++--------------------
 1 file changed, 26 insertions(+), 20 deletions(-)
```
