### PR TITLE
doc: add go target documentation and  reference

### DIFF
--- a/doc/en/build_rules/gen_rule.md
+++ b/doc/en/build_rules/gen_rule.md
@@ -18,6 +18,18 @@ Used to customize your own construction rules, parameters:
     - $FIRST\_SRC, first input file path
     - $FIRST\_OUT, the path of the first output file
     - BUILD\_DIR, The root output directory, such as build[64,32]\_[release, debug]
+  - `$(location target)` and `$(location target label)` — replaced with the output
+    file path(s) of the referenced target. The optional `label` parameter specifies
+    a particular output (e.g. `$(location //bin:server bin)`). Commonly used in
+    `gen_rule.cmd`, `testdata`, `package`, and `sh_test`. Example:
+
+    ```python
+    gen_rule(
+        name = 'copy_binary',
+        cmd = 'cp $(location //server:server) $OUT_DIR/server',
+        outs = ['server'],
+    )
+    ```
 
 - cmd\_name: str, the name of the command, used to display in simplified mode, the default is `COMMAND`
 - generate\_hdrs: bool, indicates whether this target will generate C/C++ header files other than the file names already listed in `outs`.

--- a/doc/en/build_rules/go.md
+++ b/doc/en/build_rules/go.md
@@ -1,0 +1,132 @@
+# Build Go Targets
+
+Blade uses `go_library`, `go_binary`, and `go_test` to build Go packages.
+There is also a `go_package` convenience wrapper that auto-detects the package type.
+
+## Configuration
+
+Before using go targets, configure the Go toolchain in `BLADE_ROOT`:
+
+```python
+go_config(
+    go = '/usr/local/go/bin/go',
+    go_home = '/usr/local/go',
+)
+```
+
+When Go modules are enabled, set `go_module_enabled = True`:
+
+```python
+go_config(
+    go_home = '/usr/local/go',
+    go_module_enabled = True,
+    go_module_relpath = '',
+)
+```
+
+## go_library
+
+Build a Go package as a library.
+
+```python
+go_library(
+    name = 'mylib',
+    srcs = [
+        'mylib.go',
+        'helper.go',
+    ],
+    deps = [
+        '//common/go:base',
+    ],
+)
+```
+
+Attributes:
+
+- `srcs`: Go source files. All `.go` files in the same directory must belong to the same Go package.
+- `deps`: Other go_library or proto_library targets with Go output.
+- `extra_goflags`: Extra flags passed to the Go compiler (`list[str]` or `str`).
+- `visibility`: Visibility specification.
+- `tags`: Build tags.
+
+Output: a `.a` archive file placed under `$go_home/pkg/$GOOS_$GOARCH/`.
+
+## go_binary
+
+Build a Go executable.
+
+```python
+go_binary(
+    name = 'myserver',
+    srcs = [
+        'main.go',
+    ],
+    deps = [
+        ':mylib',
+    ],
+)
+```
+
+Attributes are the same as `go_library`.
+
+## go_test
+
+Build and run a Go test binary.
+
+```python
+go_test(
+    name = 'mylib_test',
+    srcs = [
+        'mylib_test.go',
+    ],
+    deps = [
+        ':mylib',
+    ],
+    testdata = [
+        'testdata/config.json',
+    ],
+)
+```
+
+Additional attributes:
+
+- `testdata`: Test data files, similar to other test targets.
+
+## go_package
+
+Convenience wrapper that automatically detects whether a directory contains a library or a command.
+
+```python
+go_package(
+    name = 'mypackage',
+    deps = [
+        '//common/go:base',
+    ],
+)
+```
+
+Blade scans the current directory for `.go` files:
+
+- If any file has `package main`, a `go_binary` is created.
+- Otherwise, a `go_library` is created.
+- If `*_test.go` files exist, a `go_test` is created automatically.
+
+## Using Protobuf with Go
+
+Add a `proto_library` dependency to generate Go protobuf code:
+
+```python
+go_library(
+    name = 'service',
+    srcs = ['service.go'],
+    deps = [
+        '//proto:myproto',  # proto_library target
+    ],
+)
+```
+
+The proto file must contain a `go_package` option:
+
+```protobuf
+option go_package = "github.com/example/myproto";
+```

--- a/doc/zh_CN/build_rules/gen_rule.md
+++ b/doc/zh_CN/build_rules/gen_rule.md
@@ -18,6 +18,15 @@
   - $FIRST\_SRC 第一个输入文件的路径
   - $FIRST\_OUT 第一个输出文件的路径
   - $BUILD\_DIR 输出的根目录，比如 build[64,32]\_[release,debug]
