### PR TITLE
feat(v3): type-annotate cc_library entry and CcLibrary.__init__

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -840,47 +840,61 @@ class CcLibrary(CcTarget):
     """
 
     def __init__(self,
-                 name,
-                 srcs,
-                 hdrs,
-                 deps,
-                 visibility,
-                 tags,
-                 warning,
-                 defs,
-                 incs,
-                 export_incs,
-                 optimize,
-                 always_optimize,
-                 link_all_symbols,
-                 binary_link_only,
-                 deprecated,
-                 linkflags,
-                 extra_cppflags,
-                 extra_linkflags,
-                 allow_undefined,
-                 secret,
-                 secret_revision_file,
-                 kwargs):
+                 name: str | None,
+                 srcs: StrOrListOpt,
+                 hdrs: StrOrListOpt,
+                 deps: StrOrListOpt,
+                 visibility: StrOrListOpt,
+                 tags: StrOrListOpt,
+                 warning: str,
+                 defs: StrOrListOpt,
+                 incs: StrOrListOpt,
+                 export_incs: StrOrListOpt,
+                 optimize: StrOrListOpt,
+                 always_optimize: bool,
+                 link_all_symbols: bool,
+                 binary_link_only: bool,
+                 deprecated: bool,
+                 linkflags: StrOrListOpt,
+                 extra_cppflags: StrOrListOpt,
+                 extra_linkflags: StrOrListOpt,
+                 allow_undefined: bool,
+                 secret: bool,
+                 secret_revision_file: str | None,
+                 kwargs: dict[str, object]):
         """Init method.
 
         Init the cc library.
 
         """
         # pylint: disable=too-many-locals
+        # Normalize list-ish entry params to list[str] once so the forward to
+        # super() and the rest of the body can work on a uniform shape.
+        # `optimize` / `linkflags` / `visibility` keep None-sentinel semantics.
+        srcs = var_to_list(srcs)
+        deps = var_to_list(deps)
+        tags = var_to_list(tags)
+        defs = var_to_list(defs)
+        incs = var_to_list(incs)
+        export_incs = var_to_list(export_incs)
+        extra_cppflags = var_to_list(extra_cppflags)
+        extra_linkflags = var_to_list(extra_linkflags)
+        visibility_list = var_to_list_or_none(visibility)
+        optimize_list = var_to_list_or_none(optimize)
+        linkflags_list = var_to_list_or_none(linkflags)
         super().__init__(
                 name=name,
                 type='cc_library',
                 srcs=srcs,
                 deps=deps,
-                visibility=visibility,
+                visibility=visibility_list,
                 tags=tags,
                 warning=warning,
                 defs=defs,
                 incs=incs,
                 export_incs=export_incs,
-                optimize=optimize,
-                linkflags=linkflags,
+                optimize=optimize_list,
+                linkflags=linkflags_list,
                 extra_cppflags=extra_cppflags,
                 extra_linkflags=extra_linkflags,
                 kwargs=kwargs)
@@ -1068,7 +1082,7 @@ class PrebuiltCcLibrary(CcTarget):
 
 
 def prebuilt_cc_library(
-        name: 'str | None' = None,
+        name: str,
         deps: 'StrOrListOpt' = None,
         visibility: 'StrOrListOpt' = None,
         tags: 'StrOrListOpt' = None,
@@ -1097,32 +1111,32 @@ def prebuilt_cc_library(
 
 
 def cc_library(
-        name,
-        srcs=None,
-        hdrs=None,
-        deps=None,
-        visibility=None,
-        tags=None,
-        warning='yes',
-        defs=None,
-        incs=None,
-        export_incs=None,
-        optimize=None,
-        always_optimize=False,
-        pre_build=False,
-        prebuilt=False,
-        prebuilt_libpath_pattern=None,
-        link_all_symbols=False,
-        binary_link_only=False,
-        deprecated=False,
-        linkflags=None,
-        extra_cppflags=None,
-        extra_linkflags=None,
-        allow_undefined=False,
-        secret=False,
-        secret_revision_file=None,
-        secure=False,
-        **kwargs):
+        name: str,
+        srcs: StrOrListOpt = None,
+        hdrs: StrOrListOpt = None,
+        deps: StrOrListOpt = None,
+        visibility: StrOrListOpt = None,
+        tags: StrOrListOpt = None,
+        warning: str = 'yes',
+        defs: StrOrListOpt = None,
+        incs: StrOrListOpt = None,
+        export_incs: StrOrListOpt = None,
+        optimize: StrOrListOpt = None,
+        always_optimize: bool = False,
+        pre_build: bool = False,
+        prebuilt: bool = False,
+        prebuilt_libpath_pattern: str | None = None,
+        link_all_symbols: bool = False,
+        binary_link_only: bool = False,
+        deprecated: bool = False,
+        linkflags: StrOrListOpt = None,
+        extra_cppflags: StrOrListOpt = None,
+        extra_linkflags: StrOrListOpt = None,
+        allow_undefined: bool = False,
+        secret: bool = False,
+        secret_revision_file: str | None = None,
+        secure: bool = False,
+        **kwargs: object):
     """cc_library target.
 
     Args:


### PR DESCRIPTION
## Summary

Follow-up to PRs #1114 / #1115 / #1116 — annotate the `cc_library` rule
entry and `CcLibrary.__init__` with the same layering convention. Also
opportunistically tighten `prebuilt_cc_library`'s entry `name` (the last
rule entry in this module still on the pre-#1114 `name: 'str | None' =
None` spelling) since `cc_library` forwards to it on the `pre_build` /
`prebuilt` path.

## Changes

### `cc_library` (rule entry)
- `name: str` — required, no default, no `Optional` (rule-entry convention)
- list-ish params: `StrOrListOpt = None` so BUILD files can keep passing
  a single string (`srcs='foo.cc'`)
- `warning: str = 'yes'`, bool flags stay `bool`, scalar sentinels stay
  `str | None`
- `**kwargs: object` (forwarded to the class `__init__` and to
  `prebuilt_cc_library` entry)

### `CcLibrary.__init__`
- `name: str | None` matching `CcTarget` base and siblings
- list-ish params: `StrOrListOpt`
- normalize once at the top with `var_to_list` / `var_to_list_or_none`,
  forward `list[str]` / `list[str] | None` shapes to `super().__init__`
- matches the `CcBinary` / `CcPlugin` / `CcTest` body style

### `prebuilt_cc_library` (rule entry, opportunistic)
- `name: 'str | None' = None` → `name: str`

## Convention / style notes
- Quoted annotations are dropped only where touched (memory item 19); the
  remaining quoted `'str | None'` / `'StrOrListOpt'` annotations in this
  file belong to unmodified signatures and will be cleaned up in a
  dedicated mechanical PR.
- Per the rule-entry convention established in #1114/#1115, `name` in
  rule entries is required with no Optional and no default — this lets
  pyright catch real bugs where callers forget to pass `name`.

## Verification
- **pyright**: 0 errors, 113 warnings (baseline unchanged).
- **unit tests**: 49/49 passing.
- **E2E (macOS local)**: 26 run / 9 failures, matching the macOS baseline
  exactly. CI on ubuntu-22.04 is green.

## Findings but NOT acted upon
None in this PR. All findings during annotation were consistent with the
existing rule-entry / class-init layering.
