### PR TITLE
Add deterministic and thin options to cc_library_config, deprecate arflags

### DIFF
--- a/doc/en/FAQ.md
+++ b/doc/en/FAQ.md
@@ -449,7 +449,7 @@ cc_test_config(
 
 ```python
 cc_library_config(
-    arflags = 'rcsT'  # Add 'T' flag for thin library generation
+    thin = True  # Generate thin static libraries
 )
 ```
 

--- a/doc/en/config.md
+++ b/doc/en/config.md
@@ -297,6 +297,34 @@ C/C++ library configuration
   If you only concern to one target platform, it is sure OK to have only one directory or have no
   directory at all.
 
+- `generate_dynamic` : bool = False
+
+  Whether to generate a dynamic library in addition to the static library.
+
+- `arflags` : list = ['rcs'] **(DEPRECATED)**
+
+  Deprecated — use `deterministic` and/or `thin` instead.
+  Platform-specific archive flags (`rcs`/`D`/`T`) are now handled automatically.
+
+- `deterministic` : bool = False
+
+  Generate deterministic (reproducible) static libraries.
+
+  By default, ``ar`` embeds timestamps, UID, GID, and other metadata into the archive,
+  so the same source code produces a different checksum on every build — breaking
+  build reproducibility and reducing distributed cache (e.g. ccache) hit rates.
+
+  When enabled, each platform eliminates these sources of non-determinism:
+
+  - **Linux:** passes ``D`` to ``ar`` — zeros out timestamps, UID, and GID, keeping only file contents and symbol table
+  - **macOS:** uses ``libtool -static`` instead of ``ar`` (Apple's ``ar`` does not support ``D``; ``libtool -static`` is inherently deterministic)
+  - **MSVC:** passes ``/Brepro`` to ``lib.exe`` — likewise zeros out timestamps
+
+- `thin` : bool = False
+
+  Generate thin static libraries that store object file paths instead of actual code.
+  **Only supported on Linux** (GNU `ar` `T` flag). Emits an error on macOS and a warning on MSVC where thin archives are not supported.
+
 - `hdrs_missing_severity` : string = 'error' | ['debug', 'info', 'warning', 'error']
 
   The severity of missing `cc_library.hdrs`

--- a/doc/zh_CN/FAQ.md
+++ b/doc/zh_CN/FAQ.md
@@ -452,7 +452,7 @@ cc_test_config(
 
 ```python
 cc_library_config(
-    arflags = 'rcsT'  # 加上 'T' 标志以生成 thin 静态库
+    thin = True  # 生成 thin 静态库
 )
 ```
 

--- a/doc/zh_CN/config.md
+++ b/doc/zh_CN/config.md
@@ -308,6 +308,36 @@ Blade 支持构建多目标平台的产物，例如在 x64 Linux 下，可以通
 
 如果只关心一个目标平台，完全可以只有一个子目录，甚至根本不用子目录。
 
+#### `generate_dynamic`：bool = False
+
+**是否同时生成动态库**
+
+除了生成静态库之外，是否同时生成动态库。
+
+#### `deterministic`：bool = False
+
+**生成可重复构建（deterministic）的静态库。**
+
+默认情况下，`ar` 在打包 `.o` 文件时会嵌入文件的时间戳、UID、GID 等元数据，
+导致同一份源码每次构建产物的 checksum 不同，破坏构建的可重复性（reproducible builds），
+也让分布式缓存（如 ccache）命中率下降。
+
+启用此选项后，各平台通过以下方式消除不确定性，确保相同源码产生相同的二进制产物：
+
+- **Linux：** 为 `ar` 加上 `D` 标志，清零时间戳、UID、GID，只保留文件内容和符号表
+- **macOS：** 使用 `libtool -static` 取代 `ar`（Apple 的 `ar` 不支持 `D` 标志，`libtool -static` 天生是 deterministic 的）
+- **MSVC：** 为 `lib.exe` 加上 `/Brepro` 标志，同样清零时间戳
+
+#### `thin`：bool = False
+
+**生成 thin 静态库**，只记录 `.o` 文件路径，不打包实际内容。
+**仅 Linux 支持**（GNU `ar` 的 `T` 标志）。macOS 会报错，MSVC 会警告。
+
+#### `arflags`：list = ['rcs'] ~~**（已废弃）**~~
+
+已废弃 — 请改用 `deterministic` 和/或 `thin`。
+平台特定的归档标志（`rcs`/`D`/`T`）现在由系统自动处理。
+
 #### `hdrs_missing_severity`：string = 'error'
 
 **缺失 `cc_library.hdrs` 时的严重性**

--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -312,9 +312,16 @@ class _NinjaFileHeaderGenerator:
 
     def _generate_windows_ar_rules(self):
         """Generate Windows static library rules."""
+        cc_lib = config.get_section('cc_library_config')
+        deterministic = cc_lib.get('deterministic', False)
+        thin = cc_lib.get('thin', False)
+        if thin:
+            console.warning('cc_library_config.thin=True has no effect on MSVC (lib.exe '
+                            'does not support thin archives)')
         ar = self.build_accelerator.get_ar_command()
+        brepro = ' /Brepro' if deterministic else ''
         self.generate_rule(name='ar',
-                           command=f'{ar} /nologo /out:${{out}} ${{in}}',
+                           command=f'{ar} /nologo{brepro} /out:${{out}} ${{in}}',
                            description='LIB ${out}')
 
     def _generate_windows_link_rules(self):
@@ -432,11 +439,34 @@ class _NinjaFileHeaderGenerator:
                            description='CC INCLUSION CHECK ${in}')
 
     def _generate_cc_ar_rules(self):
-        arflags = ''.join(config.get_item('cc_library_config', 'arflags'))
-        ar = self.build_accelerator.get_ar_command()
-        self.generate_rule(name='ar',
-                           command=f'rm -f $out; {ar} {arflags} $out $in',
-                           description='AR ${out}')
+        cc_lib = config.get_section('cc_library_config')
+        deterministic = cc_lib.get('deterministic', False)
+        thin = cc_lib.get('thin', False)
+        target_os = self.build_toolchain.target_os
+
+        if target_os == 'darwin':
+            if thin:
+                console.error('cc_library_config.thin=True is not supported on macOS '
+                              '(Apple ar does not support thin archives)')
+            if deterministic:
+                command = 'rm -f $out; libtool -static -o $out $in'
+            else:
+                ar = self.build_accelerator.get_ar_command()
+                command = f'rm -f $out; {ar} rcs $out $in'
+        elif target_os == 'linux':
+            ar = self.build_accelerator.get_ar_command()
+            extra = ''
+            if deterministic:
+                extra += 'D'
+            if thin:
+                extra += 'T'
+            command = f'rm -f $out; {ar} rcs{extra} $out $in'
+        else:
+            arflags = ''.join(cc_lib.get('arflags', ['rcs']))
+            ar = self.build_accelerator.get_ar_command()
+            command = f'rm -f $out; {ar} {arflags} $out $in'
+
+        self.generate_rule(name='ar', command=command, description='AR ${out}')
 
     def _generate_cc_link_rules(self, ld, linkflags):
         self._add_line('linkflags = %s' % ' '.join(config.get_item('cc_config', 'linkflags')))

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -112,11 +112,11 @@ _CONFIG_TEMPLATE = {
         '__help__': 'C/C++ Library Configuration',
         'prebuilt_libpath_pattern': 'lib${bits}',
         'generate_dynamic': False,
-        # Options passed to ar/ranlib to control how
-        # the archive is created, such as, let ar operate
-        # in deterministic mode discarding timestamps
+        # DEPRECATED: use 'deterministic' and/or 'thin' instead.
+        # Platform-specific flags (rcs/D/T) are now handled automatically.
         'arflags': ['rcs'],
-        'ranlibflags': [],
+        'deterministic': False,
+        'thin': False,
         'hdrs_missing_severity': 'error',
         'hdrs_missing_suppress': set(),
     },
@@ -753,6 +753,14 @@ def cc_binary_config(append=None, **kwargs):
 @config_rule
 def cc_library_config(append=None, **kwargs):
     """cc_library_config section."""
+    has_arflags = 'arflags' in kwargs
+    has_new = 'deterministic' in kwargs or 'thin' in kwargs
+    if has_arflags and has_new:
+        _blade_config.error(
+            'cc_library_config: "arflags" and "deterministic"/"thin" cannot be used together')
+    elif has_arflags:
+        _blade_config.warning(
+            'cc_library_config: "arflags" is deprecated, use "deterministic" and/or "thin" instead')
     _blade_config.update_config('cc_library_config', append, kwargs)
 
 

--- a/src/tests/unit/cc_library_config_test.py
+++ b/src/tests/unit/cc_library_config_test.py
@@ -122,8 +122,7 @@ class CcArchiveRulesTest(unittest.TestCase):
                     'thin': thin,
                 }
                 gen._generate_cc_ar_rules()
-                if mock_rule.call_count == 0:
-                    return None
+                self.assertTrue(mock_rule.called, 'generate_rule was not called')
                 return mock_rule.call_args[1]['command']
 
     def _capture_windows_ar_command(self, gen, deterministic=False, thin=False):
@@ -135,8 +134,7 @@ class CcArchiveRulesTest(unittest.TestCase):
                     'thin': thin,
                 }
                 gen._generate_windows_ar_rules()
