### PR TITLE
fix(v3): forbid '..' in gen_rule.outs, cc_library.incs/export_incs, and glob patterns

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -276,6 +276,9 @@ class CcTarget(Target):
         """Expand incs to full path"""
         result = []
         for inc in var_to_list(incs):
+            if '..' in inc.split(os.sep):
+                self.error('"incs" must not contain "..": %s' % inc)
+                continue
             if inc.startswith('//'):  # Full path
                 result.append(inc[2:])
             else:

--- a/src/blade/gen_rule_target.py
+++ b/src/blade/gen_rule_target.py
@@ -75,6 +75,9 @@ class GenRuleTarget(Target):
         outs = var_to_list(outs)
         # self._check_path_list(outs, "outs", must_exist=False)
         outs = [os.path.normpath(o) for o in outs]
+        for o in outs:
+            if '..' in o.split(os.sep):
+                self.error('"outs" must not contain "..": %s' % o)
 
         self.attr['outs'] = var_to_list(outs)
         self.attr['outputs'] = [self._target_file_path(o) for o in self.attr['outs']]

--- a/src/blade/load_build_files.py
+++ b/src/blade/load_build_files.py
@@ -116,6 +116,10 @@ def glob(include, exclude=None, excludes=None, allow_empty=False):
     source_loc = _current_source_location()
     include = var_to_list(include)
     severity = config.get_item('global_config', 'glob_error_severity')
+    for pattern in include:
+        if '..' in pattern.split(os.sep):
+            console.diagnose(source_loc, 'error',
+                             '"glob" pattern must not contain "..": %s' % pattern)
     if excludes:
         console.diagnose(source_loc, severity, '"excludes" is deprecated, use "exclude" instead')
     exclude = var_to_list(exclude) + var_to_list(excludes)


### PR DESCRIPTION
## Summary

Add validation to disallow `..` (parent directory traversal) in:

- `gen_rule.outs` (fixes #870)
- `cc_library.incs` / `cc_library.export_incs` (fixes #870)
- `glob` include patterns (fixes #695)

The `..` pattern is blocked in path targets already (see Target._check_path), but these three locations were missing the check. The detection uses `'..' in path.split(os.sep)` to catch the path component, not just the substring.

## Verification
- pyright: 0 errors, 3 warnings
- unit tests: 49/49 passing

Closes #695, #870