### PR TITLE
Skip redundant inclusion checks (write-if-changed .H + ninja restat)

### DIFF
--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -70,7 +70,15 @@ else
     "$@" 2> "$err"
 fi
 ec=$?
-awk '%s' "$err" > "$out"
+awk '%s' "$err" > "$out.new"
+# write-if-changed: keep $out's mtime when the inclusion stack is unchanged, so
+# ninja's `restat` can prune the inclusion check on recompiles that don't alter
+# the set of included headers. See issue #1161.
+if [ -f "$out" ] && cmp -s "$out.new" "$out"; then
+    rm -f "$out.new"
+else
+    mv "$out.new" "$out"
+fi
 rm -f "$err"
 exit $ec
 ''' % _INCLUSION_SPLITTER_AWK
@@ -426,7 +434,11 @@ class _NinjaFileHeaderGenerator:
                            command=template % cc_command,
                            description='CC ${in}',
                            depfile='${out}.d',
-                           deps='gcc')
+                           deps='gcc',
+                           # restat lets ninja prune the inclusion check when the
+                           # compile's `${out}.H` inclusion stack is unchanged (it
+                           # is written write-if-changed). See issue #1161.
+                           restat=True)
 
         cxx_command = ('%s -o ${out} -MMD -MF ${out}.d -c -fPIC %s %s ${optimize} '
                        '${cxx_warnings} ${cppflags} %s ${includes} ${in}') % (
@@ -435,12 +447,14 @@ class _NinjaFileHeaderGenerator:
                            command=template % cxx_command,
                            description='CXX ${in}',
                            depfile='${out}.d',
-                           deps='gcc')
+                           deps='gcc',
+                           restat=True)  # see the cc rule / issue #1161
 
         self.generate_rule(name='secretcc',
                            command=template % (cc_config['secretcc'] + ' ' + cxx_command),
                            description='SECRET CC ${in}',
-                           depfile='${out}.d')
+                           depfile='${out}.d',
+                           restat=True)  # see the cc rule / issue #1161
 
         self._generate_cc_hdrs_rule(cc, cxx, cppflags, cflags, cxxflags, includes)
 
@@ -452,6 +466,10 @@ class _NinjaFileHeaderGenerator:
         self.generate_rule(name='cxxhdrs',
                            command=self._hdrs_command(cxx, cxxflags, cppflags, includes),
                            depfile='${out}.d', deps='gcc',
+                           # restat lets ninja prune the inclusion check when the
+                           # header's inclusion stack is unchanged (the wrapper
+                           # writes ${out} write-if-changed). See issue #1161.
+                           restat=True,
                            description='CXX HDRS ${in}')
 
     def _hdrs_command(self, cc, flags, cppflags, includes):

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -621,7 +621,13 @@ class CcTarget(Target):
             implicit_deps.append(self._source_file_path(self.attr['secret_revision_file']))
 
         objs_dir = self._target_file_path(self.name + '.objs')
+        # The cc/cxx compile wrapper writes a `<obj>.H` inclusion stack for real
+        # GCC/clang compiles; declaring it an implicit output (with `restat` on the
+        # rule) lets ninja prune the inclusion check when the stack is unchanged.
+        # See issue #1161. (Not produced for MSVC or compdb dump.)
+        emit_inclusion_stack = self._emits_inclusion_stack()
         objs = []
+        inclusion_stacks = []
         for src, full_src in expanded_srcs:
             # secret source is not really exist and is not target of any build, declare it as phony
             # to avoid file missing error
@@ -629,25 +635,44 @@ class CcTarget(Target):
                 self.generate_build('phony', full_src, inputs=[], clean=[])
             obj = os.path.join(objs_dir, self.blade.get_build_toolchain().object_file_of(src))
             rule = self._get_rule_from_suffix(src, secret)
+            stack = obj + '.H'
             self.generate_build(rule, obj, inputs=full_src,
                                 implicit_deps=implicit_deps,
                                 order_only_deps=order_only_deps,
+                                implicit_outputs=[stack] if emit_inclusion_stack else None,
                                 variables=vars, clean=[])
             objs.append(obj)
+            if emit_inclusion_stack:
+                inclusion_stacks.append(stack)
         self._remove_on_clean(objs_dir)
 
         if 'inclusion_check_info_file' in self.data:
-            return objs, self._generate_inclusion_check(objs_dir, objs, vars, order_only_deps)
+            return objs, self._generate_inclusion_check(
+                objs_dir, objs, vars, order_only_deps,
+                source_inclusion_stacks=inclusion_stacks if emit_inclusion_stack else None)
 
         return objs, None
+
+    def _emits_inclusion_stack(self):
+        """Whether the cc/cxx compile writes a `<obj>.H` inclusion stack.
+
+        True only for real GCC/clang compiles (the wrapper emits it). False for
+        MSVC (no `.H` from compilation) and for compdb dump (the wrapper, and thus
+        `-H`, is bypassed). See issue #1161.
+        """
+        if self.blade.get_build_toolchain().obj_suffix != '.o':
+            return False
+        return not (self.blade.get_command() == 'dump' and
+                    getattr(self.blade.get_options(), 'dump_compdb', False))
 
     def _generated_cc_objects(self, sources, generated_headers=None):
         """Compile generated cc sources"""
         expanded_sources = [(src, self._target_file_path(src)) for src in sources]
         return self._cc_objects(expanded_sources, generated_headers)[0]
 
-    def _generate_inclusion_check(self, objs_dir, objs, vars, order_only_deps):
-        implicit_deps = objs[:]
+    def _generate_inclusion_check(self, objs_dir, objs, vars, order_only_deps,
+                                  source_inclusion_stacks=None):
+        implicit_deps = []
         # Generate inclusion stack file for header files.
         for hdr, full_hdr in self.attr['expanded_hdrs']:
             if path_under_dir(full_hdr, self.build_dir):  # Don't check generated header files
@@ -656,10 +681,10 @@ class CcTarget(Target):
             implicit_deps.append(output)
             self.generate_build('cxxhdrs', output, inputs=full_hdr,
                                 order_only_deps=order_only_deps, variables=vars, clean=[])
-        # MSVC does not generate .H files during compilation (unlike GCC's -H wrapper),
-        # so we need an explicit cxxhdrs preprocess step for source files too.
         tc = self.blade.get_build_toolchain()
         if tc.obj_suffix != '.o':
+            # MSVC does not generate .H files during compilation (unlike GCC's -H wrapper),
+            # so we need an explicit cxxhdrs preprocess step for source files too.
             for src, full_src in self.attr['expanded_srcs']:
                 if path_under_dir(full_src, self.build_dir):
                     continue
@@ -667,6 +692,18 @@ class CcTarget(Target):
                 implicit_deps.append(output)
                 self.generate_build('cxxhdrs', output, inputs=full_src,
                                     order_only_deps=order_only_deps, variables=vars, clean=[])
+            implicit_deps += objs
+        elif source_inclusion_stacks is not None:
+            # GCC/clang: each compile declares its `<obj>.H` inclusion stack as an
+            # implicit output (written write-if-changed, with `restat` on the rule).
+            # Triggering the check on those instead of the `.o` lets ninja prune it
+            # when the inclusion set is unchanged, while still ordering it after the
+            # compile. See issue #1161.
+            implicit_deps += source_inclusion_stacks
+        else:
+            # Fallback (e.g. cuda, or compdb dump where no `.H` is produced): the
+            # `.o` is the ordering/trigger dep as before.
+            implicit_deps += objs
 
         check_info_file = self.data['inclusion_check_info_file']
         check_result_file = check_info_file + '.result'


### PR DESCRIPTION
## Summary

`ccincchk` (the C/C++ header inclusion check) re-ran on **every** recompile, because it depended on the `.o` — which changes on any source/header edit, even when the **set of included headers** (the only thing the check cares about) is unchanged. Most incremental edits touch a body, not includes, so most of those re-runs were redundant.

This makes the check trigger on the inclusion stack instead of the object:

- The cc/cxx compile wrapper writes `<obj>.H` **write-if-changed** (temp + `cmp` + replace only on change); the `cxxhdrs` rule writes `<hdr>.H` the same way.
- The `cc` / `cxx` / `secretcc` / `cxxhdrs` rules set `restat = 1`, so ninja re-stats the `.H` and prunes downstream when it is unchanged.
- `<obj>.H` is declared an **implicit output** of the cc/cxx compile (GCC/clang, non-compdb), and `ccincchk` now depends on the per-source `<obj>.H` plus the header `<hdr>.H` **instead of the `.o`**. ninja still orders `ccincchk` after the compile because the compile declares `.H` as an output.

MSVC, cuda and compdb-dump fall back to the previous `.o`-trigger behavior (via an optional param to `_generate_inclusion_check`), so their wiring is unchanged.

## Why restat is safe / no infinite regen

Validated with an isolated ninja experiment: a write-if-changed generator + `restat=1` prunes its consumer when content is unchanged, reports `no work to do` on a no-op rebuild (no infinite regeneration — `restat` + `.ninja_log` handle the "output older than input" case), and still triggers the consumer when content changes.

## Validation (blade-test/cc_basic, clang/macOS)

- Edit a `.cc` body (no include change) -> only `CXX hello.cc` reruns; **`ccincchk` pruned** (result mtime unchanged).
- Edit a `.h` body (no include change) -> `CXX HDRS` + `CXX` rerun; **`ccincchk` pruned**.
- `hdr_dep_check_test` still **fails with the expected messages** -> the check still runs on a fresh build and parses `.H` correctly, so violations are still caught (no false negatives).

## Test plan

- [x] isolated ninja restat experiment
- [x] blade-test/cc_basic: `.cc` and `.h` body edits prune `ccincchk`
- [x] `hdr_dep_check_test` passes (violations caught)
- [ ] CI: MSVC/Windows, cuda, compdb-dump (`dump_test`), full unit/integration

Closes #1161