-                if mock_rule.call_count == 0:
-                    return None
+                self.assertTrue(mock_rule.called, 'generate_rule was not called')
                 return mock_rule.call_args[1]['command']
 
     # --- Linux ---

--- a/src/tests/unit/cc_library_config_test.py
+++ b/src/tests/unit/cc_library_config_test.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Unit tests for cc_library_config template defaults, validation,
+# and platform-aware archive command generation.
+
+"""Unit tests for cc_library_config."""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import config  # noqa: E402
+
+
+class CcLibraryConfigDefaultsTest(unittest.TestCase):
+    """Pin the template defaults so the contract stays coherent."""
+
+    def setUp(self):
+        self._template = config._CONFIG_TEMPLATE['cc_library_config']
+
+    def test_default_deterministic_is_false(self):
+        self.assertFalse(self._template['deterministic'])
+
+    def test_default_thin_is_false(self):
+        self.assertFalse(self._template['thin'])
+
+    def test_arflags_still_exists_for_backward_compat(self):
+        self.assertIn('arflags', self._template)
+        self.assertEqual(self._template['arflags'], ['rcs'])
+
+    def test_ranlibflags_removed(self):
+        self.assertNotIn('ranlibflags', self._template)
+
+    def test_generate_dynamic_still_exists(self):
+        self.assertIn('generate_dynamic', self._template)
+        self.assertFalse(self._template['generate_dynamic'])
+
+
+class CcLibraryConfigValidationTest(unittest.TestCase):
+    """Test the validation/deprecation logic in cc_library_config()."""
+
+    def setUp(self):
+        self._bc = config._blade_config
+        # Save config dict so we can restore it after each test.
+        self._saved_config = dict(self._bc.config)
+
+    def tearDown(self):
+        self._bc.config = self._saved_config
+
+    def _call(self, **kwargs):
+        """Call cc_library_config and capture warning/error messages."""
+        warnings = []
+        errors = []
+        with mock.patch.object(self._bc, 'warning', side_effect=warnings.append), \
+             mock.patch.object(self._bc, 'error', side_effect=errors.append):
+            config.cc_library_config(**kwargs)
+        return warnings, errors
+
+    def test_deterministic_bool_accepted_without_warning(self):
+        warnings, errors = self._call(deterministic=True)
+        self.assertEqual(warnings, [])
+        self.assertEqual(errors, [])
+
+    def test_thin_bool_accepted_without_warning(self):
+        warnings, errors = self._call(thin=True)
+        self.assertEqual(warnings, [])
+        self.assertEqual(errors, [])
+
+    def test_arflags_alone_emits_warning(self):
+        warnings, errors = self._call(arflags=['rcsD'])
+        self.assertEqual(len(warnings), 1)
+        self.assertIn('deprecated', warnings[0])
+        self.assertEqual(errors, [])
+
+    def test_arflags_with_deterministic_errors(self):
+        warnings, errors = self._call(arflags=['rcsD'], deterministic=True)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('cannot be used together', errors[0])
+        self.assertEqual(warnings, [])
+
+    def test_arflags_with_thin_errors(self):
+        warnings, errors = self._call(arflags=['rcsT'], thin=True)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('cannot be used together', errors[0])
+        self.assertEqual(warnings, [])
+
+    def test_no_conflict_without_arflags(self):
+        warnings, errors = self._call(deterministic=True, thin=True)
+        self.assertEqual(warnings, [])
+        self.assertEqual(errors, [])
+
+
+class CcArchiveRulesTest(unittest.TestCase):
+    """Test platform-specific archive command generation."""
+
+    def _make_gen(self, target_os):
+        """Build a _NinjaFileHeaderGenerator with enough state for ar tests."""
+        from blade import backend
+        gen = backend._NinjaFileHeaderGenerator.__new__(backend._NinjaFileHeaderGenerator)
+        gen._NinjaFileHeaderGenerator__all_rule_names = set()
+        gen.rules_buf = []
+        gen._add_line = mock.Mock()
+        gen.build_toolchain = mock.Mock()
+        gen.build_toolchain.target_os = target_os
+        gen.build_accelerator = mock.Mock()
+        gen.build_accelerator.get_ar_command.return_value = 'ar'
+        return gen
+
+    def _capture_ar_command(self, gen, deterministic=False, thin=False):
+        """Call _generate_cc_ar_rules and return the generated command."""
+        with mock.patch.object(gen, 'generate_rule') as mock_rule:
+            with mock.patch('blade.backend.config') as mock_config:
+                mock_config.get_section.return_value = {
+                    'arflags': ['rcs'],
+                    'deterministic': deterministic,
+                    'thin': thin,
+                }
+                gen._generate_cc_ar_rules()
+                if mock_rule.call_count == 0:
+                    return None
+                return mock_rule.call_args[1]['command']
+
+    def _capture_windows_ar_command(self, gen, deterministic=False, thin=False):
+        """Call _generate_windows_ar_rules and return the generated command."""
+        with mock.patch.object(gen, 'generate_rule') as mock_rule:
+            with mock.patch('blade.backend.config') as mock_config:
+                mock_config.get_section.return_value = {
+                    'deterministic': deterministic,
+                    'thin': thin,
+                }
+                gen._generate_windows_ar_rules()
+                if mock_rule.call_count == 0:
+                    return None
+                return mock_rule.call_args[1]['command']
+
+    # --- Linux ---
+
+    def test_linux_default(self):
+        gen = self._make_gen('linux')
+        cmd = self._capture_ar_command(gen, deterministic=False, thin=False)
+        self.assertIn('ar rcs ', cmd)
+
+    def test_linux_deterministic(self):
+        gen = self._make_gen('linux')
+        cmd = self._capture_ar_command(gen, deterministic=True, thin=False)
+        self.assertIn('ar rcsD ', cmd)
+
+    def test_linux_thin(self):
+        gen = self._make_gen('linux')
+        cmd = self._capture_ar_command(gen, deterministic=False, thin=True)
+        self.assertIn('ar rcsT ', cmd)
+
+    def test_linux_deterministic_and_thin(self):
+        gen = self._make_gen('linux')
+        cmd = self._capture_ar_command(gen, deterministic=True, thin=True)
+        self.assertIn('ar rcsDT ', cmd)
+
+    # --- macOS ---
+
+    def test_darwin_default(self):
+        gen = self._make_gen('darwin')
+        cmd = self._capture_ar_command(gen, deterministic=False, thin=False)
+        self.assertIn('ar rcs ', cmd)
+
+    def test_darwin_deterministic_uses_libtool(self):
+        gen = self._make_gen('darwin')
+        cmd = self._capture_ar_command(gen, deterministic=True, thin=False)
+        self.assertIn('libtool -static -o $out $in', cmd)
+
+    def test_darwin_thin_logs_error(self):
+        gen = self._make_gen('darwin')
+        with mock.patch.object(gen, 'generate_rule'):
+            with mock.patch('blade.backend.console') as mock_console:
+                with mock.patch('blade.backend.config') as mock_config:
+                    mock_config.get_section.return_value = {
+                        'arflags': ['rcs'],
+                        'deterministic': False,
+                        'thin': True,
+                    }
+                    gen._generate_cc_ar_rules()
+                    mock_console.error.assert_called_once()
+                    self.assertIn('thin', mock_console.error.call_args[0][0])
+
+    # --- Windows (MSVC) ---
+
+    def test_windows_default(self):
+        gen = self._make_gen('windows')
+        cmd = self._capture_windows_ar_command(gen, deterministic=False, thin=False)
+        self.assertIn('/nologo ', cmd)
+        self.assertNotIn('/Brepro', cmd)
+
+    def test_windows_deterministic(self):
+        gen = self._make_gen('windows')
+        cmd = self._capture_windows_ar_command(gen, deterministic=True, thin=False)
+        self.assertIn('/nologo /Brepro', cmd)
+
+    def test_windows_thin_warns(self):
+        gen = self._make_gen('windows')
+        with mock.patch.object(gen, 'generate_rule'):
+            with mock.patch('blade.backend.console') as mock_console:
+                with mock.patch('blade.backend.config') as mock_config:
+                    mock_config.get_section.return_value = {
+                        'deterministic': False,
+                        'thin': True,
+                    }
+                    gen._generate_windows_ar_rules()
+                    mock_console.warning.assert_called_once()
+                    self.assertIn('thin', mock_console.warning.call_args[0][0])
+
+    # --- Unknown platform ---
+
+    def test_unknown_platform_falls_back_to_arflags(self):
+        gen = self._make_gen('freebsd')
+        cmd = self._capture_ar_command(gen, deterministic=True, thin=True)
+        self.assertIn('ar rcs ', cmd)
+        self.assertNotIn('D', cmd)
+        self.assertNotIn('T', cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Replace the raw `arflags` string with cross-platform `deterministic` and `thin` boolean options. Platform differences are handled automatically.

## Changes

- **config.py**: Add `deterministic`/`thin` to template (default `False`), remove dead `ranlibflags`, deprecate `arflags`. Add validation: error when `arflags` is used together with new options, warning when used alone.
- **backend.py**: Platform-aware archive rules — Linux uses `ar rcs[D][T]`, macOS uses `libtool -static` for deterministic, MSVC uses `/Brepro` for deterministic.
- **cc_library_config_test.py** (new): 22 unit tests covering template defaults, validation logic, and all platform × option command generation combinations.
- **Documentation**: Update config.md (en/zh) and FAQ.md (en/zh) — document new options, mark `arflags` as deprecated, update thin archive examples.

## Platform behavior

| Platform | `deterministic=True` | `thin=True` |
|----------|---------------------|-------------|
| Linux | `ar rcsD` | `ar rcsT` |
| macOS | `libtool -static` | error (unsupported) |
| MSVC | `lib.exe /Brepro` | warning (no effect) |

Fixes #1149