### PR TITLE
Fix source inclusion-file lookup on MSVC (.obj vs .o suffix)

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -817,6 +817,9 @@ class CcTarget(Target):
             'declared_incs': declared_incs,
             'declared_genhdrs': declared_genhdrs,
             'declared_genincs': declared_genincs,
+            # The per-source inclusion file is named `<src><obj_suffix>.H`; carry
+            # the suffix so the checker finds it on MSVC (.obj) too, not just GCC (.o).
+            'obj_suffix': self.blade.get_build_toolchain().obj_suffix,
             'severity': config.get_item('cc_config', 'hdr_dep_missing_severity'),
             'suppress': verify_suppress.get(self.key, {}),
             'unused_deps_severity': config.get_item('cc_config', 'unused_deps_severity'),

--- a/src/blade/inclusion_check.py
+++ b/src/blade/inclusion_check.py
@@ -260,6 +260,9 @@ class Checker:
         self.allowed_undeclared_hdrs = target['allowed_undeclared_hdrs']
         self.suppress = target['suppress']
         self.severity = target['severity']
+        # `<src><obj_suffix>.H` (.o on GCC/clang, .obj on MSVC); default '.o' for
+        # forward compatibility with older incchk files.
+        self.obj_suffix = target.get('obj_suffix', '.o')
         # Unused-deps check (forward-compatible defaults for older incchk files).
         self.unused_deps_severity = target.get('unused_deps_severity', 'debug')
         self.unused_deps_suppress = set(target.get('unused_deps_suppress', []))
@@ -276,9 +279,11 @@ class Checker:
         https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html
         for details.
         """
-        # NOTE: The inclusion file for header file and impl file has different extension name.
+        # NOTE: a header's inclusion file is `<hdr>.H`; a source's is
+        # `<src><obj_suffix>.H` (`.o.H` on GCC/clang, `.obj.H` on MSVC).
         objs_dir = os.path.join(self.build_dir, self.path, self.name + '.objs')
-        path = ('%s.H' if is_header else '%s.o.H') % os.path.join(objs_dir, src)
+        base = os.path.join(objs_dir, src)
+        path = '%s.H' % base if is_header else '%s%s.H' % (base, self.obj_suffix)
         if not os.path.exists(path):
             return ''
         return path

--- a/src/tests/unit/find_inclusion_file_test.py
+++ b/src/tests/unit/find_inclusion_file_test.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+
+"""Unit tests for inclusion_check.Checker._find_inclusion_file.
+
+Regression for the MSVC suffix mismatch: a source's inclusion file is named
+`<src><obj_suffix>.H` (`.o.H` on GCC/clang, `.obj.H` on MSVC), so the finder
+must use the toolchain's obj suffix instead of hardcoding `.o`.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import inclusion_check  # noqa: E402
+
+
+class FindInclusionFileTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.path = 'pkg'
+        self.name = 'lib'
+        self.objs_dir = os.path.join(self.tmp, self.path, self.name + '.objs')
+        os.makedirs(self.objs_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _checker(self, obj_suffix: str) -> inclusion_check.Checker:
+        target = {
+            'type': 'cc_library', 'name': self.name, 'path': self.path,
+            'key': '%s:%s' % (self.path, self.name), 'deps': [],
+            'build_dir': self.tmp, 'source_location': 'pkg/BUILD:1',
+            'expanded_srcs': [], 'expanded_hdrs': [],
+            'declared_hdrs': set(), 'declared_incs': set(),
+            'declared_genhdrs': set(), 'declared_genincs': set(),
+            'hdrs_deps': {}, 'private_hdrs_deps': {}, 'allowed_undeclared_hdrs': {},
+            'suppress': {}, 'severity': 'error', 'obj_suffix': obj_suffix,
+        }
+        return inclusion_check.Checker(target)
+
+    def _touch(self, name: str) -> str:
+        path = os.path.join(self.objs_dir, name)
+        open(path, 'w').close()
+        return path
+
+    def test_source_gcc_suffix(self):
+        c = self._checker('.o')
+        expected = self._touch('foo.cc.o.H')
+        self.assertEqual(c._find_inclusion_file('foo.cc', is_header=False), expected)
+
+    def test_source_msvc_suffix(self):
+        c = self._checker('.obj')
+        expected = self._touch('foo.cc.obj.H')  # MSVC writes <src>.obj.H
+        self.assertEqual(c._find_inclusion_file('foo.cc', is_header=False), expected)
+
+    def test_source_msvc_does_not_match_dot_o(self):
+        # The old hardcoded `.o.H` would not exist for an MSVC build; ensure the
+        # finder returns '' (not a stale match) when only `.obj.H` would be wrong.
+        c = self._checker('.obj')
+        self._touch('foo.cc.o.H')  # wrong-suffix file present
+        self.assertEqual(c._find_inclusion_file('foo.cc', is_header=False), '')
+
+    def test_header_suffix_independent(self):
+        for suffix in ('.o', '.obj'):
+            c = self._checker(suffix)
+            expected = self._touch('foo.h.H')
+            self.assertEqual(c._find_inclusion_file('foo.h', is_header=True), expected)
+
+    def test_default_suffix_is_dot_o(self):
+        target = {
+            'type': 'cc_library', 'name': self.name, 'path': self.path,
+            'key': 'pkg:lib', 'deps': [], 'build_dir': self.tmp,
+            'source_location': 'pkg/BUILD:1', 'expanded_srcs': [], 'expanded_hdrs': [],
+            'declared_hdrs': set(), 'declared_incs': set(), 'declared_genhdrs': set(),
+            'declared_genincs': set(), 'hdrs_deps': {}, 'private_hdrs_deps': {},
+            'allowed_undeclared_hdrs': {}, 'suppress': {}, 'severity': 'error',
+            # no 'obj_suffix' -> forward-compat default
+        }
+        c = inclusion_check.Checker(target)
+        self.assertEqual(c.obj_suffix, '.o')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- `Checker._find_inclusion_file` hardcoded `<src>.o.H` for source files, but the per-source inclusion stack is named `<src><obj_suffix>.H` — and MSVC's `obj_suffix` is `.obj`, not `.o`. As a result source-side header-missing checking silently matched nothing on MSVC.
- Carry the build toolchain's `obj_suffix` into the inclusion-check info and use it in the finder. Headers are unchanged (`<hdr>.H`).
- Default to `.o` when the suffix is absent, for forward compatibility with `.incchk` files written by older Blade versions.

## Test plan
- [x] `python3 src/tests/unit/find_inclusion_file_test.py` — 5 tests: `.o` source, `.obj` source, `.obj` does not match a stale `.o.H`, header (suffix-independent), default `.o`.
- [x] `python3 src/tests/unit/unused_deps_test.py` — 7 tests still pass (shared `Checker.__init__`).
- [x] GCC end-to-end inclusion check unaffected (suffix resolves to `.o`).
- [ ] MSVC path validated via Windows CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)