### PR TITLE
Add unused cc dependency check (part of #1155)

### DIFF
--- a/doc/en/build_rules/cc.md
+++ b/doc/en/build_rules/cc.md
@@ -225,6 +225,19 @@ If it belongs to other libraries, it should be added to `hdrs` of other librarie
 For undeclared header files that already existed in the code base before the upgrade, you can use the
 [cc_config.allowed_undeclared_hdrs](../config.md#cc_config) configuration item to mask the check.
 
+### Check unused dependencies
+
+The complement of the missing-dependency check above: Blade can also detect **redundant dependencies** — a library declared in `deps` whose public headers are never directly `#include`d by the target's sources or headers. Redundant deps slow down builds, leak unnecessary transitive dependencies, and rot over time.
+
+This check is **off by default**; enable it via [`cc_config.unused_deps_severity`](../config.md#cc_config): set it to `'warning'` for an advisory message, or `'error'` to fail the build. Advisory by default, like Bazel's `unused_deps` tool and Buck2.
+
+The following deps are never reported:
+
+- Libraries declared with an explicit empty `hdrs = []` (no public interface — e.g. a library depended on only for linking / static-initializer self-registration), since there is no header that could be used. Note `proto_library` has `.pb.h` and is still checked; a library with `hdrs` unset (`None`) is also still checked.
+- Deps listed in [`cc_config.unused_deps_suppress`](../config.md#cc_config) as a `{target: [deps]}` map of intentionally-kept deps (mainly for incrementally cleaning up an existing code base).
+
+> Tip: a library depended on for its link-time side effects (e.g. self-registration via global objects) without including its headers should itself declare `link_all_symbols = True` so the linker does not drop it. The check does **not** auto-exempt such libraries (many `link_all_symbols` libraries are in fact redundant deps), so if the dependency is genuinely intentional, list it in `unused_deps_suppress`.
+
 ## prebuilt_cc_library
 
 For libraries without source code, library should be put under the lib{32,64} sub dir accordingly.

--- a/doc/en/build_rules/cc.md
+++ b/doc/en/build_rules/cc.md
@@ -234,7 +234,19 @@ This check is **on by default at `'warning'`** (advisory — reported but does n
 The following deps are never reported:
 
 - Libraries declared with an explicit empty `hdrs = []` (no public interface — e.g. a library depended on only for linking / static-initializer self-registration), since there is no header that could be used. Note `proto_library` has `.pb.h` and is still checked; a library with `hdrs` unset (`None`) is also still checked.
-- Deps listed in [`cc_config.unused_deps_suppress`](../config.md#cc_config) as a `{target: [deps]}` map of intentionally-kept deps (mainly for incrementally cleaning up an existing code base).
+- Deps listed in a target's `keep_deps` attribute — deps you intentionally keep (e.g. linked but headers not directly used). `keep_deps` are real dependencies (built, linked, header-visible, just like `deps`); they are merged into the dependency graph but exempt from this check, and reading better than burying them in config:
+
+  ```python
+  cc_library(
+      name = 'foo',
+      srcs = ['foo.cc'],
+      hdrs = ['foo.h'],
+      deps = [':bar'],            # used via headers
+      keep_deps = [':baz'],       # intentionally linked, headers not included
+  )
+  ```
+
+- Deps listed in [`cc_config.unused_deps_suppress`](../config.md#cc_config) as a `{target: [deps]}` map (mainly for incrementally cleaning up an existing code base, where editing every BUILD file is impractical).
 
 > Tip: a library depended on for its link-time side effects (e.g. self-registration via global objects) without including its headers should itself declare `link_all_symbols = True` so the linker does not drop it. The check does **not** auto-exempt such libraries (many `link_all_symbols` libraries are in fact redundant deps), so if the dependency is genuinely intentional, list it in `unused_deps_suppress`.
 

--- a/doc/en/build_rules/cc.md
+++ b/doc/en/build_rules/cc.md
@@ -229,7 +229,7 @@ For undeclared header files that already existed in the code base before the upg
 
 The complement of the missing-dependency check above: Blade can also detect **redundant dependencies** — a library declared in `deps` whose public headers are never directly `#include`d by the target's sources or headers. Redundant deps slow down builds, leak unnecessary transitive dependencies, and rot over time.
 
-This check is **off by default**; enable it via [`cc_config.unused_deps_severity`](../config.md#cc_config): set it to `'warning'` for an advisory message, or `'error'` to fail the build. Advisory by default, like Bazel's `unused_deps` tool and Buck2.
+This check is **on by default at `'warning'`** (advisory — reported but does not fail the build); via [`cc_config.unused_deps_severity`](../config.md#cc_config) set it to `'error'` to fail the build, or `'debug'` to silence. Advisory by default, like Bazel's `unused_deps` tool and Buck2.
 
 The following deps are never reported:
 

--- a/doc/en/config.md
+++ b/doc/en/config.md
@@ -276,7 +276,7 @@ the ``name`` of a ``cc_toolchain_config()`` entry, or a toolchain kind
     library with `hdrs` unset (`None`) is also NOT exempt — that is the separate
     `cc_library_config.hdrs_missing_severity` warning);
   - deps listed in `unused_deps_suppress`;
-  - deps listed in a target's `keep_deps` attribute (provided later).
+  - deps listed in a target's `keep_deps` attribute (see [build_rules/cc.md](build_rules/cc.md#cc_library)).
 
 - `unused_deps_suppress`: dict = {}
 

--- a/doc/en/config.md
+++ b/doc/en/config.md
@@ -262,6 +262,35 @@ the ``name`` of a ``cc_toolchain_config()`` entry, or a toolchain kind
 
   Considering the long-term health of the code base, these problems should eventually be corrected.
 
+- `unused_deps_severity`: string = 'debug' | ['debug', 'info', 'notice', 'warning', 'error']
+
+  Severity of the unused dependency check: a dep declared in `deps` none of whose public headers
+  is directly `#include`d by the target. Defaults to `'debug'` (effectively off — the check is
+  skipped and the global declaration is not loaded); set to `'warning'` (advisory) or `'error'`
+  (enforce) to enable. Advisory by default, like Bazel's `unused_deps` tool and Buck2.
+
+  Exempt from the check:
+  - libraries declared with an explicit empty `hdrs = []` (no public interface, so there is no
+    header that could be used — note this does NOT exempt `proto_library`, which has `.pb.h`; a
+    library with `hdrs` unset (`None`) is also NOT exempt — that is the separate
+    `cc_library_config.hdrs_missing_severity` warning);
+  - deps listed in `unused_deps_suppress`;
+  - deps listed in a target's `keep_deps` attribute (provided later).
+
+- `unused_deps_suppress`: dict = {}
+
+  A `{target: [deps]}` map of intentionally-kept deps to exempt from the unused dependency check,
+  mainly for incrementally cleaning up an existing code base.
+
+  ```python
+  cc_config(
+      unused_deps_severity = 'warning',
+      unused_deps_suppress = {
+          '//app/foo:bar': ['//common/baz:qux'],
+      },
+  )
+  ```
+
 Example:
 
 ```python

--- a/doc/en/config.md
+++ b/doc/en/config.md
@@ -265,9 +265,10 @@ the ``name`` of a ``cc_toolchain_config()`` entry, or a toolchain kind
 - `unused_deps_severity`: string = 'debug' | ['debug', 'info', 'notice', 'warning', 'error']
 
   Severity of the unused dependency check: a dep declared in `deps` none of whose public headers
-  is directly `#include`d by the target. Defaults to `'debug'` (effectively off — the check is
-  skipped and the global declaration is not loaded); set to `'warning'` (advisory) or `'error'`
-  (enforce) to enable. Advisory by default, like Bazel's `unused_deps` tool and Buck2.
+  is directly `#include`d by the target. Defaults to `'warning'` (advisory — reported but does not
+  fail the build); set to `'error'` to fail the build on a redundant dep, or `'debug'` to silence
+  (the check is skipped and the global declaration is not loaded). Advisory by default, like
+  Bazel's `unused_deps` tool and Buck2.
 
   Exempt from the check:
   - libraries declared with an explicit empty `hdrs = []` (no public interface, so there is no

--- a/doc/zh_CN/build_rules/cc.md
+++ b/doc/zh_CN/build_rules/cc.md
@@ -206,7 +206,19 @@ Blade 能检查到两种缺失情况：
 以下依赖不会被报告：
 
 - 以**显式空 `hdrs = []`** 声明的「无公开接口」库——它没有可被使用的公开头文件（典型如仅用于链接、靠静态初始化自注册的库）。注意 `proto_library` 有 `.pb.h`，仍会被检查；`hdrs` 未声明（`None`）的库也仍会被检查。
-- 在 [`cc_config.unused_deps_suppress`](../config.md#cc_config) 中按 `{target: [deps]}` 列出的、有意保留的依赖（主要用于存量代码的逐步治理）。
+- 列在目标 `keep_deps` 属性中的依赖——你**有意保留**的依赖（例如需要链接、但不直接包含其头文件）。`keep_deps` 是真实依赖（和 `deps` 一样会被构建、链接、头文件可见），只是会被合并进依赖图、同时豁免本检查；相比埋在 config 里，写在目标处更自文档化：
+
+  ```python
+  cc_library(
+      name = 'foo',
+      srcs = ['foo.cc'],
+      hdrs = ['foo.h'],
+      deps = [':bar'],            # 通过头文件使用
+      keep_deps = [':baz'],       # 有意链接，但不包含其头文件
+  )
+  ```
+
+- 在 [`cc_config.unused_deps_suppress`](../config.md#cc_config) 中按 `{target: [deps]}` 列出的依赖（主要用于存量代码的逐步治理——逐个改 BUILD 不现实时）。
 
 > 提示：有的库是为了链接其副作用（例如靠全局对象自注册）而被依赖、并不包含其头文件。这类库为了不被链接器丢弃，本身应声明 `link_all_symbols = True`；但该检查**不会**因此自动豁免它（很多 `link_all_symbols` 的库其实是多余依赖），所以如果确属有意保留，请将其列入 `unused_deps_suppress`。
 

--- a/doc/zh_CN/build_rules/cc.md
+++ b/doc/zh_CN/build_rules/cc.md
@@ -197,6 +197,19 @@ Blade 能检查到两种缺失情况：
 根据其是公开或者私有的，分别将其加入到 `hdrs` 或者 `srcs` 中；如果属于其他库，则应当加入到其他库的 `hdrs` 中，不能包含其他库的未声明的私有头文件。
 对于升级前代码库中已经存在的未声明的头文件，可以用 [cc_config.allowed_undeclared_hdrs](../config.md#cc_config) 配置项屏蔽检查。
 
+### 检查未使用的依赖
+
+与上面「缺失依赖」相对，Blade 还能检查**多余的依赖**：在 `deps` 中声明了某个库，但本目标的源文件和头文件并没有直接 `#include` 它的任何公开头文件。多余依赖会拖慢构建、传递不必要的依赖，长期容易腐化。
+
+该检查默认**关闭**，通过 [`cc_config.unused_deps_severity`](../config.md#cc_config) 启用：设为 `'warning'` 仅提示，`'error'` 则让构建失败。与 Bazel 的 `unused_deps`、Buck2 一致，默认是建议性的。
+
+以下依赖不会被报告：
+
+- 以**显式空 `hdrs = []`** 声明的「无公开接口」库——它没有可被使用的公开头文件（典型如仅用于链接、靠静态初始化自注册的库）。注意 `proto_library` 有 `.pb.h`，仍会被检查；`hdrs` 未声明（`None`）的库也仍会被检查。
+- 在 [`cc_config.unused_deps_suppress`](../config.md#cc_config) 中按 `{target: [deps]}` 列出的、有意保留的依赖（主要用于存量代码的逐步治理）。
+
+> 提示：有的库是为了链接其副作用（例如靠全局对象自注册）而被依赖、并不包含其头文件。这类库为了不被链接器丢弃，本身应声明 `link_all_symbols = True`；但该检查**不会**因此自动豁免它（很多 `link_all_symbols` 的库其实是多余依赖），所以如果确属有意保留，请将其列入 `unused_deps_suppress`。
+
 ## prebuilt_cc_library
 
 主要用于描述一些没有源代码或者或者是通过别的构建系统已经构建好的第三方库。

--- a/doc/zh_CN/build_rules/cc.md
+++ b/doc/zh_CN/build_rules/cc.md
@@ -201,7 +201,7 @@ Blade 能检查到两种缺失情况：
 
 与上面「缺失依赖」相对，Blade 还能检查**多余的依赖**：在 `deps` 中声明了某个库，但本目标的源文件和头文件并没有直接 `#include` 它的任何公开头文件。多余依赖会拖慢构建、传递不必要的依赖，长期容易腐化。
 
-该检查默认**关闭**，通过 [`cc_config.unused_deps_severity`](../config.md#cc_config) 启用：设为 `'warning'` 仅提示，`'error'` 则让构建失败。与 Bazel 的 `unused_deps`、Buck2 一致，默认是建议性的。
+该检查默认即以 `'warning'`（建议性）开启：会提示但不导致构建失败。通过 [`cc_config.unused_deps_severity`](../config.md#cc_config) 可设为 `'error'` 让构建失败，或设为 `'debug'` 关闭。与 Bazel 的 `unused_deps`、Buck2 一致，默认是建议性的。
 
 以下依赖不会被报告：
 

--- a/doc/zh_CN/config.md
+++ b/doc/zh_CN/config.md
@@ -286,7 +286,7 @@ cc_config(
 
 - 以**显式空 `hdrs = []`** 声明的「无公开接口」库：它没有可被使用的公开头文件，报告它纯属噪音。注意 `proto_library` 因为有 `.pb.h`，**不**在此列，仍会被检查；`hdrs` **未声明（None）** 的库也不在豁免之列——那是 [`cc_library_config.hdrs_missing_severity`](#cc_library_config) 所管的另一类问题。
 - 列在 `unused_deps_suppress` 中的依赖；
-- 列在目标 `keep_deps` 属性中的依赖（该属性后续提供）。
+- 列在目标 `keep_deps` 属性中的依赖（见 [build_rules/cc.md](build_rules/cc.md#cc_library)）。
 
 #### `unused_deps_suppress`：dict = {}
 

--- a/doc/zh_CN/config.md
+++ b/doc/zh_CN/config.md
@@ -280,7 +280,7 @@ cc_config(
 
 **未使用依赖检查的严重性**
 
-**用途：** 检查「在 `deps` 中声明、但其任何公开头文件都没有被本目标直接 `#include`」的多余依赖。可取值为 `debug` / `info` / `notice` / `warning` / `error`。默认 `'debug'`（相当于关闭：不产生输出，也不会因此加载全局声明文件）；设为 `'warning'`（仅提示）或 `'error'`（构建失败）以启用。与 Bazel 的 `unused_deps`、Buck2 一致，默认是建议性的、不强制。
+**用途：** 检查「在 `deps` 中声明、但其任何公开头文件都没有被本目标直接 `#include`」的多余依赖。可取值为 `debug` / `info` / `notice` / `warning` / `error`。默认 `'warning'`（建议性：会提示但不导致构建失败）；设为 `'error'` 可让多余依赖导致构建失败，或设为 `'debug'` 关闭（不产生输出，也不加载全局声明文件）。与 Bazel 的 `unused_deps`、Buck2 一致，默认是建议性的、不强制。
 
 **豁免：** 以下依赖不会被报告——
 

--- a/doc/zh_CN/config.md
+++ b/doc/zh_CN/config.md
@@ -276,6 +276,33 @@ cc_config(
 
 从代码库长期健康的角度，最终还是应当把这些问题彻底修正。
 
+#### `unused_deps_severity`：string = 'debug'
+
+**未使用依赖检查的严重性**
+
+**用途：** 检查「在 `deps` 中声明、但其任何公开头文件都没有被本目标直接 `#include`」的多余依赖。可取值为 `debug` / `info` / `notice` / `warning` / `error`。默认 `'debug'`（相当于关闭：不产生输出，也不会因此加载全局声明文件）；设为 `'warning'`（仅提示）或 `'error'`（构建失败）以启用。与 Bazel 的 `unused_deps`、Buck2 一致，默认是建议性的、不强制。
+
+**豁免：** 以下依赖不会被报告——
+
+- 以**显式空 `hdrs = []`** 声明的「无公开接口」库：它没有可被使用的公开头文件，报告它纯属噪音。注意 `proto_library` 因为有 `.pb.h`，**不**在此列，仍会被检查；`hdrs` **未声明（None）** 的库也不在豁免之列——那是 [`cc_library_config.hdrs_missing_severity`](#cc_library_config) 所管的另一类问题。
+- 列在 `unused_deps_suppress` 中的依赖；
+- 列在目标 `keep_deps` 属性中的依赖（该属性后续提供）。
+
+#### `unused_deps_suppress`：dict = {}
+
+**未使用依赖检查的抑制列表**
+
+**用途：** 形如 `{target: [deps]}` 的映射，把「有意保留」的依赖从未使用依赖检查中豁免，主要用于存量代码库的逐步治理。
+
+```python
+cc_config(
+    unused_deps_severity = 'warning',
+    unused_deps_suppress = {
+        '//app/foo:bar': ['//common/baz:qux'],
+    },
+)
+```
+
 示例：
 
 ```python

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -123,7 +123,7 @@ def declare_private_hdrs(target, hdrs):
         _private_hdrs_target_map[hdr].add(target.key)
 
 
-def declare_header_less(target):
+def declare_header_less(target: 'CcTarget') -> None:
     """Declare a library as having no public headers (explicit `hdrs = []`)."""
     _header_less_target_keys.add(target.key)
 

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -822,7 +822,7 @@ class CcTarget(Target):
             'unused_deps_severity': config.get_item('cc_config', 'unused_deps_severity'),
             'unused_deps_suppress':
                 config.get_item('cc_config', 'unused_deps_suppress').get(self.key, []),
-            'keep_deps': self.attr.get('keep_deps', []),  # populated once keep_deps attr lands
+            'keep_deps': self.attr.get('keep_deps', []),
         }
         content = pickle.dumps(target_check_info)
 
@@ -1208,6 +1208,7 @@ def cc_library(
         srcs: StrOrListOpt = None,
         hdrs: StrOrListOpt = None,
         deps: StrOrListOpt = None,
+        keep_deps: StrOrListOpt = None,
         visibility: StrOrListOpt = None,
         tags: StrOrListOpt = None,
         warning: str = 'yes',
@@ -1243,6 +1244,10 @@ def cc_library(
             trigger recompilation.
     """
     # pylint: disable=too-many-locals
+    # `keep_deps` are real deps (built/linked/header-visible) merged into `deps`,
+    # but recorded so the unused-deps check exempts them. See issue #1155.
+    keep_deps = var_to_list(keep_deps)
+    deps = var_to_list(deps) + keep_deps
     if pre_build or prebuilt:
         target = prebuilt_cc_library(
                 name=name,
@@ -1282,6 +1287,7 @@ def cc_library(
             secret=secret or secure,
             secret_revision_file=secret_revision_file,
             kwargs=kwargs)
+    target.attr['keep_deps'] = [target._unify_dep(d) for d in keep_deps]
     build_manager.instance.register_target(target)
 
 
@@ -1618,6 +1624,7 @@ class CcBinary(CcTarget):
 def cc_binary(name: str,
               srcs: StrOrListOpt = None,
               deps: StrOrListOpt = None,
+              keep_deps: StrOrListOpt = None,
               visibility: StrOrListOpt = None,
               tags: StrOrListOpt = None,
               warning: str = 'yes',
@@ -1634,10 +1641,11 @@ def cc_binary(name: str,
               export_dynamic: bool = False,
               **kwargs: object):
     """cc_binary target."""
+    keep_deps = var_to_list(keep_deps)
     cc_binary_target = CcBinary(
             name=name,
             srcs=srcs,
-            deps=deps,
+            deps=var_to_list(deps) + keep_deps,
             visibility=visibility,
             tags=tags,
             warning=warning,
@@ -1653,6 +1661,7 @@ def cc_binary(name: str,
             version_scripts=version_scripts,
             export_dynamic=export_dynamic,
             kwargs=kwargs)
+    cc_binary_target.attr['keep_deps'] = [cc_binary_target._unify_dep(d) for d in keep_deps]
     build_manager.instance.register_target(cc_binary_target)
 
 
@@ -1808,6 +1817,7 @@ def cc_plugin(
         name: str,
         srcs: 'StrOrListOpt' = None,
         deps: 'StrOrListOpt' = None,
+        keep_deps: 'StrOrListOpt' = None,
         visibility: 'StrOrListOpt' = None,
         tags: 'StrOrListOpt' = None,
         warning: str = 'yes',
@@ -1825,10 +1835,11 @@ def cc_plugin(
         strip: bool = False,
         **kwargs: object):
     """cc_plugin target."""
+    keep_deps = var_to_list(keep_deps)
     target = CcPlugin(
             name=name,
             srcs=srcs,
-            deps=deps,
+            deps=var_to_list(deps) + keep_deps,
             visibility=visibility,
             tags=tags,
             warning=warning,
@@ -1845,6 +1856,7 @@ def cc_plugin(
             allow_undefined=allow_undefined,
             strip=strip,
             kwargs=kwargs)
+    target.attr['keep_deps'] = [target._unify_dep(d) for d in keep_deps]
     build_manager.instance.register_target(target)
 
 
@@ -1940,6 +1952,7 @@ class CcTest(CcBinary):
 def cc_test(name: str,
             srcs: StrOrListOpt = None,
             deps: StrOrListOpt = None,
+            keep_deps: StrOrListOpt = None,
             visibility: StrOrListOpt = None,
             tags: StrOrListOpt = None,
             warning: str = 'yes',
@@ -1960,10 +1973,11 @@ def cc_test(name: str,
             **kwargs: object):
     """cc_test target."""
     # pylint: disable=too-many-locals
+    keep_deps = var_to_list(keep_deps)
     cc_test_target = CcTest(
             name=name,
             srcs=srcs,
-            deps=deps,
+            deps=var_to_list(deps) + keep_deps,
             visibility=visibility,
             tags=tags,
             warning=warning,
@@ -1982,6 +1996,7 @@ def cc_test(name: str,
             heap_check=heap_check,
             heap_check_debug=heap_check_debug,
             kwargs=kwargs)
+    cc_test_target.attr['keep_deps'] = [cc_test_target._unify_dep(d) for d in keep_deps]
     build_manager.instance.register_target(cc_test_target)
 
 

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -107,6 +107,12 @@ def find_libs_by_header(hdr):
 # dict(hdr, set(targets))
 _private_hdrs_target_map = {}
 
+# set(target_key): libraries declared with an explicit empty `hdrs = []`, i.e.
+# "no public interface". Such a lib can never be header-used, so the unused-deps
+# check exempts it (flagging it would be pure noise). NOTE: a lib with `hdrs`
+# unset (None) is NOT recorded here -- that is a separate `hdrs_missing` warning.
+_header_less_target_keys = set()
+
 
 def declare_private_hdrs(target, hdrs):
     """Declare private header files of a cc target."""
@@ -117,11 +123,17 @@ def declare_private_hdrs(target, hdrs):
         _private_hdrs_target_map[hdr].add(target.key)
 
 
+def declare_header_less(target):
+    """Declare a library as having no public headers (explicit `hdrs = []`)."""
+    _header_less_target_keys.add(target.key)
+
+
 def inclusion_declaration():
     return {
         'public_hdrs': _hdr_targets_map,
         'public_incs': _hdr_dir_targets_map,
         'private_hdrs': _private_hdrs_target_map,
+        'header_less': _header_less_target_keys,
         'allowed_undeclared_hdrs': config.get_item('cc_config', 'allowed_undeclared_hdrs')
     }
 
@@ -290,6 +302,10 @@ class CcTarget(Target):
                 getattr(self, severity)(
                         'Missing "hdrs" declaration. The public header files should be declared '
                         'explicitly, if no public header file, set "hdrs" to empty (hdrs = [])')
+        elif not hdrs:
+            # Explicit `hdrs = []`: the library declares it has no public interface,
+            # so the unused-deps check exempts it. See `_header_less_target_keys`.
+            declare_header_less(self)
         if not hdrs:
             return
         hdrs = var_to_list(hdrs)
@@ -803,6 +819,10 @@ class CcTarget(Target):
             'declared_genincs': declared_genincs,
             'severity': config.get_item('cc_config', 'hdr_dep_missing_severity'),
             'suppress': verify_suppress.get(self.key, {}),
+            'unused_deps_severity': config.get_item('cc_config', 'unused_deps_severity'),
+            'unused_deps_suppress':
+                config.get_item('cc_config', 'unused_deps_suppress').get(self.key, []),
+            'keep_deps': self.attr.get('keep_deps', []),  # populated once keep_deps attr lands
         }
         content = pickle.dumps(target_check_info)
 

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -106,6 +106,13 @@ _CONFIG_TEMPLATE = {
         'hdr_dep_missing_suppress__help__': 'Header deps missing suppress control, see docs for details',
         'allowed_undeclared_hdrs': set(),
         'allowed_undeclared_hdrs__help__': 'Allowed undeclared header files',
+        'unused_deps_severity': 'debug',
+        'unused_deps_severity__help__': 'Severity of the unused dependency check (a dep declared '
+            'in "deps" none of whose public headers is directly included), can be %s. Defaults to '
+            '"debug" (effectively off); set to "warning" or "error" to enable.' % constants.SEVERITIES,
+        'unused_deps_suppress': {},
+        'unused_deps_suppress__help__': 'Unused deps suppress control, a {target: [deps]} map of '
+            'intentionally-kept deps to exempt from the unused dependency check',
     },
 
     'cc_library_config': {

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -106,10 +106,11 @@ _CONFIG_TEMPLATE = {
         'hdr_dep_missing_suppress__help__': 'Header deps missing suppress control, see docs for details',
         'allowed_undeclared_hdrs': set(),
         'allowed_undeclared_hdrs__help__': 'Allowed undeclared header files',
-        'unused_deps_severity': 'debug',
+        'unused_deps_severity': 'warning',
         'unused_deps_severity__help__': 'Severity of the unused dependency check (a dep declared '
             'in "deps" none of whose public headers is directly included), can be %s. Defaults to '
-            '"debug" (effectively off); set to "warning" or "error" to enable.' % constants.SEVERITIES,
+            '"warning" (advisory); set to "error" to enforce, or "debug" to silence.'
+            % constants.SEVERITIES,
         'unused_deps_suppress': {},
         'unused_deps_suppress__help__': 'Unused deps suppress control, a {target: [deps]} map of '
             'intentionally-kept deps to exempt from the unused dependency check',

--- a/src/blade/inclusion_check.py
+++ b/src/blade/inclusion_check.py
@@ -59,6 +59,7 @@ class GlobalDeclaration:
         self._hdr_targets_map = declaration['public_hdrs']
         self._hdr_dir_targets_map = declaration['public_incs']
         self._private_hdrs_target_map = declaration['private_hdrs']
+        self._header_less = declaration.get('header_less', set())
         self._allowed_undeclared_hdrs = declaration['allowed_undeclared_hdrs']
         self._initialized = True
 
@@ -74,6 +75,11 @@ class GlobalDeclaration:
     def is_allowed_undeclared_hdr(self, hdr):
         self.lazy_init('is_allowed_undeclared_hdr ' + hdr)
         return hdr in self._allowed_undeclared_hdrs
+
+    def is_header_less(self, key):
+        """Whether a library was declared with an explicit empty `hdrs = []`."""
+        self.lazy_init('is_header_less ' + key)
+        return key in self._header_less
 
 
 _MSVC_INCUSION_PREFIX = 'Note: including file:'
@@ -254,6 +260,10 @@ class Checker:
         self.allowed_undeclared_hdrs = target['allowed_undeclared_hdrs']
         self.suppress = target['suppress']
         self.severity = target['severity']
+        # Unused-deps check (forward-compatible defaults for older incchk files).
+        self.unused_deps_severity = target.get('unused_deps_severity', 'debug')
+        self.unused_deps_suppress = set(target.get('unused_deps_suppress', []))
+        self.keep_deps = set(target.get('keep_deps', []))
 
         inclusion_declaration_file = os.path.join(self.build_dir, 'inclusion_declaration.data')
         self.global_declaration = GlobalDeclaration(inclusion_declaration_file)
@@ -391,6 +401,26 @@ class Checker:
                 msg.append(prefix % ('"%s"' % full_src))
         check_msg += msg
 
+    def _beautify_lib(self, lib):
+        """Render a lib key as ":name" (same dir) or "//path:name"."""
+        if lib.startswith(self.path + ':'):
+            return '"%s"' % lib[len(self.path):]
+        return '"//%s"' % lib
+
+    def _check_unused_deps(self, all_direct_hdrs):
+        """Return declared deps none of whose public headers is directly included.
+
+        Exemptions: `keep_deps`, configured `unused_deps_suppress`, the target
+        itself, and header-less libraries (declared `hdrs = []` -- they have no
+        public header that could be used, so flagging them would be pure noise).
+        """
+        used = set()
+        for hdr in all_direct_hdrs:
+            used |= self.find_libs_by_header(hdr)
+        candidates = set(self.deps) - used - self.keep_deps - self.unused_deps_suppress
+        candidates.discard(self.key)
+        return {dep for dep in candidates if not self.global_declaration.is_header_less(dep)}
+
     def check(self):
         """
         Check whether included header files is declared in "deps" correctly.
@@ -445,13 +475,26 @@ class Checker:
             console.diagnose(self.source_location, severity,
                 '{}: Missing indirect dependency declaration:\n{}'.format(self.name, '\n'.join(generated_check_msg)))
 
+        unused_deps = set()
+        if self.unused_deps_severity != 'debug':  # 'debug' == effectively off
+            unused_deps = self._check_unused_deps(all_direct_hdrs)
+            if unused_deps:
+                console.diagnose(self.source_location, self.unused_deps_severity,
+                    '{}: Unused dependency (declared in "deps" but none of its public headers is '
+                    'directly included):\n{}'.format(
+                        self.name, '\n'.join('  ' + self._beautify_lib(d) for d in sorted(unused_deps))))
+
         ok = (severity != 'error' or not direct_check_msg and not generated_check_msg)
+        if self.unused_deps_severity == 'error' and unused_deps:
+            ok = False
 
         details = {}
         if missing_details:
             details['missing_dep'] = missing_details
         if undeclared_hdrs:
             details['undeclared'] = sorted(undeclared_hdrs)
+        if unused_deps:
+            details['unused_deps'] = sorted(unused_deps)
         details['direct_hdrs'] = all_direct_hdrs
         details['generated_hdrs'] = all_generated_hdrs
         return ok, details

--- a/src/blade/inclusion_check.py
+++ b/src/blade/inclusion_check.py
@@ -76,7 +76,7 @@ class GlobalDeclaration:
         self.lazy_init('is_allowed_undeclared_hdr ' + hdr)
         return hdr in self._allowed_undeclared_hdrs
 
-    def is_header_less(self, key):
+    def is_header_less(self, key: str) -> bool:
         """Whether a library was declared with an explicit empty `hdrs = []`."""
         self.lazy_init('is_header_less ' + key)
         return key in self._header_less
@@ -401,13 +401,13 @@ class Checker:
                 msg.append(prefix % ('"%s"' % full_src))
         check_msg += msg
 
-    def _beautify_lib(self, lib):
+    def _beautify_lib(self, lib: str) -> str:
         """Render a lib key as ":name" (same dir) or "//path:name"."""
         if lib.startswith(self.path + ':'):
             return '"%s"' % lib[len(self.path):]
         return '"//%s"' % lib
 
-    def _check_unused_deps(self, all_direct_hdrs):
+    def _check_unused_deps(self, all_direct_hdrs: 'set[str]') -> 'set[str]':
         """Return declared deps none of whose public headers is directly included.
 
         Exemptions: `keep_deps`, configured `unused_deps_suppress`, the target

--- a/src/tests/unit/unused_deps_test.py
+++ b/src/tests/unit/unused_deps_test.py
@@ -16,6 +16,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+from typing import Sequence
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
@@ -32,7 +33,8 @@ class UnusedDepsTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def _checker(self, deps, header_less=(), keep_deps=(), suppress=()):
+    def _checker(self, deps: Sequence[str], header_less: Sequence[str] = (),
+                 keep_deps: Sequence[str] = (), suppress: Sequence[str] = ()) -> inclusion_check.Checker:
         """Build a Checker over a fabricated global declaration.
 
         Each non-header-less dep ``pkg:x`` owns the public header ``pkg/x.h``.
@@ -67,7 +69,7 @@ class UnusedDepsTest(unittest.TestCase):
         }
         return inclusion_check.Checker(target)
 
-    def _hdr(self, dep):
+    def _hdr(self, dep: str) -> str:
         return '%s/%s.h' % (self.path, dep.split(':')[-1])
 
     def test_used_dep_not_flagged(self):

--- a/src/tests/unit/unused_deps_test.py
+++ b/src/tests/unit/unused_deps_test.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+
+"""Unit tests for the unused cc dependency check (issue #1155).
+
+Exercises ``inclusion_check.Checker._check_unused_deps`` in isolation: a dep is
+flagged only when none of its public headers is directly included, and is
+exempt when it is header-less (``hdrs = []``), listed in ``keep_deps``, or
+suppressed via config; the target itself is never flagged.
+"""
+
+import os
+import pickle
+import shutil
+import sys
+import tempfile
+import unittest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import inclusion_check  # noqa: E402
+
+
+class UnusedDepsTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.path = 'pkg'
+        self.key = 'pkg:t'
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _checker(self, deps, header_less=(), keep_deps=(), suppress=()):
+        """Build a Checker over a fabricated global declaration.
+
+        Each non-header-less dep ``pkg:x`` owns the public header ``pkg/x.h``.
+        """
+        header_less = set(header_less)
+        public_hdrs = {}
+        for dep in deps:
+            if dep in header_less:
+                continue
+            name = dep.split(':')[-1]
+            public_hdrs.setdefault('%s/%s.h' % (self.path, name), set()).add(dep)
+        declaration = {
+            'public_hdrs': public_hdrs,
+            'public_incs': {},
+            'private_hdrs': {},
+            'header_less': header_less,
+            'allowed_undeclared_hdrs': set(),
+        }
+        with open(os.path.join(self.tmp, 'inclusion_declaration.data'), 'wb') as f:
+            pickle.dump(declaration, f)
+        target = {
+            'type': 'cc_library', 'name': 't', 'path': self.path, 'key': self.key,
+            'deps': list(deps), 'build_dir': self.tmp, 'source_location': 'pkg/BUILD:1',
+            'expanded_srcs': [], 'expanded_hdrs': [],
+            'declared_hdrs': set(), 'declared_incs': set(),
+            'declared_genhdrs': set(), 'declared_genincs': set(),
+            'hdrs_deps': {}, 'private_hdrs_deps': {}, 'allowed_undeclared_hdrs': {},
+            'suppress': {}, 'severity': 'error',
+            'unused_deps_severity': 'warning',
+            'unused_deps_suppress': list(suppress),
+            'keep_deps': list(keep_deps),
+        }
+        return inclusion_check.Checker(target)
+
+    def _hdr(self, dep):
+        return '%s/%s.h' % (self.path, dep.split(':')[-1])
+
+    def test_used_dep_not_flagged(self):
+        c = self._checker(['pkg:a'])
+        self.assertEqual(c._check_unused_deps({self._hdr('pkg:a')}), set())
+
+    def test_unused_dep_flagged(self):
+        c = self._checker(['pkg:a', 'pkg:b'])
+        # Only a's header is included -> b is unused.
+        self.assertEqual(c._check_unused_deps({self._hdr('pkg:a')}), {'pkg:b'})
+
+    def test_header_less_dep_exempt(self):
+        c = self._checker(['pkg:a', 'pkg:hl'], header_less=['pkg:hl'])
+        # hl has no public headers (hdrs = []) -> exempt even though unused.
+        self.assertEqual(c._check_unused_deps({self._hdr('pkg:a')}), set())
+
+    def test_keep_deps_exempt(self):
+        c = self._checker(['pkg:a', 'pkg:b'], keep_deps=['pkg:b'])
+        self.assertEqual(c._check_unused_deps({self._hdr('pkg:a')}), set())
+
+    def test_suppress_exempt(self):
+        c = self._checker(['pkg:a', 'pkg:b'], suppress=['pkg:b'])
+        self.assertEqual(c._check_unused_deps({self._hdr('pkg:a')}), set())
+
+    def test_self_never_flagged(self):
+        # The target may own its own headers; depending on self is never "unused".
+        c = self._checker([self.key, 'pkg:b'])
+        self.assertEqual(c._check_unused_deps(set()), {'pkg:b'})
+
+    def test_multiple_unused(self):
+        c = self._checker(['pkg:a', 'pkg:b', 'pkg:c'])
+        self.assertEqual(c._check_unused_deps({self._hdr('pkg:a')}), {'pkg:b', 'pkg:c'})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/unit/unused_deps_test.py
+++ b/src/tests/unit/unused_deps_test.py
@@ -39,10 +39,10 @@ class UnusedDepsTest(unittest.TestCase):
 
         Each non-header-less dep ``pkg:x`` owns the public header ``pkg/x.h``.
         """
-        header_less = set(header_less)
+        header_less_keys = set(header_less)
         public_hdrs = {}
         for dep in deps:
-            if dep in header_less:
+            if dep in header_less_keys:
                 continue
             name = dep.split(':')[-1]
             public_hdrs.setdefault('%s/%s.h' % (self.path, name), set()).add(dep)
@@ -50,7 +50,7 @@ class UnusedDepsTest(unittest.TestCase):
             'public_hdrs': public_hdrs,
             'public_incs': {},
             'private_hdrs': {},
-            'header_less': header_less,
+            'header_less': header_less_keys,
             'allowed_undeclared_hdrs': set(),
         }
         with open(os.path.join(self.tmp, 'inclusion_declaration.data'), 'wb') as f:


### PR DESCRIPTION
## Summary

Adds the **unused cc dependency check**: flag a dep declared in `deps` when **none of its public headers is directly included** by the target's `srcs`/`hdrs`. It reuses the data already gathered by the inclusion check (`Checker.check`): `used = owners of the directly-included headers`, `unused = deps - used`.

Gated by **`cc_config.unused_deps_severity`** (default `'warning'` — advisory, on by default; `'error'` to enforce, `'debug'` to silence). Advisory-by-default matches Bazel's `unused_deps` tool and Buck2.

## Exemptions (avoiding false positives)

- **Header-less libraries** — a lib declared with an explicit `hdrs = []` has no public interface, so nothing could be used; flagging it would be noise. Recorded via a `header_less` set in the global inclusion declaration. `hdrs` unset (`None`) is **not** exempt (that's the separate `hdrs_missing` warning), and `proto_library` (has `.pb.h`) stays flaggable.
- **`keep_deps`** — a per-target attribute on `cc_library` / `cc_binary` / `cc_test` / `cc_plugin` for deps you intentionally keep (e.g. linked but headers not directly used). Modeled on java's `provided_deps`: merged into `deps` so they are real dependencies (built, linked, header-visible) and resolved label→key via `_unify_dep`, but exempt from this check.
- **`cc_config.unused_deps_suppress`** — a `{target: [deps]}` map for bulk grandfathering of existing code.

## Validation

- **Unit tests** — `src/tests/unit/unused_deps_test.py` (7 cases): used/unused/header-less/keep_deps/suppress/self/multiple.
- **End-to-end** (clang): a `keep_deps` dep is exempt and still built/linked; a header-less dep is exempt; a non-kept unused dep is flagged; build green at `warning`.
- **Regression** — `hdr_dep_check_test` still catches missing-dep violations.
- Docs: `config.md` + `build_rules/cc.md` (zh + en).

Closes #1155
Closes #704
