### PR TITLE
Fix dsl_api.py crash on Python 3.9 (PEP 604 union annotation)

### DIFF
--- a/src/blade/dsl_api.py
+++ b/src/blade/dsl_api.py
@@ -13,6 +13,10 @@
 API for BUILD files and extensions.
 """
 
+# Keep `X | None` and similar annotations lazy so they don't fail on Python 3.9
+# (PEP 604 union syntax is only evaluable at runtime on 3.10+).
+from __future__ import annotations
+
 import os
 import re
 import sys


### PR DESCRIPTION
## Problem

`blade.cc_toolchain.tool()` in `dsl_api.py` is annotated `-> str | None`.
PEP 604 union syntax (`X | Y`) is only evaluable at runtime on Python 3.10+,
and this annotation is evaluated while the class body executes at **import
time**. So on **Python 3.9** simply importing blade fails:

```
File "blade/dsl_api.py", line 165, in _CCToolchainProxy
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

(Surfaced by a downstream project whose CI runs blade under Python 3.9.)

## Fix

Add `from __future__ import annotations` to the module, so all annotations are
stored as lazy strings (PEP 563) and never evaluated at runtime — restoring
Python 3.9 compatibility without changing the annotation.