### PR TITLE
Lazy-import heavy stdlib to speed up builtin_tools startup

### DIFF
--- a/src/blade/builtin_tools.py
+++ b/src/blade/builtin_tools.py
@@ -7,21 +7,24 @@
 """
 This module defines various build functions for building
 targets from sources and custom parameters.
+
+Performance note: this module is the entry point of the
+``python -m blade.builtin_tools`` subprocess, spawned once per build action
+(the hot one being ``cc_inclusion_check``, run per cc target). To keep that
+startup cheap, heavier stdlib modules used only by cold tools (``fnmatch``,
+``getpass``, ``socket``, ``subprocess``, ``tarfile``, ``zipfile``) are imported
+lazily inside the functions that use them, each marked
+``pylint: disable=import-outside-toplevel``. See issue #1159.
 """
 
 
-import fnmatch
-import getpass
 import os
+import pickle
 import shutil
-import socket
-import subprocess
 import sys
-import tarfile
 import textwrap
 import traceback
 import time
-import zipfile
 
 from blade import console
 from blade import util
@@ -76,6 +79,8 @@ def _cleanup_outputs():
 
 def generate_scm(scm, revision, url, profile, compiler, args):
     """Generate `scm.c` file"""
+    import getpass  # pylint: disable=import-outside-toplevel
+    import socket  # pylint: disable=import-outside-toplevel
 
     _declare_outputs(scm)
 
@@ -116,7 +121,7 @@ def generate_cc_inclusion_check(args):
     console.enable_color(True)
     ok, details = inclusion_check.check(info_file)
     with open(info_file + '.details', 'wb') as f:
-        util.pickle.dump(details, f)
+        pickle.dump(details, f)
     if not ok:
         return 1
     with open(result_file, 'w') as f:
@@ -137,6 +142,7 @@ def archive_package_sources(package, sources, destinations):
 
 
 def generate_zip_package(path, sources, destinations):
+    import zipfile  # pylint: disable=import-outside-toplevel
     zip = zipfile.ZipFile(path, 'w', zipfile.ZIP_DEFLATED, allowZip64=True)
     manifest = archive_package_sources(zip.write, sources, destinations)
     zip.writestr(_PACKAGE_MANIFEST, '\n'.join(manifest) + '\n')
@@ -144,6 +150,7 @@ def generate_zip_package(path, sources, destinations):
 
 
 def generate_tar_package(path, sources, destinations, mode):
+    import tarfile  # pylint: disable=import-outside-toplevel
     tar = tarfile.open(path, mode, dereference=True)
     manifest = archive_package_sources(tar.add, sources, destinations)
     manifest_path = '%s.MANIFEST' % path
