### PR TITLE
chore(v3): suppress reportAttributeAccessIssue in java_targets.py

### DIFF
--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -4,6 +4,11 @@
 # Author: CHEN Feng <phongchen@tencent.com>
 # Created: Jun 26, 2013
 
+# pyright: reportAttributeAccessIssue=false
+# JavaTargetMixIn methods access Target attributes (self.deps, self.attr,
+# self.warning, etc.) that pyright can't resolve because the mixin does
+# not inherit from Target. The attributes exist at runtime via MRO when
+# mixed into JavaTarget / ScalaTarget / ProtoLibrary.
 # pylint: disable=too-many-lines
 
 """


### PR DESCRIPTION
## Summary

Add file-level `# pyright: reportAttributeAccessIssue=false` in `java_targets.py` with an explanation: JavaTargetMixIn methods access Target attributes (`deps`, `attr`, `warning`, etc.) through MRO that pyright can't resolve because the mixin doesn't inherit from Target.

## Before / After
- pyright: 76 → 3 warnings (73 eliminated)
- unit tests: 49/49 passing