### PR TITLE
feat(v3): type-annotate remaining target files (gen_rule, lex_yacc, sh_test, swig, thrift, fbthrift, package)

### DIFF
--- a/src/blade/fbthrift_library.py
+++ b/src/blade/fbthrift_library.py
@@ -22,23 +22,28 @@ import os
 from blade import build_manager
 from blade import build_rules
 from blade import config
+from blade.blade_types import StrOrListOpt
 from blade.cc_targets import CcTarget
 from blade.thrift_helper import FBThriftHelper
-from blade.util import var_to_list
+from blade.util import var_to_list, var_to_list_or_none
 
 
 class FBThriftLibrary(CcTarget):
     """A fbthrift library target derived from CcTarget."""
     def __init__(self,
-                 name,
-                 srcs,
-                 deps,
-                 optimize,
-                 visibility,
-                 tags,
-                 deprecated,
-                 kwargs):
+                 name: str | None,
+                 srcs: StrOrListOpt,
+                 deps: StrOrListOpt,
+                 optimize: StrOrListOpt,
+                 visibility: StrOrListOpt,
+                 tags: StrOrListOpt,
+                 deprecated: bool,
+                 kwargs: dict[str, object]):
         srcs = var_to_list(srcs)
+        deps = var_to_list(deps)
+        tags = var_to_list(tags)
+        visibility = var_to_list_or_none(visibility)
+        optimize = var_to_list_or_none(optimize)
         super().__init__(
                 name=name,
                 type='fbthrift_library',
@@ -88,14 +93,14 @@ class FBThriftLibrary(CcTarget):
         # (don't forget `generated_hdrs`)
 
 
-def fbthrift_library(name=None,
-                     srcs=None,
-                     deps=None,
-                     optimize=None,
-                     visibility=None,
-                     tags=None,
-                     deprecated=False,
-                     **kwargs):
+def fbthrift_library(name: str,
+                     srcs: StrOrListOpt = None,
+                     deps: StrOrListOpt = None,
+                     optimize: StrOrListOpt = None,
+                     visibility: StrOrListOpt = None,
+                     tags: StrOrListOpt = None,
+                     deprecated: bool = False,
+                     **kwargs: object):
     """fbthrift_library target."""
     fbthrift_library_target = FBThriftLibrary(
             name=name,

--- a/src/blade/gen_rule_target.py
+++ b/src/blade/gen_rule_target.py
@@ -16,9 +16,10 @@ from blade import build_manager
 from blade import build_rules
 from blade import cc_targets
 from blade import console
+from blade.blade_types import StrOrListOpt
 from blade.target import Target, LOCATION_RE
 from blade.util import regular_variable_name
-from blade.util import var_to_list
+from blade.util import var_to_list, var_to_list_or_none
 
 
 # The rule template for gen_rule
@@ -33,32 +34,35 @@ class GenRuleTarget(Target):
     """General Rule Target"""
 
     def __init__(self,
-                 name,
-                 srcs,
-                 src_exts,
-                 deps,
-                 visibility,
-                 tags,
-                 outs,
-                 cmd,
-                 cmd_name,
-                 generated_hdrs,
-                 generated_incs,
-                 export_incs,
-                 cleans,
-                 heavy,
-                 exclude_dep_labels,
-                 kwargs):
+                 name: str | None,
+                 srcs: StrOrListOpt,
+                 src_exts: StrOrListOpt,
+                 deps: StrOrListOpt,
+                 visibility: StrOrListOpt,
+                 tags: StrOrListOpt,
+                 outs: StrOrListOpt,
+                 cmd: str,
+                 cmd_name: str,
+                 generated_hdrs: StrOrListOpt,
+                 generated_incs: StrOrListOpt,
+                 export_incs: StrOrListOpt,
+                 cleans: StrOrListOpt,
+                 heavy: bool,
+                 exclude_dep_labels: StrOrListOpt,
+                 kwargs: dict[str, object]):
         """Init method.
         Init the gen rule target.
         """
         srcs = var_to_list(srcs)
         deps = var_to_list(deps)
+        src_exts = var_to_list(src_exts) if src_exts is not None else None
+        tags = var_to_list(tags)
+        visibility = var_to_list_or_none(visibility)
         super().__init__(
                 name=name,
                 type='gen_rule',
                 srcs=srcs,
-                src_exts=src_exts,
+                src_exts=src_exts if src_exts is not None else [],
                 deps=deps,
                 visibility=visibility,
                 tags=tags,
@@ -185,22 +189,22 @@ class GenRuleTarget(Target):
 
 
 def gen_rule(
-        name,
-        srcs=None,
-        src_exts=None,
-        deps=None,
-        visibility=None,
-        tags=None,
-        outs=None,
-        cmd='',
-        cmd_name='COMMAND',
-        generated_hdrs=None,
-        generated_incs=None,
-        export_incs=None,
-        cleans=None,
-        heavy=False,
-        exclude_dep_labels=None,
-        **kwargs):
+        name: str,
+        srcs: StrOrListOpt = None,
+        src_exts: StrOrListOpt = None,
+        deps: StrOrListOpt = None,
+        visibility: StrOrListOpt = None,
+        tags: StrOrListOpt = None,
+        outs: StrOrListOpt = None,
+        cmd: str = '',
+        cmd_name: str = 'COMMAND',
+        generated_hdrs: StrOrListOpt = None,
+        generated_incs: StrOrListOpt = None,
+        export_incs: StrOrListOpt = None,
+        cleans: StrOrListOpt = None,
+        heavy: bool = False,
+        exclude_dep_labels: StrOrListOpt = None,
+        **kwargs: object):
     """General Build Rule
     Args:
         src_exts: List[str],

--- a/src/blade/lex_yacc_target.py
+++ b/src/blade/lex_yacc_target.py
@@ -11,35 +11,43 @@ Define lex_yacc_library target.
 
 from blade import build_manager
 from blade import build_rules
+from blade.blade_types import StrOrListOpt
 from blade.cc_targets import CcTarget
-from blade.util import var_to_list
+from blade.util import var_to_list, var_to_list_or_none
 
 
 class LexYaccLibrary(CcTarget):
     """This class generates lex yacc rules."""
 
     def __init__(self,
-                 name,
-                 srcs,
-                 deps,
-                 visibility,
-                 tags,
-                 warning,
-                 defs,
-                 incs,
-                 extra_cppflags,
-                 extra_linkflags,
-                 allow_undefined,
-                 recursive,
-                 prefix,
-                 lexflags,
-                 yaccflags,
-                 kwargs):
+                 name: str | None,
+                 srcs: StrOrListOpt,
+                 deps: StrOrListOpt,
+                 visibility: StrOrListOpt,
+                 tags: StrOrListOpt,
+                 warning: str,
+                 defs: StrOrListOpt,
+                 incs: StrOrListOpt,
+                 extra_cppflags: StrOrListOpt,
+                 extra_linkflags: StrOrListOpt,
+                 allow_undefined: bool,
+                 recursive: bool,
+                 prefix: str | None,
+                 lexflags: StrOrListOpt,
+                 yaccflags: StrOrListOpt,
+                 kwargs: dict[str, object]):
         """Init method.
 
         Init the cc lex yacc target
 
         """
+        # Normalize before forwarding to CcTarget.__init__
+        srcs = var_to_list(srcs)
+        deps = var_to_list(deps)
+        tags = var_to_list(tags)
+        defs = var_to_list(defs)
+        incs = var_to_list(incs)
+        visibility = var_to_list_or_none(visibility)
         super().__init__(
                 name=name,
                 type='lex_yacc_library',
@@ -153,22 +161,22 @@ class LexYaccLibrary(CcTarget):
 
 
 def lex_yacc_library(
-        name,
-        srcs=None,
-        deps=None,
-        visibility=None,
-        tags=None,
-        warning='yes',
-        defs=None,
-        incs=None,
-        extra_cppflags=None,
-        extra_linkflags=None,
-        allow_undefined=False,
-        recursive=False,
-        prefix=None,
-        lexflags=None,
-        yaccflags=None,
-        **kwargs):
+        name: str,
+        srcs: StrOrListOpt = None,
+        deps: StrOrListOpt = None,
+        visibility: StrOrListOpt = None,
+        tags: StrOrListOpt = None,
+        warning: str = 'yes',
+        defs: StrOrListOpt = None,
+        incs: StrOrListOpt = None,
+        extra_cppflags: StrOrListOpt = None,
+        extra_linkflags: StrOrListOpt = None,
+        allow_undefined: bool = False,
+        recursive: bool = False,
+        prefix: str | None = None,
+        lexflags: StrOrListOpt = None,
+        yaccflags: StrOrListOpt = None,
+        **kwargs: object):
     """lex_yacc_library."""
     target = LexYaccLibrary(
             name=name,

--- a/src/blade/package_target.py
+++ b/src/blade/package_target.py
@@ -14,8 +14,9 @@ import os
 
 from blade import build_manager
 from blade import build_rules
+from blade.blade_types import StrOrListOpt
 from blade.target import Target, LOCATION_RE
-from blade.util import which, var_to_list
+from blade.util import which, var_to_list, var_to_list_or_none
 
 
 _package_types = frozenset([
@@ -39,17 +40,19 @@ class PackageTarget(Target):
     """
 
     def __init__(self,
-                 name,
-                 srcs,
-                 deps,
-                 visibility,
-                 tags,
-                 type,
-                 out,
-                 shell,
-                 kwargs):
+                 name: str | None,
+                 srcs: StrOrListOpt,
+                 deps: StrOrListOpt,
+                 visibility: StrOrListOpt,
+                 tags: StrOrListOpt,
+                 type: str,
+                 out: str | None,
+                 shell: bool,
+                 kwargs: dict[str, object]):
         srcs = var_to_list(srcs)
         deps = var_to_list(deps)
