### PR TITLE
feat(v3): type-annotate proto_library entry and ProtocPlugin/ProtoLibrary.__init__

### DIFF
--- a/src/blade/proto_library_target.py
+++ b/src/blade/proto_library_target.py
@@ -17,8 +17,9 @@ from blade import build_rules
 from blade import config
 from blade import console
 from blade import java_targets
+from blade.blade_types import StrOrListOpt
 from blade.cc_targets import CcTarget
-from blade.util import var_to_list
+from blade.util import var_to_list, var_to_list_or_none
 
 
 class ProtocPlugin:
@@ -34,9 +35,9 @@ class ProtocPlugin:
     __languages = ['cpp', 'java', 'python']
 
     def __init__(self,
-                 name,
-                 path,
-                 code_generation):
+                 name: str,
+                 path: str,
+                 code_generation: dict[str, 'dict[str, StrOrListOpt]']):
         self.name = name
         self.path = path
         assert isinstance(code_generation, dict)
@@ -76,27 +77,34 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
     """
 
     def __init__(self,
-                 name,
-                 srcs,
-                 deps,
-                 visibility,
-                 tags,
-                 optimize,
-                 deprecated,
-                 generate_descriptors,
-                 target_languages,
-                 plugins,
-                 source_encoding,
-                 cpp_outs,
-                 plugin_opts,
-                 kwargs):
+                 name: str | None,
+                 srcs: StrOrListOpt,
+                 deps: StrOrListOpt,
+                 visibility: StrOrListOpt,
+                 tags: StrOrListOpt,
+                 optimize: StrOrListOpt,
+                 deprecated: bool,
+                 generate_descriptors: bool,
+                 target_languages: StrOrListOpt,
+                 plugins: StrOrListOpt,
+                 source_encoding: str,
+                 cpp_outs: StrOrListOpt,
+                 plugin_opts: 'dict[str, list[str]] | None',
+                 kwargs: dict[str, object]):
         """Init method.
 
         Init the proto target.
 
         """
         # pylint: disable=too-many-locals
+        # Normalize BUILD-file-friendly StrOrList unions to list[str] once
+        # for the CcTarget.__init__ forward; the rest of the body uses the
+        # normalized shapes.
         srcs = var_to_list(srcs)
+        deps = var_to_list(deps)
+        tags = var_to_list(tags)
+        visibility = var_to_list_or_none(visibility)
+        optimize = var_to_list_or_none(optimize)
         proto_config = config.get_section('proto_library_config')
 
         super().__init__(
@@ -465,20 +473,20 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
 
 
 def proto_library(
-        name,
-        srcs=None,
-        deps=None,
-        visibility=None,
-        tags=None,
-        optimize=None,
-        deprecated=False,
-        generate_descriptors=False,
-        target_languages=None,
-        plugins=None,
-        source_encoding='iso-8859-1',
-        cpp_outs=None,
-        plugin_opts=None,
-        **kwargs):
+        name: str,
+        srcs: StrOrListOpt = None,
+        deps: StrOrListOpt = None,
+        visibility: StrOrListOpt = None,
+        tags: StrOrListOpt = None,
+        optimize: StrOrListOpt = None,
+        deprecated: bool = False,
+        generate_descriptors: bool = False,
+        target_languages: StrOrListOpt = None,
+        plugins: StrOrListOpt = None,
+        source_encoding: str = 'iso-8859-1',
+        cpp_outs: StrOrListOpt = None,
+        plugin_opts: 'dict[str, list[str]] | None' = None,
+        **kwargs: object):
     """proto_library target.
     Args:
         generate_descriptors (bool): Whether generate binary protobuf descriptors.


### PR DESCRIPTION
## Summary

Type-annotate the `proto_library` rule-entry function, `ProtocPlugin.__init__`, and `ProtoLibrary.__init__` in `proto_library_target.py`.

- **`proto_library` entry**: `name: str`, `StrOrListOpt = None` for list-ish params, `bool` for flags, `**kwargs: object`.
- **`ProtoLibrary.__init__`**: normalizes `StrOrListOpt` → `list[str]` at the top with `var_to_list` / `var_to_list_or_none`, forwards to `CcTarget.__init__`.
- **`ProtocPlugin.__init__`**: annotated with simple types (non-Target helper class).

## Verification

- pyright: 0 errors, 113 warnings (baseline unchanged)
- unit tests: 49/49 passing (python 3.12)