### PR TITLE
fix(v3): skip GCC-specific -static-libgcc/-static-libstdc++ on macOS

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1447,7 +1447,9 @@ class CcBinary(CcTarget):
     def _generate_cc_binary_link_flags(self, dynamic_link):
         linkflags = []
         toolchain = self.blade.get_build_toolchain()
-        if not dynamic_link and toolchain.cc_is('gcc') and version_parse(toolchain.get_cc_version()) > version_parse('4.5'):
+        if (not dynamic_link and toolchain.cc_is('gcc')
+                and version_parse(toolchain.get_cc_version()) > version_parse('4.5')
+                and sys.platform != 'darwin'):
             linkflags += ['-static-libgcc', '-static-libstdc++']
         if self.attr.get('export_dynamic'):
             linkflags.append('-rdynamic')


### PR DESCRIPTION
## Summary

macOS clang does not support `-static-libgcc` / `-static-libstdc++` (GCC-specific flags). Add `sys.platform != 'darwin'` guard so these flags are only emitted on Linux.

The existing `toolchain.cc_is('gcc')` check is insufficient on macOS where Apple ships clang as `gcc`.

Closes #1048.

## Verification
- unit tests: 49/49 passing