### PR TITLE
fix(v3): include expanded resource files in target fingerprint

### DIFF
--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -541,7 +541,8 @@ class JavaTargetMixIn:
             return []
         inputs, outputs = [], []
         resources_dir = self._target_file_path(self.name + '.resources')
-        resources = self._process_regular_resources(resources)
+        resources = self.attr.get('expanded_resources',
+            self._process_regular_resources(resources))
         for src, dst in resources:
             inputs.append(src)
             outputs.append(os.path.join(resources_dir, dst))
@@ -654,6 +655,11 @@ class JavaTarget(Target, JavaTargetMixIn):
                 tags=tags,
                 kwargs=kwargs)
         self._process_resources(resources)
+        # Pre-expand resource directories so that changes to files inside
+        # the directory are captured in the target's fingerprint.
+        if self.attr['resources']:
+            self.attr['expanded_resources'] = self._process_regular_resources(
+                self.attr['resources'])
         self.attr['source_encoding'] = source_encoding
         self._add_tags('lang:java')
 

--- a/src/blade/scala_targets.py
+++ b/src/blade/scala_targets.py
@@ -61,6 +61,11 @@ class ScalaTarget(Target, JavaTargetMixIn):
                 tags=tags,
                 kwargs=kwargs)
         self._process_resources(resources)
+        # Pre-expand resource directories so that changes to files inside
+        # the directory are captured in the target's fingerprint.
+        if self.attr['resources']:
+            self.attr['expanded_resources'] = self._process_regular_resources(
+                self.attr['resources'])
         if source_encoding:
             self.attr['source_encoding'] = source_encoding
         if warnings:


### PR DESCRIPTION
## Summary

When a resource is a directory, changes to files inside the directory did not trigger a rebuild because `_process_regular_resources(os.walk)` was called too late — in `_generate_resources`, after the fingerprint had already been computed.

**Fix**: Pre-expand resource directories in `__init__` and store the result in `self.attr['expanded_resources']`, which is included in the fingerprint via `_fingerprint_entropy`. Location references (`$(location ...)`) remain resolved lazily at build time since target outputs aren't available at init time.

Applies to both `JavaTarget` and `ScalaTarget`.

Supersedes #944 (the original PR had a location-reference issue pointed out in review).

## Verification
- unit tests: 49/49 passing