@@ -292,6 +299,7 @@ def generate_javac_compile(args):
     multi-word Ninja variables (``${javacflags}``, ``${in}``) can be
     unpacked unambiguously.
     """
+    import subprocess  # pylint: disable=import-outside-toplevel
     sep = args.index('--')
     classes_dir = args[0]
     output = args[1]
@@ -349,6 +357,7 @@ def generate_java_resource(args):
 
 def _get_all_test_class_names_in_jar(jar):
     """Returns a list of test class names in the jar file."""
+    import zipfile  # pylint: disable=import-outside-toplevel
     test_class_names = []
     zip_file = zipfile.ZipFile(jar, 'r')
     name_list = zip_file.namelist()
@@ -431,6 +440,7 @@ def generate_fat_jar(output, **kwargs):
 
 
 def generate_one_jar(onejar, main_class, bootjar, args):
+    import zipfile  # pylint: disable=import-outside-toplevel
     _declare_outputs(onejar)
     # Assume the first jar is the main jar, others jars are dependencies.
     main_jar = args[0]
@@ -569,6 +579,7 @@ def generate_python_library(pylib, basedir, args):
 
 
 def _is_python_excluded_path(filename, exclusions):
+    import fnmatch  # pylint: disable=import-outside-toplevel
     for exclusion in exclusions:
         if fnmatch.fnmatch(filename, exclusion):
             return True
@@ -596,6 +607,7 @@ def _pybin_add_pylib(pybin, libname, exclusions, dirs, dirs_with_init_py):
 
 
 def _pybin_add_zip(pybin, libname, filter, exclusions, dirs, dirs_with_init_py):
+    import zipfile  # pylint: disable=import-outside-toplevel
     with zipfile.ZipFile(libname, 'r') as lib:
         name_list = lib.namelist()
         for name in name_list:
@@ -628,6 +640,7 @@ def _pybin_add_whl(pybin, libname, exclusions, dirs, dirs_with_init_py):
 def generate_python_binary(pybin, basedir, exclusions, mainentry, args):
     # pybin is the wrapper script.  The zip always goes to
     # <pybin_without_extension>.zip, identical on all platforms.
+    import zipfile  # pylint: disable=import-outside-toplevel
     base, _ = os.path.splitext(pybin)
     zip_path = base + '.zip'
     _declare_outputs(pybin, zip_path)

--- a/src/blade/inclusion_check.py
+++ b/src/blade/inclusion_check.py
@@ -10,8 +10,21 @@ import os
 import pickle
 
 from blade import console
-from blade import util
-from blade.util import to_unix_path
+
+
+# Inlined from `util` (both are one-liners) so this module -- imported on the
+# hot `cc_inclusion_check` path -- does not pull in the whole `util` module.
+def to_unix_path(path):
+    """Convert path separators to Unix-style forward slashes."""
+    return path.replace('\\', '/')
+
+
+def path_under_dir(path, dir):
+    """Check whether *path* is under *dir*.
+
+    Both must be normalized, and both relative or both absolute.
+    """
+    return dir == '.' or path == dir or path.startswith(dir) and path[len(dir)] == os.path.sep
 
 
 def find_libs_by_header(hdr, hdr_targets_map, hdr_dir_targets_map):
@@ -327,7 +340,7 @@ class Checker:
 
     def _header_undeclared_message(self, hdr):
         msg = '"%s" is not declared in any cc target. ' % hdr
-        if util.path_under_dir(hdr, self.path):
+        if path_under_dir(hdr, self.path):
             msg += 'If it belongs to this target, it should be declared in "src"'
             if self.type.endswith('_library'):
                 msg += ' if it is private or in "hdrs" if it is public'
@@ -394,7 +407,7 @@ class Checker:
         generated_check_msg = []
 
         def check_file(src, full_src, is_header):
-            if util.path_under_dir(full_src, self.build_dir):  # Don't check generated files.
+            if path_under_dir(full_src, self.build_dir):  # Don't check generated files.
                 return
             path = self._find_inclusion_file(src, is_header)
             if not path:

--- a/src/blade/util.py
+++ b/src/blade/util.py
@@ -27,15 +27,6 @@ import shutil
 import sys
 from typing import TYPE_CHECKING
 
-# Only one of these exists per platform; guard on os.name so we don't attempt
-# (and swallow) an import that is guaranteed to fail on the other platform.
-if os.name == 'nt':
-    import msvcrt
-    fcntl = None
-else:
-    import fcntl
-    msvcrt = None
-
 if TYPE_CHECKING:
     from blade.blade_types import StrOrListOpt  # noqa: F401 (used in annotations)
 
@@ -74,15 +65,17 @@ def lock_file(filename):
     """lock file."""
     try:
         fd = os.open(filename, os.O_CREAT | os.O_RDWR)
-        if fcntl:
+        if os.name != 'nt':
+            import fcntl  # pylint: disable=import-outside-toplevel
             old_fd_flags = fcntl.fcntl(fd, fcntl.F_GETFD)
             fcntl.fcntl(fd, fcntl.F_SETFD, old_fd_flags | fcntl.FD_CLOEXEC)
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        elif msvcrt:
+        elif os.name == 'nt':
+            import msvcrt  # pylint: disable=import-outside-toplevel
             msvcrt.locking(fd, msvcrt.LK_NBLCK, os.stat(fd).st_size)
         return fd, 0
     except OSError as ex_value:
-        if msvcrt:  # msvcrt doesn't set errno correctly
+        if os.name == 'nt':  # msvcrt doesn't set errno correctly
             return -1, errno.EAGAIN
         return -1, ex_value.errno
 
@@ -90,9 +83,11 @@ def lock_file(filename):
 def unlock_file(fd):
     """unlock file."""
     try:
-        if fcntl:
+        if os.name != 'nt':
+            import fcntl  # pylint: disable=import-outside-toplevel
             fcntl.flock(fd, fcntl.LOCK_UN)
-        elif msvcrt:
+        elif os.name == 'nt':
+            import msvcrt  # pylint: disable=import-outside-toplevel
             msvcrt.locking(fd, msvcrt.LK_UNLCK, os.stat(fd).st_size)
         os.close(fd)
     except OSError:

--- a/src/blade/util.py
+++ b/src/blade/util.py
@@ -65,14 +65,14 @@ def lock_file(filename):
     """lock file."""
     try:
         fd = os.open(filename, os.O_CREAT | os.O_RDWR)
-        if os.name != 'nt':
+        if os.name == 'nt':
+            import msvcrt  # pylint: disable=import-outside-toplevel
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, os.stat(fd).st_size)
+        else:
             import fcntl  # pylint: disable=import-outside-toplevel
             old_fd_flags = fcntl.fcntl(fd, fcntl.F_GETFD)
             fcntl.fcntl(fd, fcntl.F_SETFD, old_fd_flags | fcntl.FD_CLOEXEC)
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        elif os.name == 'nt':
-            import msvcrt  # pylint: disable=import-outside-toplevel
-            msvcrt.locking(fd, msvcrt.LK_NBLCK, os.stat(fd).st_size)
         return fd, 0
     except OSError as ex_value:
         if os.name == 'nt':  # msvcrt doesn't set errno correctly
@@ -83,12 +83,12 @@ def lock_file(filename):
 def unlock_file(fd):
     """unlock file."""
     try:
-        if os.name != 'nt':
-            import fcntl  # pylint: disable=import-outside-toplevel
-            fcntl.flock(fd, fcntl.LOCK_UN)
-        elif os.name == 'nt':
+        if os.name == 'nt':
             import msvcrt  # pylint: disable=import-outside-toplevel
             msvcrt.locking(fd, msvcrt.LK_UNLCK, os.stat(fd).st_size)
+        else:
+            import fcntl  # pylint: disable=import-outside-toplevel
+            fcntl.flock(fd, fcntl.LOCK_UN)
         os.close(fd)
     except OSError:
         pass

--- a/src/blade/util.py
+++ b/src/blade/util.py
@@ -10,30 +10,30 @@
 
 """
 This is the util module which provides some helper functions.
