### PR TITLE
feat(v3): type-annotate cu_library/cu_binary/cu_test entries and CuTarget/CuLibrary/CuBinary/CuTest.__init__

### DIFF
--- a/src/blade/cu_targets.py
+++ b/src/blade/cu_targets.py
@@ -17,8 +17,9 @@ from blade import build_manager
 from blade import build_rules
 from blade import config
 from blade import console
+from blade.blade_types import StrOrListOpt
 from blade.cc_targets import CcTarget
-from blade.util import var_to_list
+from blade.util import var_to_list, var_to_list_or_none
 
 
 # See https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#supported-input-file-suffixes
@@ -34,20 +35,23 @@ class CuTarget(CcTarget):
     """
 
     def __init__(self,
-                 name,
-                 type,
-                 srcs,
-                 cuda_path,
-                 deps,
-                 visibility,
-                 tags,
-                 warning,
-                 defs,
-                 incs,
-                 extra_cppflags,
-                 extra_cuflags,
-                 extra_linkflags,
-                 kwargs):
+                 name: str | None,
+                 type: str,
+                 srcs: list[str],
+                 cuda_path: str | None,
+                 deps: list[str],
+                 visibility: list[str] | None,
+                 tags: list[str],
+                 warning: str,
+                 defs: list[str],
+                 incs: list[str],
+                 extra_cppflags: list[str],
+                 extra_cuflags: list[str],
+                 extra_linkflags: list[str],
+                 kwargs: dict[str, object]):
+        # Defensive normalization: children normalize before passing to us,
+        # but keep the var_to_list calls for any callers that may still pass
+        # raw values (consistent with CcTarget's defensive pattern).
         srcs = var_to_list(srcs)
         deps = var_to_list(deps)
         extra_cppflags = var_to_list(extra_cppflags)
@@ -185,21 +189,32 @@ class CuLibrary(CuTarget):
     """
 
     def __init__(self,
-                 name,
-                 srcs,
-                 hdrs,
-                 cuda_path,
-                 deps,
-                 visibility,
-                 tags,
-                 warning,
-                 defs,
-                 incs,
-                 link_all_symbols,
-                 extra_cppflags,
-                 extra_cuflags,
-                 extra_linkflags,
-                 kwargs):
+                 name: str | None,
+                 srcs: StrOrListOpt,
+                 hdrs: StrOrListOpt,
+                 cuda_path: str | None,
+                 deps: StrOrListOpt,
+                 visibility: StrOrListOpt,
+                 tags: StrOrListOpt,
+                 warning: str,
+                 defs: StrOrListOpt,
+                 incs: StrOrListOpt,
+                 link_all_symbols: bool,
+                 extra_cppflags: StrOrListOpt,
+                 extra_cuflags: StrOrListOpt,
+                 extra_linkflags: StrOrListOpt,
+                 kwargs: dict[str, object]):
+        # Normalize BUILD-file-friendly StrOrList unions once, right at the
+        # top; CuTarget.__init__ below sees layer-2 list[str].
+        srcs = var_to_list(srcs)
+        deps = var_to_list(deps)
+        tags = var_to_list(tags)
+        defs = var_to_list(defs)
+        incs = var_to_list(incs)
+        extra_cppflags = var_to_list(extra_cppflags)
+        extra_cuflags = var_to_list(extra_cuflags)
+        extra_linkflags = var_to_list(extra_linkflags)
+        visibility = var_to_list_or_none(visibility)
         super().__init__(
                 name=name,
                 type='cu_library',
@@ -232,21 +247,21 @@ class CuLibrary(CuTarget):
             self._cuda_library(objs, inclusion_check_result)
 
 
-def cu_library(name=None,
-               srcs=None,
-               hdrs=None,
-               cuda_path=None,
-               deps=None,
-               visibility=None,
-               tags=None,
-               warning='yes',
-               defs=None,
-               incs=None,
-               link_all_symbols=False,
-               extra_cppflags=None,
-               extra_cuflags=None,
-               extra_linkflags=None,
-               **kwargs):
+def cu_library(name: str,
+               srcs: StrOrListOpt = None,
+               hdrs: StrOrListOpt = None,
+               cuda_path: str | None = None,
+               deps: StrOrListOpt = None,
+               visibility: StrOrListOpt = None,
+               tags: StrOrListOpt = None,
+               warning: str = 'yes',
+               defs: StrOrListOpt = None,
+               incs: StrOrListOpt = None,
+               link_all_symbols: bool = False,
+               extra_cppflags: StrOrListOpt = None,
+               extra_cuflags: StrOrListOpt = None,
+               extra_linkflags: StrOrListOpt = None,
+               **kwargs: object):
     target = CuLibrary(
             name,
             srcs=srcs,
@@ -276,19 +291,30 @@ class CuBinary(CuTarget):
     """
 
     def __init__(self,
-                 name,
-                 srcs,
-                 cuda_path,
-                 deps,
-                 visibility,
-                 tags,
-                 warning,
-                 defs,
-                 incs,
-                 extra_cppflags,
-                 extra_cuflags,
-                 extra_linkflags,
-                 kwargs):
+                 name: str | None,
+                 srcs: StrOrListOpt,
+                 cuda_path: str | None,
+                 deps: StrOrListOpt,
+                 visibility: StrOrListOpt,
+                 tags: StrOrListOpt,
+                 warning: str,
+                 defs: StrOrListOpt,
+                 incs: StrOrListOpt,
+                 extra_cppflags: StrOrListOpt,
+                 extra_cuflags: StrOrListOpt,
+                 extra_linkflags: StrOrListOpt,
+                 kwargs: dict[str, object]):
+        # Normalize BUILD-file-friendly StrOrList unions once, right at the
+        # top; CuTarget.__init__ below sees layer-2 list[str].
+        srcs = var_to_list(srcs)
+        deps = var_to_list(deps)
+        tags = var_to_list(tags)
+        defs = var_to_list(defs)
+        incs = var_to_list(incs)
+        extra_cppflags = var_to_list(extra_cppflags)
+        extra_cuflags = var_to_list(extra_cuflags)
+        extra_linkflags = var_to_list(extra_linkflags)
+        visibility = var_to_list_or_none(visibility)
         super().__init__(
                 name=name,
                 type='cu_binary',
@@ -349,19 +375,19 @@ class CuBinary(CuTarget):
         self._write_inclusion_check_info()
 
 
-def cu_binary(name=None,
-              srcs=None,
-              cuda_path=None,
-              deps=None,
-              visibility=None,
-              tags=None,
-              warning='yes',
-              defs=None,
-              incs=None,
-              extra_cppflags=None,
-              extra_cuflags=None,
-              extra_linkflags=None,
-              **kwargs):
+def cu_binary(name: str,
+              srcs: StrOrListOpt = None,
+              cuda_path: str | None = None,
+              deps: StrOrListOpt = None,
+              visibility: StrOrListOpt = None,
+              tags: StrOrListOpt = None,
+              warning: str = 'yes',
+              defs: StrOrListOpt = None,
+              incs: StrOrListOpt = None,
+              extra_cppflags: StrOrListOpt = None,
+              extra_cuflags: StrOrListOpt = None,
+              extra_linkflags: StrOrListOpt = None,
+              **kwargs: object):
     target = CuBinary(
             name=name,
             srcs=srcs,
@@ -389,23 +415,34 @@ class CuTest(CuBinary):
     """
 
     def __init__(self,
-                 name,
-                 srcs,
-                 cuda_path,
-                 deps,
-                 visibility,
-                 tags,
-                 warning,
-                 defs,
-                 incs,
-                 extra_cppflags,
-                 extra_cuflags,
-                 extra_linkflags,
-                 testdata,
-                 always_run,
-                 exclusive,
-                 kwargs):
+                 name: str | None,
+                 srcs: StrOrListOpt,
+                 cuda_path: str | None,
+                 deps: StrOrListOpt,
+                 visibility: StrOrListOpt,
+                 tags: StrOrListOpt,
+                 warning: str,
+                 defs: StrOrListOpt,
+                 incs: StrOrListOpt,
+                 extra_cppflags: StrOrListOpt,
+                 extra_cuflags: StrOrListOpt,
+                 extra_linkflags: StrOrListOpt,
+                 testdata: StrOrListOpt,
+                 always_run: bool,
+                 exclusive: bool,
+                 kwargs: dict[str, object]):
         # pylint: disable=too-many-locals
+        # Normalize BUILD-file-friendly StrOrList unions once, right at the
+        # top; CuTarget.__init__ below sees layer-2 list[str].
+        srcs = var_to_list(srcs)
+        deps = var_to_list(deps)
+        tags = var_to_list(tags)
+        defs = var_to_list(defs)
+        incs = var_to_list(incs)
+        extra_cppflags = var_to_list(extra_cppflags)
+        extra_cuflags = var_to_list(extra_cuflags)
+        extra_linkflags = var_to_list(extra_linkflags)
+        visibility = var_to_list_or_none(visibility)
         super().__init__(
                 name=name,
                 srcs=srcs,
@@ -436,22 +473,22 @@ class CuTest(CuBinary):
 
 
 def cu_test(
-        name,
-        srcs=None,
-        cuda_path=None,
-        deps=None,
-        visibility=None,
-        tags=None,
-        warning='yes',
-        defs=None,
-        incs=None,
-        extra_cppflags=None,
-        extra_cuflags=None,
-        extra_linkflags=None,
-        testdata=None,
-        always_run=False,
-        exclusive=False,
-        **kwargs):
+        name: str,
+        srcs: StrOrListOpt = None,
+        cuda_path: str | None = None,
+        deps: StrOrListOpt = None,
+        visibility: StrOrListOpt = None,
+        tags: StrOrListOpt = None,
+        warning: str = 'yes',
+        defs: StrOrListOpt = None,
+        incs: StrOrListOpt = None,
+        extra_cppflags: StrOrListOpt = None,
+        extra_cuflags: StrOrListOpt = None,
+        extra_linkflags: StrOrListOpt = None,
+        testdata: StrOrListOpt = None,
+        always_run: bool = False,
+        exclusive: bool = False,
+        **kwargs: object):
     target = CuTest(
             name=name,
             srcs=srcs,


### PR DESCRIPTION
## Summary

Type-annotate all rule-entry functions and `__init__` methods in `cu_targets.py`, following the same pattern established by the cc_* series (#1114–#1117).

- **Rule-entry functions** (`cu_library`, `cu_binary`, `cu_test`): `name: str` (no default per the rule-entry convention), list-ish params use `StrOrListOpt` with `= None` defaults, bool flags use `bool`, `**kwargs: object`.
- **Class `__init__` methods**: `name: str | None` matching CcTarget base; list-ish params use `StrOrListOpt` at the leaf level, normalized once at the top with `var_to_list` / `var_to_list_or_none`, then forwarded to `CuTarget.__init__` (and ultimately `CcTarget.__init__`) as layer-2 `list[str]` / `list[str] | None` shapes.
- **`CuTarget.__init__`**: accepts `list[str]` from children, with defensive `var_to_list` calls retained (consistent with CcTarget's defensive normalization pattern).

## Verification

- pyright: 0 errors, 113 warnings (baseline unchanged)
- unit tests: 49/49 passing on Python 3.12