+  - `$(location target)` 和 `$(location target label)` — 被替换为所引用目标的输出文件路径。可选的 `label` 参数指定特定输出（如 `$(location //bin:server bin)` 表示可执行文件）。常用于 `gen_rule.cmd`、`testdata`、`package`、`sh_test` 等场景。示例：
+
+    ```python
+    gen_rule(
+        name = 'copy_binary',
+        cmd = 'cp $(location //server:server) $OUT_DIR/server',
+        outs = ['server'],
+    )
+    ```
 
 - `cmd_name`: str，命令的名字，用于简略模式下显示，默认为 `COMMAND`
 - generate\_hdrs bool，指示这个目标是否会生成 outs 里列出的文件名之外的 C/C++ 头文件。

--- a/doc/zh_CN/build_rules/go.md
+++ b/doc/zh_CN/build_rules/go.md
@@ -1,0 +1,131 @@
+# 构建 Go 目标
+
+Blade 通过 `go_library`、`go_binary`、`go_test` 构建 Go 程序，另外提供了 `go_package` 便捷包装函数用于自动判断包类型。
+
+## 配置
+
+使用 Go 目标前，需在 `BLADE_ROOT` 中配置 Go 工具链：
+
+```python
+go_config(
+    go = '/usr/local/go/bin/go',
+    go_home = '/usr/local/go',
+)
+```
+
+如果启用了 Go modules，设置 `go_module_enabled = True`：
+
+```python
+go_config(
+    go_home = '/usr/local/go',
+    go_module_enabled = True,
+    go_module_relpath = '',
+)
+```
+
+## go_library
+
+将 Go 源码编译为库文件。
+
+```python
+go_library(
+    name = 'mylib',
+    srcs = [
+        'mylib.go',
+        'helper.go',
+    ],
+    deps = [
+        '//common/go:base',
+    ],
+)
+```
+
+参数说明：
+
+- `srcs`：Go 源文件。同一目录下的所有 `.go` 文件必须属于同一个 Go 包。
+- `deps`：依赖的其他 go_library 或带 Go 输出的 proto_library 目标。
+- `extra_goflags`：传递给 Go 编译器的额外参数（`list[str]` 或 `str`）。
+- `visibility`：可见性控制。
+- `tags`：构建标记。
+
+输出：`.a` 归档文件，位于 `$go_home/pkg/$GOOS_$GOARCH/`。
+
+## go_binary
+
+构建 Go 可执行文件。
+
+```python
+go_binary(
+    name = 'myserver',
+    srcs = [
+        'main.go',
+    ],
+    deps = [
+        ':mylib',
+    ],
+)
+```
+
+参数与 `go_library` 相同。
+
+## go_test
+
+构建并运行 Go 测试。
+
+```python
+go_test(
+    name = 'mylib_test',
+    srcs = [
+        'mylib_test.go',
+    ],
+    deps = [
+        ':mylib',
+    ],
+    testdata = [
+        'testdata/config.json',
+    ],
+)
+```
+
+额外参数：
+
+- `testdata`：测试数据文件，与其他 test 目标类似。
+
+## go_package
+
+便捷包装函数，自动检测目录类型。
+
+```python
+go_package(
+    name = 'mypackage',
+    deps = [
+        '//common/go:base',
+    ],
+)
+```
+
+Blade 会扫描当前目录的 `.go` 文件：
+
+- 如果有文件包含 `package main`，则创建 `go_binary`。
+- 否则创建 `go_library`。
+- 如果有 `*_test.go` 文件，自动创建 `go_test`。
+
+## 与 Protobuf 集成
+
+在 deps 中添加 `proto_library` 即可自动生成 Go protobuf 代码：
+
+```python
+go_library(
+    name = 'service',
+    srcs = ['service.go'],
+    deps = [
+        '//proto:myproto',  # proto_library 目标
+    ],
+)
+```
+
+proto 文件中需要指定 `go_package` 选项：
+
+```protobuf
+option go_package = "github.com/example/myproto";
+```


### PR DESCRIPTION
## Summary

- **Add `go.md` (en + zh_CN)** — documents `go_library`, `go_binary`, `go_test`, `go_package`, Go toolchain configuration, and protobuf integration. Closes #635.
- **Add `$(location)` documentation to `gen_rule.md` (en + zh_CN)** — documents the `$(location target)` and `$(location target label)` syntax with examples. Closes #945.

## Files changed

| File | Type |
|------|------|
| `doc/en/build_rules/go.md` | New |
| `doc/zh_CN/build_rules/go.md` | New |
| `doc/en/build_rules/gen_rule.md` | Modified |
| `doc/zh_CN/build_rules/gen_rule.md` | Modified |