+
+Performance note: this module is imported by the ``python -m blade.builtin_tools``
+subprocess that is spawned once per build action, so several comparatively heavy
+and only-occasionally-used stdlib modules (``inspect``, ``json``, ``signal``,
+``subprocess``, ``zipfile``) are imported lazily inside the functions that use
+them instead of at module load, to keep that startup cheap. Each such import is
+marked ``pylint: disable=import-outside-toplevel``. See issue #1159.
 """
 
 import ast
 import errno
 import hashlib
-import inspect
-import json
 import os
-import pickle  # re-exported; consumed via `blade.util.pickle` by external code
 import shutil
-import signal
-import subprocess
 import sys
-import zipfile
 from typing import TYPE_CHECKING
 
-try:
-    import fcntl
-except ImportError:
-    fcntl = None
-
-try:
+# Only one of these exists per platform; guard on os.name so we don't attempt
+# (and swallow) an import that is guaranteed to fail on the other platform.
+if os.name == 'nt':
     import msvcrt
-except ImportError:
+    fcntl = None
+else:
+    import fcntl
     msvcrt = None
 
 if TYPE_CHECKING:
@@ -164,6 +164,7 @@ def get_cwd():
     """
     if os.name == 'nt':
         return os.getcwd()
+    import subprocess  # pylint: disable=import-outside-toplevel
     p = subprocess.Popen(['pwd'], stdout=subprocess.PIPE)
     return to_string(p.communicate()[0].strip())
 
@@ -237,6 +238,8 @@ def _echo(stdout, stderr):
 
 
 def shell(cmd, env=None):
