### PR TITLE
Pass -H to cxxhdrs preprocess so header inclusion stacks are non-empty

### DIFF
--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -476,9 +476,12 @@ class _NinjaFileHeaderGenerator:
         """Build the bare preprocess command for a header's inclusion file.
 
         Run by the `hdrs`-mode wrapper script (see `_INCLUSION_WRAPPER_SCRIPT`);
-        `${out}` is the inclusion (`.incstk`) file.
+        `${out}` is the inclusion (`.incstk`) file. `-H` is what the wrapper's
+        awk extracts -- without it the inclusion stack is never emitted and the
+        `.incstk` ends up empty, silently breaking checks for header-only
+        libraries. See issue #1169.
         """
-        cmd = ('%s -o /dev/null -E -MMD -MF ${out}.d %s %s -w ${cppflags} %s ${includes} ${in}' % (
+        cmd = ('%s -o /dev/null -E -MMD -MF ${out}.d %s %s -w ${cppflags} %s ${includes} ${in} -H' % (
             cc, ' '.join(flags), ' '.join(cppflags), includes))
         return 'sh %s hdrs ${out} %s' % (self._inclusion_wrapper_script(), cmd)
 

--- a/src/test/header_only_incstk_test.py
+++ b/src/test/header_only_incstk_test.py
@@ -1,0 +1,38 @@
+"""Regression test for issue #1169.
+
+The `cxxhdrs` rule preprocesses each public header to produce an inclusion-stack
+(`.incstk`) file used by the missing-deps / unused-deps checks. If the command
+omits `-H`, the wrapper's awk has nothing to extract and the file ends up empty
+-- which silently breaks the checks for header-only libraries (every dep used
+only through a header looks unused).
+
+This test builds a header-only library whose header `#include`s a dep, and
+asserts that the resulting `.incstk` is non-empty and records the include.
+"""
+
+import os
+
+import blade_test
+
+
+class TestHeaderOnlyIncstk(blade_test.TargetTest):
+    def setUp(self):
+        self.doSetUp('header_only_incstk', target='hdr_only')
+
+    def testIncstkRecordsDirectInclude(self):
+        self.assertTrue(self.runBlade('build'))
+        incstk = 'build64_release/header_only_incstk/hdr_only.objs/hdr_only.h.incstk'
+        self.assertTrue(os.path.exists(incstk), '%s was not generated' % incstk)
+        self.assertGreater(
+            os.path.getsize(incstk), 0,
+            "header inclusion stack is empty -- the cxxhdrs preprocess must pass "
+            "-H so the wrapper can extract the stack (issue #1169)")
+        with open(incstk) as f:
+            content = f.read()
+        self.assertIn(
+            'header_only_incstk/inner.h', content,
+            'expected inner.h to be recorded as a direct include of hdr_only.h')
+
+
+if __name__ == '__main__':
+    blade_test.run(TestHeaderOnlyIncstk)

--- a/src/test/testdata/header_only_incstk/BUILD
+++ b/src/test/testdata/header_only_incstk/BUILD
@@ -1,0 +1,12 @@
+cc_library(
+    name = 'inner',
+    hdrs = 'inner.h',
+    visibility = 'PUBLIC',
+)
+
+cc_library(
+    name = 'hdr_only',
+    hdrs = 'hdr_only.h',
+    deps = [':inner'],
+    visibility = 'PUBLIC',
+)

--- a/src/test/testdata/header_only_incstk/hdr_only.h
+++ b/src/test/testdata/header_only_incstk/hdr_only.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "header_only_incstk/inner.h"

--- a/src/test/testdata/header_only_incstk/inner.h
+++ b/src/test/testdata/header_only_incstk/inner.h
@@ -1,0 +1,1 @@
+#pragma once


### PR DESCRIPTION
Fixes #1169.

## Summary
The `cxxhdrs` rule preprocesses each public header to capture its inclusion stack into a `.incstk` file (consumed by the missing-deps / unused-deps checks). The command built by `_hdrs_command` was missing `-H`, so the wrapper's `awk` had nothing to extract and **every header's `.incstk` ended up 0 bytes**. This silently broke checks for **header-only** libraries — deps used only through a header `#include` were flagged as unused (the user-visible symptom in #1169), and undeclared deps included only from a header would not be flagged either. Libraries *with* sources masked the bug because the source's `.incstk` already carried `-H` from the compile step.

## Change
- Append `-H` to the hdrs preprocess in `_hdrs_command` ([backend.py](src/blade/backend.py)). MSVC's `/showIncludes`-based `cxxhdrs` is unaffected (different code path).
- Add a regression integration test: a header-only library whose header `#include`s a dep; asserts the resulting `.incstk` is non-empty and records the include — would have caught the bug.

## Test plan
- [x] New test `header_only_incstk_test.py` passes (would fail without the fix: empty `.incstk`).
- [x] Real flare target rebuilt: `flare/base/function.objs/function.h.incstk` is now 47 bytes with `. ./flare/base/align.h` / `. ./flare/base/likely.h`; the `function: Unused dependency` false-positive warning is gone.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)