### PR TITLE
feat(v3): type-annotate cc_test entry and CcTest.__init__

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1734,32 +1734,32 @@ class CcTest(CcBinary):
 
     def __init__(
             self,
-            name,
-            srcs,
-            deps,
-            visibility,
-            tags,
-            warning,
-            defs,
-            incs,
-            embed_version,
-            optimize,
-            dynamic_link,
-            testdata,
-            linkflags,
-            extra_cppflags,
-            extra_linkflags,
-            export_dynamic,
-            always_run,
-            exclusive,
-            heap_check,
-            heap_check_debug,
-            kwargs):
+            name: str | None,
+            srcs: StrOrListOpt,
+            deps: StrOrListOpt,
+            visibility: StrOrListOpt,
+            tags: StrOrListOpt,
+            warning: str,
+            defs: StrOrListOpt,
+            incs: StrOrListOpt,
+            embed_version: bool,
+            optimize: StrOrListOpt,
+            dynamic_link: bool | None,
+            testdata: StrOrListOpt,
+            linkflags: StrOrListOpt,
+            extra_cppflags: StrOrListOpt,
+            extra_linkflags: StrOrListOpt,
+            export_dynamic: bool,
+            always_run: bool,
+            exclusive: bool,
+            heap_check: str | None,
+            heap_check_debug: bool,
+            kwargs: dict[str, object]):
         """Init method."""
         # pylint: disable=too-many-locals
         cc_test_config = config.get_section('cc_test_config')
         if dynamic_link is None:
-            dynamic_link = cc_test_config['dynamic_link']
+            dynamic_link = bool(cc_test_config['dynamic_link'])
 
         super().__init__(
                 name=name,
@@ -1812,27 +1812,27 @@ class CcTest(CcBinary):
             self._add_implicit_library(perftools_lib_list)
 
 
-def cc_test(name=None,
-            srcs=None,
-            deps=None,
-            visibility=None,
-            tags=None,
-            warning='yes',
-            defs=None,
-            incs=None,
-            embed_version=False,
-            optimize=None,
-            dynamic_link=None,
-            testdata=None,
-            linkflags=None,
-            extra_cppflags=None,
-            extra_linkflags=None,
-            export_dynamic=False,
-            always_run=False,
-            exclusive=False,
-            heap_check=None,
-            heap_check_debug=False,
-            **kwargs):
+def cc_test(name: str,
+            srcs: StrOrListOpt = None,
+            deps: StrOrListOpt = None,
+            visibility: StrOrListOpt = None,
+            tags: StrOrListOpt = None,
+            warning: str = 'yes',
+            defs: StrOrListOpt = None,
+            incs: StrOrListOpt = None,
+            embed_version: bool = False,
+            optimize: StrOrListOpt = None,
+            dynamic_link: bool | None = None,
+            testdata: StrOrListOpt = None,
+            linkflags: StrOrListOpt = None,
+            extra_cppflags: StrOrListOpt = None,
+            extra_linkflags: StrOrListOpt = None,
+            export_dynamic: bool = False,
+            always_run: bool = False,
+            exclusive: bool = False,
+            heap_check: str | None = None,
+            heap_check_debug: bool = False,
+            **kwargs: object):
     """cc_test target."""
     # pylint: disable=too-many-locals
     cc_test_target = CcTest(


### PR DESCRIPTION
## Summary

Type-annotate the `cc_test` rule entry and `CcTest.__init__`, continuing
the per-module rule-entry annotate rollout (PRs #1107-#1115).

## Scope

### `cc_test` (rule entry)

- `name` tightened to required `str` (no default, no Optional, no quotes)
  per the convention established in PR #1114/#1115.
- list-ish params take `StrOrListOpt = None`.
- flags (`embed_version`, `export_dynamic`, `always_run`, `exclusive`,
  `heap_check_debug`) become `bool`.
- `dynamic_link: bool | None = None` — `cc_test`-specific sentinel
  meaning "defer to `cc_test_config`". Not a typo vs `cc_binary`'s
  `dynamic_link: bool = False`: the runtime default for `cc_test` is
  derived from config, and the sentinel is how that's expressed today.
- `heap_check: str | None = None` — None-sentinel for a string enum.
- `warning: str = 'yes'`.
- `**kwargs: object` (forwards to `CcTest` class-init).

### `CcTest.__init__`

- Typed signature. `name: str | None` kept as mid-layer sentinel per the
  convention used by `CcBinary.__init__` / `CcTarget.__init__`.
- list-ish params `StrOrListOpt`; flags `bool`; sentinel params
  `bool | None` / `str | None`; `kwargs: dict[str, object]`.
- After `if dynamic_link is None: dynamic_link = cc_test_config[...]`,
  the value is now explicitly coerced with `bool(...)` so pyright can
  narrow the forwarded arg to `super().__init__`'s `dynamic_link: bool`
  (pyright sees the config lookup as `Unknown`, so `Unknown | bool`
  wouldn't otherwise assign to `bool`). In practice the config value has
  always been a boolean, so this is a no-op for real configs. Non-bool
  values (e.g. int `1`) would now land in `self.attr` as `True` rather
  than `1`; this is harmless normalization but worth documenting.
- Only `StrOrListOpt` is imported for this change (already imported from
  earlier PRs).

## Verification

- `pyright src/blade`: 0 errors (113 warnings, unchanged baseline).
- unit tests: 49 passed under `.agent/venv-pyright` (Py3.12).
- integration tests: 26 ran / 9 baseline failures on macOS, identical to
  the macOS baseline recorded for this repo; no new regressions.

## Findings but NOT acted upon

- `cc_test.testdata` documents the form `('//path/to/file', 'new_name')`
  (a `(src, dst)` tuple element). `test_runner.py` consumes this via an
  `isinstance(i, tuple)` branch. The in-file annotation `testdata:
  StrOrListOpt` is therefore slightly narrower than the runtime-accepted
  shape (`str | list[str | tuple[str, str]] | None`). Left as-is for
  consistency with `py_test` / `scala_test` / `cu_test` / `go_test` /
  `sh_test`, all of which also annotate `testdata` the same way. A
  dedicated `TestData` type alias in `blade_types.py` could tighten this
  uniformly later; not done here to keep the PR mechanical.

## Follow-ups (not in this PR)

- Next: `cc_library` (larger, ~80+ lines), then `cu_targets` /
  `java_targets` / `scala_targets` / `py_targets` / proto / thrift / go /
  sh_test / lex_yacc / package / gen_rule.
- Eventually drop the defensive `var_to_list` guard at the top of
  `Target.__init__` and flip ruff B006/B008 to error in CI.