+    import signal  # pylint: disable=import-outside-toplevel
+    import subprocess  # pylint: disable=import-outside-toplevel
     if isinstance(cmd, list):
         cmdline = ' '.join(cmd)
     else:
@@ -260,7 +263,7 @@ def shell(cmd, env=None):
 
 def run_command(args, **kwargs):
     """Run a command without echo, return returncode, stdout and stderr (always as string)."""
-
+    import subprocess  # pylint: disable=import-outside-toplevel
     kwargs.setdefault('stdout', subprocess.PIPE)
     kwargs.setdefault('stderr', subprocess.PIPE)
 
@@ -269,6 +272,7 @@ def run_command(args, **kwargs):
 
 
 def load_scm(build_dir):
+    import json  # pylint: disable=import-outside-toplevel
     revision = url = 'unknown'
     path = os.path.join(build_dir, 'scm.json')
     if os.path.exists(path):
@@ -331,6 +335,7 @@ def source_location(filename):
     lineno = 1
 
     # See https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow
+    import inspect  # pylint: disable=import-outside-toplevel
     frame = inspect.currentframe()
     while frame:
         if frame.f_code.co_filename.endswith(filename):
@@ -345,6 +350,7 @@ def calling_source_location(skip=0):
     """Return source location of current call stack, skip specified levels (not include itself)."""
     skip += 1  # This function itself is excluded.
     skipped = 0
+    import inspect  # pylint: disable=import-outside-toplevel
     frame = inspect.currentframe()
     while frame:
         if skipped == skip:
@@ -381,6 +387,7 @@ def parse_command_line(argv):
 
 def open_zip_file_for_write(filename, compression_level):
     """Open a zip file for writing with specified compression level."""
+    import zipfile  # pylint: disable=import-outside-toplevel
     compression = zipfile.ZIP_DEFLATED
     return zipfile.ZipFile(filename, 'w', compression, compresslevel=int(compression_level), allowZip64=True)
 


### PR DESCRIPTION
## Summary

Every backend build edge that needs a builtin tool spawns `python -m blade.builtin_tools`; the hot one, `cc_inclusion_check`, runs **once per cc target**. This trims what that subprocess imports at startup:

- **`builtin_tools.py`**: `tarfile`/`socket`/`getpass`/`fnmatch`/`zipfile`/`subprocess` imported lazily inside the (cold) package/scm/java/python tools that use them; `import pickle` directly.
- **`util.py`**: `inspect`/`json`/`signal`/`subprocess`/`zipfile` imported lazily; dropped the `pickle` re-export (a Python 2 `cPickle` shim, no longer needed); `fcntl`/`msvcrt` imported inside the lock functions guarded by `os.name` instead of `try`/`except` importing both at module load.
- **`inclusion_check.py`**: inlined the two one-line helpers (`to_unix_path`, `path_under_dir`) so the hot check module no longer imports `util` at all.

The lazy-import rationale is documented in each module's docstring; every lazy import is marked `pylint: disable=import-outside-toplevel`.

## Measured (`import blade.builtin_tools`, `PYTHONPATH=src`)

| | modules in `sys.modules` |
| --- | --- |
| before | 148 |
| after | **126** |

Removed from startup: `zipfile` (and `pathlib` it pulls), `tarfile`, `socket`, `getpass`, `json`. The remaining `subprocess`/`signal`/`fnmatch`/`fcntl` come in via `blade.console` (terminal/diagnostics), which `builtin_tools` genuinely uses — removing those needs the `blade/__init__` → `blade.config`/`console` tier, tracked as a follow-up.

Interpreter **flags don't help**: `-S`/`-s` only trim site init; `-E`/`-I` disable `PYTHONPATH` (needed to find `blade`); frozen stdlib modules are already on in 3.11+. The lever is import hygiene.

## Test plan

- [x] `hdr_dep_check_test.py` passes (hot path: `cc_inclusion_check` + `pickle` + inlined helpers).
- [x] AST check: every lazified `mod.attr` usage has a matching local/top import (no missed cold path).
- [x] import smoke for `util` / `builtin_tools` / `inclusion_check`; `lock_file`/`unlock_file` functional.
- [ ] CI: unit + integration + Windows/macOS (exercises the cold java/python/package tools).

Closes #1159