### PR TITLE
chore(v3): remove stale TODO in Target._get_java_pack_deps

### DIFF
--- a/src/blade/target.py
+++ b/src/blade/target.py
@@ -598,7 +598,6 @@ class Target:
         Returns:
             A tuple of (target jars, maven jars)
         """
-        # TODO(chen3feng): put to `data`
         return [], []
 
     def _target_dir(self):


### PR DESCRIPTION
## Summary

Remove stale TODO in Target._get_java_pack_deps. The base method is a stub returning ([], []). Actual implementations (JavaTargetMixIn via _get_pack_deps, MavenJar) already cache results in self.data.

## Verification
- unit tests: 49/49 passing