+        tags = var_to_list(tags)
+        visibility = var_to_list_or_none(visibility)
 
         super().__init__(
                 name=name,
@@ -191,15 +194,15 @@ class PackageTarget(Target):
         self.generate_build(rule, output, inputs=package_sources, variables=vars)
 
 
-def package(name=None,
-            srcs=None,
-            deps=None,
-            visibility=None,
-            tags=None,
-            type='tar',
-            out=None,
-            shell=False,
-            **kwargs):
+def package(name: str,
+            srcs: StrOrListOpt = None,
+            deps: StrOrListOpt = None,
+            visibility: StrOrListOpt = None,
+            tags: StrOrListOpt = None,
+            type: str = 'tar',
+            out: str | None = None,
+            shell: bool = False,
+            **kwargs: object):
     package_target = PackageTarget(
             name=name,
             srcs=srcs,

--- a/src/blade/sh_test_target.py
+++ b/src/blade/sh_test_target.py
@@ -13,8 +13,9 @@ import os
 
 from blade import build_manager
 from blade import build_rules
+from blade.blade_types import StrOrListOpt
 from blade.target import Target, LOCATION_RE
-from blade.util import var_to_list
+from blade.util import var_to_list, var_to_list_or_none
 
 
 class ShellTest(Target):
@@ -31,15 +32,17 @@ class ShellTest(Target):
     """
 
     def __init__(self,
-                 name,
-                 srcs,
-                 deps,
-                 visibility,
-                 tags,
-                 testdata,
-                 kwargs):
+                 name: str | None,
+                 srcs: StrOrListOpt,
+                 deps: StrOrListOpt,
+                 visibility: StrOrListOpt,
+                 tags: StrOrListOpt,
+                 testdata: StrOrListOpt,
+                 kwargs: dict[str, object]):
         srcs = var_to_list(srcs)
         deps = var_to_list(deps)
+        tags = var_to_list(tags)
+        visibility = var_to_list_or_none(visibility)
         testdata = var_to_list(testdata)
 
         super().__init__(
@@ -99,13 +102,13 @@ class ShellTest(Target):
                                 variables={'testdata': ' '.join(testdata)})
 
 
-def sh_test(name=None,
-            srcs=None,
-            deps=None,
-            visibility=None,
-            tags=None,
-            testdata=None,
-            **kwargs):
+def sh_test(name: str,
+            srcs: StrOrListOpt = None,
+            deps: StrOrListOpt = None,
+            visibility: StrOrListOpt = None,
+            tags: StrOrListOpt = None,
+            testdata: StrOrListOpt = None,
+            **kwargs: object):
     build_manager.instance.register_target(ShellTest(
             name=name,
             srcs=srcs,

--- a/src/blade/swig_library_target.py
+++ b/src/blade/swig_library_target.py
@@ -13,25 +13,32 @@ import os
 
 from blade import build_manager
 from blade import build_rules
+from blade.blade_types import StrOrListOpt
 from blade.cc_targets import CcTarget
-from blade.util import var_to_list
+from blade.util import var_to_list, var_to_list_or_none
 
 
 class SwigLibrary(CcTarget):
     """This class is used to build swig library."""
 
     def __init__(self,
-                 name,
-                 srcs,
-                 deps,
-                 visibility,
-                 tags,
-                 warning,
-                 java_package,
-                 java_lib_packed,
-                 optimize,
-                 extra_swigflags,
-                 kwargs):
+                 name: str | None,
+                 srcs: StrOrListOpt,
+                 deps: StrOrListOpt,
+                 visibility: StrOrListOpt,
+                 tags: StrOrListOpt,
+                 warning: str,
+                 java_package: str,
+                 java_lib_packed: bool,
+                 optimize: StrOrListOpt,
+                 extra_swigflags: StrOrListOpt,
+                 kwargs: dict[str, object]):
+        # Normalize before forwarding to CcTarget.__init__
+        srcs = var_to_list(srcs)
+        deps = var_to_list(deps)
+        tags = var_to_list(tags)
+        visibility = var_to_list_or_none(visibility)
+        optimize = var_to_list_or_none(optimize)
         super().__init__(
                 name=name,
                 type='swig_library',
@@ -96,17 +103,17 @@ class SwigLibrary(CcTarget):
 
 
 def swig_library(
-        name,
-        srcs=None,
-        deps=None,
-        visibility=None,
-        tags=None,
-        warning='',
-        java_package='',
-        java_lib_packed=False,
-        optimize=None,
-        extra_swigflags=None,
-        **kwargs):
+        name: str,
+        srcs: StrOrListOpt = None,
+        deps: StrOrListOpt = None,
+        visibility: StrOrListOpt = None,
+        tags: StrOrListOpt = None,
+        warning: str = '',
+        java_package: str = '',
+        java_lib_packed: bool = False,
+        optimize: StrOrListOpt = None,
+        extra_swigflags: StrOrListOpt = None,
+        **kwargs: object):
     """swig_library target."""
     target = SwigLibrary(
             name=name,

--- a/src/blade/thrift_library.py
+++ b/src/blade/thrift_library.py
@@ -18,9 +18,10 @@ import os
 from blade import build_manager
 from blade import build_rules
 from blade import config
+from blade.blade_types import StrOrListOpt
 from blade.cc_targets import CcTarget
 from blade.thrift_helper import ThriftHelper
-from blade.util import var_to_list
+from blade.util import var_to_list, var_to_list_or_none
 
 
 # TODO(chen3feng): Support java generation
@@ -29,15 +30,19 @@ class ThriftLibrary(CcTarget):
 
     def __init__(
             self,
-            name,
-            srcs,
-            deps,
-            visibility,
-            tags,
-            optimize,
-            deprecated,
-            kwargs):
+            name: str | None,
+            srcs: StrOrListOpt,
+            deps: StrOrListOpt,
+            visibility: StrOrListOpt,
+            tags: StrOrListOpt,
+            optimize: StrOrListOpt,
+            deprecated: bool,
+            kwargs: dict[str, object]):
         srcs = var_to_list(srcs)
+        deps = var_to_list(deps)
+        tags = var_to_list(tags)
+        visibility = var_to_list_or_none(visibility)
+        optimize = var_to_list_or_none(optimize)
         super().__init__(
                 name=name,
                 type='thrift_library',
@@ -111,14 +116,14 @@ class ThriftLibrary(CcTarget):
 
 
 def thrift_library(
-        name,
-        srcs=None,
-        deps=None,
-        visibility=None,
-        tags=None,
-        optimize=None,
-        deprecated=False,
-        **kwargs):
+        name: str,
+        srcs: StrOrListOpt = None,
+        deps: StrOrListOpt = None,
+        visibility: StrOrListOpt = None,
+        tags: StrOrListOpt = None,
+        optimize: StrOrListOpt = None,
+        deprecated: bool = False,
+        **kwargs: object):
     """thrift_library target."""
     thrift_library_target = ThriftLibrary(
             name=name,


### PR DESCRIPTION
## Summary

Batch-annotate the last 7 target modules, all following the established two-layer pattern:

- **Rule-entry functions**: `name: str`, `StrOrListOpt = None` for list-ish params, `bool` for flags, `**kwargs: object`.
- **Class `__init__`**: normalizes `StrOrListOpt` → `list[str]` at the top with `var_to_list` / `var_to_list_or_none`, forwards to `Target`/`CcTarget` base.

### Files covered

| File | Classes | Rule entries |
|------|---------|-------------|
| gen_rule_target.py | GenRuleTarget | gen_rule |
| lex_yacc_target.py | LexYaccLibrary | lex_yacc_library |
| sh_test_target.py | ShellTest | sh_test |
| swig_library_target.py | SwigLibrary | swig_library |
| thrift_library.py | ThriftLibrary | thrift_library |
| fbthrift_library.py | FBThriftLibrary | fbthrift_library |
| package_target.py | PackageTarget | package |

This completes the type-annotation of all `src/blade/*_targets*.py` and `*_library.py` modules in the v3 branch.

## Verification

- pyright: 0 errors, 113 warnings (baseline unchanged)
- unit tests: 49/49 passing (python 3.12)