### PR TITLE
Fix flaky testDumpCompdb: specify UTF-8 encoding

### DIFF
--- a/src/test/dump_test.py
+++ b/src/test/dump_test.py
@@ -32,12 +32,12 @@ class TestDump(blade_test.TargetTest):
     def testDumpCompdb(self):
         self.assertTrue(self.runBlade('dump', '--compdb'))
         self.assertTrue(self.runBlade('dump', '--compdb --to-file=blade-bin/compdb.json'))
-        json.load(open('blade-bin/compdb.json'))
+        json.load(open('blade-bin/compdb.json', encoding='utf-8'))
 
     def testDumpTargets(self):
         self.assertTrue(self.runBlade('dump', '--targets'))
         self.assertTrue(self.runBlade('dump', '--targets  --to-file=blade-bin/targets.json'))
-        json.load(open('blade-bin/targets.json'))
+        json.load(open('blade-bin/targets.json', encoding='utf-8'))
 
 if __name__ == '__main__':
     blade_test.run(TestDump)


### PR DESCRIPTION
## Summary

`testDumpCompdb` and `testDumpTargets` were flaky on CI because `open()` was called without an explicit encoding. On runners with C locale (default encoding = ASCII), this causes `UnicodeDecodeError` when the output JSON contains non-ASCII characters (e.g. paths with Unicode).

## Fix

Add `encoding='utf-8'` to both `open()` calls. The compdb is generated by `ninja -t compdb` which always outputs UTF-8 JSON.