### PR TITLE
feat(v3): type-annotate cc_plugin entry and CcPlugin.__init__

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1536,30 +1536,47 @@ class CcPlugin(CcTarget):
     """
 
     def __init__(self,
-                 name,
-                 srcs,
-                 deps,
-                 visibility,
-                 tags,
-                 warning,
-                 defs,
-                 incs,
-                 optimize,
-                 prefix,
-                 suffix,
-                 linkflags,
-                 extra_cppflags,
-                 extra_linkflags,
-                 linker_scripts,
-                 version_scripts,
-                 allow_undefined,
-                 strip,
-                 kwargs):
+                 name: 'str | None',
+                 srcs: 'StrOrListOpt',
+                 deps: 'StrOrListOpt',
+                 visibility: 'StrOrListOpt',
+                 tags: 'StrOrListOpt',
+                 warning: str,
+                 defs: 'StrOrListOpt',
+                 incs: 'StrOrListOpt',
+                 optimize: 'StrOrListOpt',
+                 prefix: 'str | None',
+                 suffix: 'str | None',
+                 linkflags: 'StrOrListOpt',
+                 extra_cppflags: 'StrOrListOpt',
+                 extra_linkflags: 'StrOrListOpt',
+                 linker_scripts: 'StrOrListOpt',
+                 version_scripts: 'StrOrListOpt',
+                 allow_undefined: bool,
+                 strip: bool,
+                 kwargs: 'dict[str, object]'):
         """Init method.
 
         Init the cc plugin target.
 
         """
+        # Normalize the BUILD-file-friendly StrOrList unions once, right at
+        # the rule boundary, so everything downstream sees list[str].
+        # `visibility`, `optimize` and `linkflags` keep None-sentinel
+        # semantics and are handled via var_to_list_or_none to match
+        # CcTarget.__init__.
+        srcs = var_to_list(srcs)
+        deps = var_to_list(deps)
+        tags = var_to_list(tags)
+        defs = var_to_list(defs)
+        incs = var_to_list(incs)
+        extra_cppflags = var_to_list(extra_cppflags)
+        extra_linkflags = var_to_list(extra_linkflags)
+        linker_scripts = var_to_list(linker_scripts)
+        version_scripts = var_to_list(version_scripts)
+        visibility = var_to_list_or_none(visibility)
+        optimize = var_to_list_or_none(optimize)
+        linkflags = var_to_list_or_none(linkflags)
         super().__init__(
                   name=name,
                   type='cc_plugin',
@@ -1580,8 +1597,8 @@ class CcPlugin(CcTarget):
         self.suffix = suffix
         self.attr['allow_undefined'] = allow_undefined
         self.attr['strip'] = strip
-        self.attr['lds_fullpath'] = self._fullpath_sources(var_to_list(linker_scripts))
-        self.attr['vers_fullpath'] = self._fullpath_sources(var_to_list(version_scripts))
+        self.attr['lds_fullpath'] = self._fullpath_sources(linker_scripts)
+        self.attr['vers_fullpath'] = self._fullpath_sources(version_scripts)
         self._add_tags('lang:cc', 'type:plugin')
 
     def _before_generate(self):  # override
@@ -1619,25 +1636,25 @@ class CcPlugin(CcTarget):
 
 
 def cc_plugin(
-        name,
-        srcs=None,
-        deps=None,
-        visibility=None,
-        tags=None,
-        warning='yes',
-        defs=None,
-        incs=None,
-        optimize=None,
-        prefix=None,
-        suffix=None,
-        linkflags=None,
-        extra_cppflags=None,
-        extra_linkflags=None,
-        linker_scripts=None,
-        version_scripts=None,
-        allow_undefined=True,
-        strip=False,
-        **kwargs):
+        name: 'str | None' = None,
+        srcs: 'StrOrListOpt' = None,
+        deps: 'StrOrListOpt' = None,
+        visibility: 'StrOrListOpt' = None,
+        tags: 'StrOrListOpt' = None,
+        warning: str = 'yes',
+        defs: 'StrOrListOpt' = None,
+        incs: 'StrOrListOpt' = None,
+        optimize: 'StrOrListOpt' = None,
+        prefix: 'str | None' = None,
+        suffix: 'str | None' = None,
+        linkflags: 'StrOrListOpt' = None,
+        extra_cppflags: 'StrOrListOpt' = None,
+        extra_linkflags: 'StrOrListOpt' = None,
+        linker_scripts: 'StrOrListOpt' = None,
+        version_scripts: 'StrOrListOpt' = None,
+        allow_undefined: bool = True,
+        strip: bool = False,
+        **kwargs: object):
     """cc_plugin target."""
     target = CcPlugin(
             name=name,


### PR DESCRIPTION
## Summary

Annotate the **`cc_plugin`** rule-entry and its paired class `CcPlugin.__init__` in `src/blade/cc_targets.py`. Same mechanical pattern as #1110 / #1111; one notable side finding surfaced during the review (`prefix` / `suffix` appear to be dead parameters — **not fixed in this PR**, just documented).

## Signatures

### Entry (forwards to class `__init__`)

```python
def cc_plugin(
        name: 'str | None' = None,        # was positional; now aligned to rule-entry convention
        srcs: 'StrOrListOpt' = None,
        deps: 'StrOrListOpt' = None,
        visibility: 'StrOrListOpt' = None,
        tags: 'StrOrListOpt' = None,
        warning: str = 'yes',
        defs: 'StrOrListOpt' = None,
        incs: 'StrOrListOpt' = None,
        optimize: 'StrOrListOpt' = None,
        prefix: 'str | None' = None,
        suffix: 'str | None' = None,
        linkflags: 'StrOrListOpt' = None,
        extra_cppflags: 'StrOrListOpt' = None,
        extra_linkflags: 'StrOrListOpt' = None,
        linker_scripts: 'StrOrListOpt' = None,
        version_scripts: 'StrOrListOpt' = None,
        allow_undefined: bool = True,
        strip: bool = False,
        **kwargs: object):
```

`**kwargs: object` (not `Any`) — this is the "rule-entry forwards to a Target subclass `__init__`" branch (per the convention reaffirmed in #1112). `CcPlugin.__init__` types its `kwargs` dict as `dict[str, object]`, so `object` is strict-and-correct here.

### Class `__init__`

```python
def __init__(self,
             name: 'str | None',
             srcs: 'StrOrListOpt',
             deps: 'StrOrListOpt',
             visibility: 'StrOrListOpt',
             tags: 'StrOrListOpt',
             warning: str,
             defs: 'StrOrListOpt',
             incs: 'StrOrListOpt',
             optimize: 'StrOrListOpt',
             prefix: 'str | None',
             suffix: 'str | None',
             linkflags: 'StrOrListOpt',
             extra_cppflags: 'StrOrListOpt',
             extra_linkflags: 'StrOrListOpt',
             linker_scripts: 'StrOrListOpt',
             version_scripts: 'StrOrListOpt',
             allow_undefined: bool,
             strip: bool,
             kwargs: 'dict[str, object]'):
```

## Body change: normalize once at the top

`CcPlugin.__init__` previously forwarded `StrOrListOpt` values straight into `CcTarget.__init__`, which (post-#1107) strictly expects `list[str]` / `list[str] | None`. Without pre-normalizing, pyright produced **10 errors** on the `super().__init__(...)` call. Added the standard "normalize once at the rule boundary" block (copied pattern from #1110 / #1111):

```python
srcs = var_to_list(srcs)
deps = var_to_list(deps)
tags = var_to_list(tags)
defs = var_to_list(defs)
incs = var_to_list(incs)
extra_cppflags = var_to_list(extra_cppflags)
extra_linkflags = var_to_list(extra_linkflags)
linker_scripts = var_to_list(linker_scripts)
version_scripts = var_to_list(version_scripts)
visibility = var_to_list_or_none(visibility)
optimize = var_to_list_or_none(optimize)
linkflags = var_to_list_or_none(linkflags)
```

The variant `var_to_list_or_none` is used for `visibility` / `optimize` / `linkflags` to match `CcTarget.__init__`'s None-sentinel semantics.

As a consequence the two redundant `var_to_list(...)` wrappings lower in the body are now stripped:

```diff
- self.attr['lds_fullpath']  = self._fullpath_sources(var_to_list(linker_scripts))
- self.attr['vers_fullpath'] = self._fullpath_sources(var_to_list(version_scripts))
+ self.attr['lds_fullpath']  = self._fullpath_sources(linker_scripts)
+ self.attr['vers_fullpath'] = self._fullpath_sources(version_scripts)
```

## Also: aligned rule-entry default

Before this PR, `cc_plugin(name, ...)` was the odd one out with no `None` default on `name` (most other rule-entries in the repo already have it, per the convention from #1108). Now `name: str | None = None`, matching sibling rule-entries. No behavior change — `Target.__init__` already validates the name.

## Side finding: `prefix` / `suffix` are dead parameters (NOT fixed here)

During review I noticed:

```python
self.prefix = prefix
self.suffix = suffix
```

…are stored but **never read** anywhere in `src/blade/`. The actual output-filename logic hard-codes `lib<name>.so`:

```python
if self.name.endswith('.so'):
    output = self._target_file_path(self.name)
else:
    output = self._target_file_path('lib%s.so' % self.name)
```

They appear to be historical vestiges (or unfinished work). Deliberately **left untouched in this PR** to keep the diff a pure annotate-mechanical change. Candidate for a follow-up: either implement prefix/suffix honoring, or deprecate/remove them with a changelog note.

## Import delta

None — `StrOrListOpt`, `var_to_list` and `var_to_list_or_none` were already imported.

## Verification

| Check | Result |
|---|---|
| `pyright` | 0 errors, 113 warnings (unchanged) |
| Unit tests | 49 / 49 |
| E2E (`src/test/runall.sh`, macOS local) | 26 run, 9 fail = baseline |

## Follow-ups

- Decide on `prefix` / `suffix` for `cc_plugin` — a separate cleanup PR.
- **PR-v3-17**: `cc_binary` + `CcBinary.__init__` (and revisit `cc_benchmark`'s `**kwargs: Any` from #1112 afterwards).
- PR-v3-18: `cc_test` + `CcTest.__init__`.
- PR-v3-19: `cc_library` + `CcLibrary.__init__` (largest in the file).
