### PR TITLE
cc_plugin: honor prefix/suffix, drop '.so'-name escape hatch, tighten name type

### DIFF
--- a/doc/en/build_rules/cc.md
+++ b/doc/en/build_rules/cc.md
@@ -479,8 +479,8 @@ cc_plugin(
 
 Attributes:
 
-- `prefix`: str = 'lib', the file name prefix of the generated dynamic library, the default is `lib`
-- `suffix`: str = '.so', the file name prefix of the generated dynamic library, the default is `.so`
+- `prefix`: str | None = None, the file name prefix of the generated dynamic library. The default `None` means "use the current toolchain's platform default" (`lib` on Linux/macOS, empty on Windows).
+- `suffix`: str | None = None, the file name suffix of the generated dynamic library. The default `None` means "use the current toolchain's platform default" (`.so` on Linux, `.dylib` on macOS, `.dll` on Windows).
 - `allow_undefined`: bool = False, whether undefined symbols are allowed when linking. Because many plug-in libraries depend on the symbol names provided by the
   host process at runtime, the definition of these symbols does not exist in the link phase.
 - `strip`: bool = False, whether to remove the debugging symbol information. If enabled, the size of the generated library can be reduced, but symbolic debugging
@@ -495,8 +495,8 @@ Attributes:
   The linker version script is used to control the version and visibility of the symbol, if no version id is specified, it only to control the visibility of the symbol.
   Linker version script files usually have the extension `exp`, `sym`, `.ver` or `.map`.
 
-`prefix` and `suffix` control the file name of the generated dynamic library, assuming `name='file'`, the default generated library is `libfile.so`,
-set `prefix=''`, then it becomes `file.so`.
+`prefix` and `suffix` control the file name of the generated dynamic library. Assuming `name='file'`, on a Linux toolchain the default output is `libfile.so`;
+setting `prefix=''` makes it `file.so`. Passing a `name` that already carries a shared-library extension (e.g. `name='file.so'`) is no longer implicitly treated as "the full output file name"; to fully customize the output name, pass `prefix=''` and `suffix='.so'` explicitly.
 
 ### Controlling the visibility of symbols in dynamic libraries
 

--- a/doc/zh_CN/build_rules/cc.md
+++ b/doc/zh_CN/build_rules/cc.md
@@ -469,8 +469,8 @@ cc_plugin(
 
 属性：
 
-- `prefix`: str, 生成的动态库的文件名前缀，默认为 `lib`
-- `suffix`: str，生成的动态库的文件名后缀，默认为 `.so`
+- `prefix`: str | None, 生成的动态库的文件名前缀。默认为 `None`，表示沿用当前工具链的平台默认前缀（Linux/macOS 为 `lib`，Windows 为空）。
+- `suffix`: str | None, 生成的动态库的文件名后缀。默认为 `None`，表示沿用当前工具链的平台默认后缀（Linux 为 `.so`，macOS 为 `.dylib`，Windows 为 `.dll`）。
 - `allow_undefined`: bool, 链接时是否允许未定义的符号。因为很多插件库运行时依赖宿主进程提供的符号名，链接阶段并不存在这些符号的定义。
 - `strip`: bool, 是否去除调试符号信息，开启后可以减少生成的库的大小，但是无法进行符号化调试。
 - `linker_scripts`: list(string)，使用链接器脚本。
@@ -483,7 +483,7 @@ cc_plugin(
   链接器版本脚本用来控制符号的版本及可见性，内容仅限于完整的链接脚本里 `VERSION {};` 内的部分，如果不指定版本号，那么可以只用来控制符号的可见性。
   链接器版本脚本文件的扩展名一般为 `exp`、`sym`、`.ver` 或者 `.map`。
 
-`prefix` 和 `suffix` 控制生成的动态库的文件名，假设 `name='file'`，默认生成的库为 `libfile.so`，设置`prefix=''`，则变为 `file.so`。
+`prefix` 和 `suffix` 控制生成的动态库的文件名。假设 `name='file'`，在 Linux 工具链上默认生成 `libfile.so`；设置 `prefix=''` 则变为 `file.so`。传入已带共享库后缀的 `name`（如 `name='file.so'`）不再被隐式识别为"输出文件全名"，如需完全自定义输出文件名，请改用 `prefix=''` 与 `suffix='.so'` 显式表达。
 
 ### 控制动态库中符号的可见性
 

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -160,6 +160,16 @@ def need_dwp():
     return config.get_item('cc_config', 'dwp')
 
 
+def _cc_plugin_default_prefix_suffix() -> tuple[str, str]:
+    """Default (prefix, suffix) for cc_plugin output file names.
+
+    Currently fixed to ('lib', '.so') because blade only supports Linux as a
+    build target. When cross-platform support lands, derive these from the
+    active toolchain (macOS: ('lib', '.dylib'); Windows: ('', '.dll')).
+    """
+    return ('lib', '.so')
+
+
 class CcTarget(Target):
     """
     This class is derived from Target and it is the base class
@@ -1536,7 +1546,7 @@ class CcPlugin(CcTarget):
     """
 
     def __init__(self,
-                 name: 'str | None',
+                 name: str,
                  srcs: 'StrOrListOpt',
                  deps: 'StrOrListOpt',
                  visibility: 'StrOrListOpt',
@@ -1545,8 +1555,8 @@ class CcPlugin(CcTarget):
                  defs: 'StrOrListOpt',
                  incs: 'StrOrListOpt',
                  optimize: 'StrOrListOpt',
-                 prefix: 'str | None',
-                 suffix: 'str | None',
+                 prefix: str | None,
+                 suffix: str | None,
                  linkflags: 'StrOrListOpt',
                  extra_cppflags: 'StrOrListOpt',
                  extra_linkflags: 'StrOrListOpt',
@@ -1593,8 +1603,23 @@ class CcPlugin(CcTarget):
                   extra_cppflags=extra_cppflags,
                   extra_linkflags=extra_linkflags,
                   kwargs=kwargs)
-        self.prefix = prefix
-        self.suffix = suffix
+        # Soft-deprecation: before this change, `cc_plugin(name='foo.so')` was
+        # the only way to override the 'lib%s.so' output basename (because
+        # prefix/suffix were silently ignored). Now that prefix/suffix are
+        # honored, a name ending in a shared-library extension is ambiguous:
+        # under the new rules it would produce e.g. 'libfoo.so.so'. Warn the
+        # user so they can switch to the documented `prefix=''` / `suffix=''`
+        # spelling instead.
+        if (name.endswith(('.so', '.dylib', '.dll'))
+                and prefix is None and suffix is None):
+            self.warning(
+                f"cc_plugin name='{name}' ends in a shared-library extension; "
+                "the historical auto-strip behavior has been removed. "
+                "Pass prefix='' and suffix='<ext>' explicitly, or rename the "
+                "target, to control the output file name."
+            )
+        self.attr['prefix'] = prefix
+        self.attr['suffix'] = suffix
         self.attr['allow_undefined'] = allow_undefined
         self.attr['strip'] = strip
         self.attr['lds_fullpath'] = self._fullpath_sources(linker_scripts)
@@ -1614,10 +1639,14 @@ class CcPlugin(CcTarget):
         if link_all_symbols_libs:
             target_linkflags += self._generate_link_all_symbols_link_flags(link_all_symbols_libs)
 
-        if self.name.endswith('.so'):
-            output = self._target_file_path(self.name)
-        else:
-            output = self._target_file_path('lib%s.so' % self.name)
+        # Honor user-supplied prefix / suffix; fall back to the current
+        # toolchain defaults when either is left as None. See
+        # :func:`_cc_plugin_default_prefix_suffix` for the cross-platform
+        # TODO.
+        default_prefix, default_suffix = _cc_plugin_default_prefix_suffix()
+        prefix = default_prefix if self.attr['prefix'] is None else self.attr['prefix']
+        suffix = default_suffix if self.attr['suffix'] is None else self.attr['suffix']
+        output = self._target_file_path(f'{prefix}{self.name}{suffix}')
         if self.srcs or self.expanded_deps:
             if inclusion_check_result:
                 incchk_deps.append(inclusion_check_result)
@@ -1636,7 +1665,7 @@ class CcPlugin(CcTarget):
 
 
 def cc_plugin(
-        name: 'str | None' = None,
+        name: str,
         srcs: 'StrOrListOpt' = None,
         deps: 'StrOrListOpt' = None,
         visibility: 'StrOrListOpt' = None,
@@ -1645,8 +1674,8 @@ def cc_plugin(
         defs: 'StrOrListOpt' = None,
         incs: 'StrOrListOpt' = None,
         optimize: 'StrOrListOpt' = None,
-        prefix: 'str | None' = None,
-        suffix: 'str | None' = None,
+        prefix: str | None = None,
+        suffix: str | None = None,
         linkflags: 'StrOrListOpt' = None,
         extra_cppflags: 'StrOrListOpt' = None,
         extra_linkflags: 'StrOrListOpt' = None,


### PR DESCRIPTION
## Summary

Three fixes to `cc_plugin`, none of which change the behavior you get by default on Linux, but collectively restore the documented semantics of `prefix` / `suffix`, remove a latent footgun, and tighten typing.

### 1. `prefix` / `suffix` are now honored

The constructor had always stashed them on `self.prefix` / `self.suffix`, but `generate()` hard-coded the output basename to `lib{name}.so`. Now the output is `{prefix}{name}{suffix}`, falling back to the current toolchain defaults (Linux: `lib` / `.so`) via a new helper `_cc_plugin_default_prefix_suffix()`.

The helper centralizes a cross-platform TODO: when we later add macOS / Windows support, `_cc_plugin_default_prefix_suffix()` is the one place to query the active toolchain for `('lib','.dylib')` / `('','.dll')`. Today it returns the Linux-only pair.

### 2. `name.endswith('.so')` escape hatch removed

Before this PR, the only way to customize the output basename was `cc_plugin(name='foo.so', ...)`, which `generate()` special-cased into using `name` verbatim. With `prefix`/`suffix` actually working, keeping the hatch would produce ambiguous outputs (`libfoo.so.so`), so it's gone.

A **soft-deprecation warning** fires when `name` ends in `.so` / `.dylib` / `.dll` AND neither `prefix` nor `suffix` was overridden, pointing users at the documented `prefix=''` / `suffix='.so'` spelling. This is technically a breaking change for any BUILD file depending on the old implicit behavior — rare, undocumented, and surfaced loudly via the warning.

### 3. `name` parameter tightened

`cc_plugin(name: 'str | None' = None)` and `CcPlugin.__init__(name: 'str | None')` become `name: str` (required, no default). blade's rule-entry `name` has always been required at the BUILD-file level; the old annotation was decorative and hid call-site bugs from pyright. The quoted form is also dropped since the repo is Py 3.10+ (PEP 604 unions are runtime-legal).

Pure attribute storage `self.prefix` / `self.suffix` is moved into the standard `self.attr['prefix']` / `['suffix']` slots to match the rest of the class.

## Doc updates

Both `doc/en/build_rules/cc.md` and `doc/zh_CN/build_rules/cc.md` now describe `prefix` / `suffix` as defaulting to `None` with toolchain-aware semantics, and note that the `name='foo.so'` shortcut no longer works. The English version also gets a pre-existing copy-paste typo fixed (`suffix` description said "prefix").

## Verification

- pyright (basic): 0 errors, 113 warnings — unchanged baseline.
- Unit tests (venv Py 3.12, matches CI matrix): 49 passed.
- Integration tests (macOS local): 26 run, 9 failures matching the known macOS baseline. No new failures. CI (Ubuntu 22.04) is the source of truth.

## Scope kept out

- `cc_targets.py` contains many other quoted annotations (e.g. on `PrebuiltCcLibrary`, `ForeignCcLibrary`) — left alone here. A dedicated mechanical PR (`pyupgrade --py310-plus` or `ruff UP037`) will strip them repo-wide as a follow-up.
- Other rule-entries merged in #1108 / #1110 / #1111 / #1112 / #1113 still declare `name: 'str | None' = None`. Per the revised convention, these will be tightened piecewise when their respective next annotate PRs land (starting with cc_binary), not in a dedicated retro PR.

## Follow-ups captured in memory

- `_cc_plugin_default_prefix_suffix()` becomes toolchain-aware when macOS / Windows support lands.
- Decide whether to promote the soft-deprecation warning to a hard error in v4.
