### PR TITLE
fix: make the C/C++ header inclusion check work on Windows (MSVC)

### DIFF
--- a/doc/en/develop/hdrs_check.md
+++ b/doc/en/develop/hdrs_check.md
@@ -8,7 +8,7 @@ Source files involved:
 | --- | --- |
 | `src/blade/cc_targets.py` | Collect the "header → library" declarations, write per-target check info, generate the check rule |
 | `src/blade/build_manager.py` | Write the global declaration to `inclusion_declaration.data` |
-| `src/blade/backend.py` | Generate the compile command that emits the inclusion stack (`cc_wrapper.sh` adds `-H`), plus the `cxxhdrs` and `ccincchk` rules |
+| `src/blade/backend.py` | Generate the compile command that emits the inclusion stack (GCC: `cc_wrapper.sh` adds `-H`; MSVC: `cc_wrapper.py` tees `/showIncludes`), plus the `cxxhdrs` and `ccincchk` rules |
 | `src/blade/inclusion_check.py` | The actual check logic (invoked as a subprocess at build time) |
 
 ---
@@ -46,9 +46,9 @@ It also writes a `<target>.incchk.extra` containing `hdrs_deps` / `private_hdrs_
 
 The check needs to know which headers each source/header **actually** includes. The compiler produces this as a side effect of compilation:
 
-- **Source files**: every compile goes through the generated wrapper `cc_wrapper.sh` (see `backend.py`), which appends GCC's `-H` option to the compile command and uses an awk program to separate the "inclusion stack" from ordinary diagnostics, writing it to `<src>.incstk`. The path is passed via the per-object `inclusion_stack` ninja variable, so it is independent of the object-file suffix (`.o` vs `.obj`).
-- **Public headers**: a header is not compiled normally, so a separate `cxxhdrs` rule preprocesses it (`-E`) to produce `<hdr>.incstk`.
-- **MSVC**: it does not emit an inclusion stack during compilation (it uses ninja's native `deps = msvc` to parse `/showIncludes`), so an extra `cxxhdrs` preprocess step is added for source files too.
+- **Source files (GCC/Clang)**: every compile goes through the generated wrapper `cc_wrapper.sh` (see `backend.py`), which appends GCC's `-H` option to the compile command and uses an awk program to separate the "inclusion stack" from ordinary diagnostics, writing it to `<src>.incstk`. The path is passed via the per-object `inclusion_stack` ninja variable, so it is independent of the object-file suffix (`.o` vs `.obj`).
+- **Source files (MSVC)**: see the MSVC note below — the same `.incstk` is produced during the normal compile, no separate preprocess.
+- **Public headers (all toolchains)**: a header is never compiled into an object, so on **every** toolchain a separate `cxxhdrs` rule preprocesses it (GCC/Clang `-E`, MSVC `/P`) to produce `<hdr>.incstk`. This is independent of the source-file path below — it is the only inclusion stack a header gets.
 
 A `.incstk` file encodes the **inclusion level with the number of leading dots**, for example (GCC format):
 
@@ -60,6 +60,22 @@ A `.incstk` file encodes the **inclusion level with the number of leading dots**
 ```
 
 The MSVC format is `Note: including file:  <path>`, using the number of leading spaces for the level. Both are parsed by `inclusion_check._parse_hdr_level_line()`.
+
+#### MSVC: tee `/showIncludes` instead of a separate preprocess
+
+GCC's `-H` writes the inclusion stack to stderr, which the awk wrapper splits off into `.incstk`. MSVC has no `-H`; it emits `/showIncludes` lines (`Note: including file: <path>`) interleaved with diagnostics, and ninja's native `deps = msvc` already parses those same lines to build the dependency graph. To avoid compiling each source file *twice* (once for `.obj` + ninja deps, once to preprocess for the inclusion stack), the MSVC `cc`/`cxx` rules wrap the compile in `cc_wrapper.py`, which **tees** the compiler output:
+
+- it merges the child's stdout and stderr into one pipe (reading only one side risks a pipe-buffer deadlock) and streams every line back to ninja's `deps = msvc` parser unchanged;
+- in parallel it writes the `Note: including file:` lines to `<src>.incstk`, so the same single compile feeds both consumers.
+
+Two things are filtered, with **different** treatment for each:
+
+- the **bare basename** the compiler echoes for the file it processes — a cl.exe quirk that cannot be turned off. ninja's `CLParser::FilterInputFilename` already strips this echo **for source files** (it matches `.c/.cc/.cxx/.cpp/.c++`), so the `cc`/`cxx` rules need no help; but it does **not** strip header extensions, so the echoed `foo.h` from the `cxxhdrs` `/P` rule leaks through. We therefore drop any lone filename token ourselves (this also covers nvcc, which echoes its `.cu` source plus intermediate temp names). Such a token is **dropped from both sides** — neither written to `.incstk` nor forwarded to ninja — since it is not a `Note: including file:` line and the deps parser does not need it;
+- **absolute paths outside the workspace** (system/SDK headers): these are dropped from `.incstk` only (the checker discards absolute paths anyway, so keeping them would just bloat the file and slow the check), **but still forwarded to ninja** — its `deps = msvc` graph needs the complete include set.
+
+So on MSVC the inclusion stack is a by-product of the normal compile, exactly as `-H` is on GCC — no separate per-source preprocess is needed.
+
+> **Path separators.** The backend writes the declaration data (`declared_hdrs`, the global `public_hdrs` map, …) with the OS separator, i.e. backslashes on Windows, while `/showIncludes` paths are normalized to forward slashes. `inclusion_check.py` reconciles the two by normalizing **all** declaration paths to forward slashes as they are loaded (`_unix_path_set` / `_unix_path_dict` / `_unix_path_pairs`), so the comparisons are separator-agnostic regardless of which platform produced the data.
 
 ### 1.4 Triggering the check (the `ccincchk` rule)
 

--- a/doc/zh_CN/develop/hdrs_check.md
+++ b/doc/zh_CN/develop/hdrs_check.md
@@ -8,7 +8,7 @@
 | --- | --- |
 | `src/blade/cc_targets.py` | 收集"头文件 → 库"的声明、为每个目标落盘检查信息、生成检查规则 |
 | `src/blade/build_manager.py` | 把全局声明写入 `inclusion_declaration.data` |
-| `src/blade/backend.py` | 生成产出包含栈的编译命令（`cc_wrapper.sh` 加 `-H`）、`cxxhdrs` 与 `ccincchk` 规则 |
+| `src/blade/backend.py` | 生成产出包含栈的编译命令（GCC：`cc_wrapper.sh` 加 `-H`；MSVC：`cc_wrapper.py` 旁路 `/showIncludes`）、`cxxhdrs` 与 `ccincchk` 规则 |
 | `src/blade/inclusion_check.py` | 真正的检查逻辑（在构建期作为子进程被调用） |
 
 ---
@@ -46,9 +46,9 @@
 
 检查需要知道每个源文件/头文件**实际**包含了哪些头文件。这一信息由编译器在编译时顺带产出：
 
-- **源文件**：每次编译都经由生成的包装脚本 `cc_wrapper.sh`（见 `backend.py`），它给编译命令追加 GCC 的 `-H` 选项，并用一段 awk 把"包含栈"从普通诊断里分离出来，写入 `<src>.incstk`。该路径通过每个目标文件各自的 `inclusion_stack` ninja 变量传入，因此与目标文件后缀（`.o` 还是 `.obj`）无关。
-- **公开头文件**：头文件本身不参与普通编译，所以单独生成 `cxxhdrs` 规则，用 `-E` 预处理产出 `<hdr>.incstk`。
-- **MSVC**：编译时不产出包含栈（它用 ninja 原生的 `deps = msvc` 解析 `/showIncludes`），因此对源文件也额外补一条 `cxxhdrs` 预处理步骤。
+- **源文件（GCC/Clang）**：每次编译都经由生成的包装脚本 `cc_wrapper.sh`（见 `backend.py`），它给编译命令追加 GCC 的 `-H` 选项，并用一段 awk 把"包含栈"从普通诊断里分离出来，写入 `<src>.incstk`。该路径通过每个目标文件各自的 `inclusion_stack` ninja 变量传入，因此与目标文件后缀（`.o` 还是 `.obj`）无关。
+- **源文件（MSVC）**：见下方 MSVC 说明——在正常编译过程中顺带产出同样的 `.incstk`，无需单独预处理。
+- **公开头文件（所有工具链）**：头文件从不被编译成目标文件，所以在**每种**工具链上都单独生成 `cxxhdrs` 规则，用预处理（GCC/Clang `-E`、MSVC `/P`）产出 `<hdr>.incstk`。这与下面的源文件路径无关——它是头文件获得包含栈的唯一途径。
 
 `.incstk` 文件用**前导点的个数表示包含层级**，例如（GCC 格式）：
 
@@ -60,6 +60,22 @@
 ```
 
 MSVC 格式则为 `Note: including file:  <路径>`，用前导空格数表示层级。两种格式都由 `inclusion_check._parse_hdr_level_line()` 解析。
+
+#### MSVC：旁路（tee）`/showIncludes`，而非单独预处理
+
+GCC 的 `-H` 把包含栈写到 stderr，由 awk 包装脚本分流到 `.incstk`。MSVC 没有 `-H`，它输出 `/showIncludes` 行（`Note: including file: <路径>`）与诊断信息交织在一起，而 ninja 原生的 `deps = msvc` 本就要解析这些行来构建依赖图。为避免把每个源文件**编译两遍**（一遍出 `.obj` + 喂 ninja deps，一遍预处理出包含栈），MSVC 的 `cc`/`cxx` 规则用 `cc_wrapper.py` 包裹编译命令，对编译器输出做**旁路（tee）**：
+
+- 把子进程的 stdout 与 stderr 合并到同一个管道（只读其中一侧会有管道缓冲死锁风险），逐行原样转发给 ninja 的 `deps = msvc` 解析器；
+- 同时把 `Note: including file:` 行写入 `<src>.incstk`，于是同一次编译同时喂饱两个消费者。
+
+有两类内容会被过滤，但处理方式**不同**：
+
+- 编译器回显的**裸文件名**——这是 cl.exe 的怪癖，无法关闭。ninja 的 `CLParser::FilterInputFilename` 已经会**按扩展名过滤源文件**的回显（匹配 `.c/.cc/.cxx/.cpp/.c++`），所以 `cc`/`cxx` 规则无需我们插手；但它**不**过滤头文件扩展名，于是 `cxxhdrs` 的 `/P` 规则回显的 `foo.h` 会漏出来。因此我们自己丢弃任何单独的文件名 token（这也顺带覆盖 nvcc——它会回显 `.cu` 源文件名和中间临时文件名）。这类 token **两边都不发**——既不写入 `.incstk`，也不转发给 ninja——因为它不是 `Note: including file:` 行，deps 解析器并不需要它；
+- **workspace 之外的绝对路径**（系统/SDK 头文件）：只从 `.incstk` 里滤掉（检查器本就会丢弃绝对路径，保留它们只会撑大文件、拖慢检查），**但仍转发给 ninja**——它的 `deps = msvc` 依赖图需要完整的 include 集合。
+
+因此在 MSVC 上，包含栈是正常编译的副产物，与 GCC 上的 `-H` 完全一致——不需要对每个源文件单独预处理。
+
+> **路径分隔符。** 后端写出的声明数据（`declared_hdrs`、全局 `public_hdrs` 表等）用的是操作系统分隔符，即 Windows 上的反斜杠，而 `/showIncludes` 路径已归一化为正斜杠。`inclusion_check.py` 在加载时把**所有**声明路径统一归一化为正斜杠（`_unix_path_set` / `_unix_path_dict` / `_unix_path_pairs`）来消除这一差异，使比较与分隔符无关、与产出数据的平台无关。
 
 ### 1.4 检查的触发（`ccincchk` 规则）
 

--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -83,6 +83,85 @@ rm -f "$err"
 exit $ec
 ''' % _INCLUSION_SPLITTER_AWK
 
+# MSVC tee-wrapper: runs a compile command (cl.exe or nvcc with /showIncludes),
+# tees stderr to both the real stderr (for Ninja's deps=msvc) and an incstk
+# file (for inclusion checking). Invoked as:
+#   python cc_wrapper.py ${inclusion_stack} -- <compile_command...>
+#
+# Unlike the POSIX shell wrapper, stderr is passed through unfiltered — Ninja
+# needs the raw /showIncludes lines.  Bare source/header filenames that cl.exe
+# echoes (e.g. "hello.h" without a path) are stripped from the incstk file
+# only, matching what Ninja's CLParser::FilterInputFilename does for .c/.cpp
+# etc., extended to header extensions.
+_MSVC_TEE_WRAPPER_PY = r'''
+import os, re, subprocess, sys
+
+outfile = sys.argv[1]
+# sys.argv[2] is "--"
+cmd = sys.argv[3:]
+
+_NOTE_PREFIX = 'Note: including file:'
+_cwd = os.getcwd()
+
+# Compilers echo the basename of the file they process.  Ninja's
+# CLParser::FilterInputFilename strips it for source files (.c/.cc/.cxx/.cpp/
+# .c++) but NOT for headers, so the cxxhdrs rule (/P on a .h) leaks a bare
+# "foo.h" onto the build console; nvcc additionally echoes its source (.cu)
+# and a zoo of intermediate temp names (tmpxft_*.cpp1.ii, *.cudafe1.cpp, ...).
+# Enumerating extensions is hopeless, so match any lone filename token: no
+# whitespace, no path separator, at least one dot, only filename-safe chars.
+# Real diagnostics always carry spaces/colons/parens and never match.
+_BARE_FILENAME_RE = re.compile(r'^[\w.+\-]+\.[\w.+\-]+$')
+
+def _in_workspace(hdr):
+    try:
+        return os.path.commonpath([_cwd, hdr]) == _cwd
+    except ValueError:  # different drive -> outside the workspace
+        return False
+
+# Merge stdout+stderr into one pipe (like Ninja).  Reading only stderr risks
+# a pipe deadlock: if cl.exe writes enough to stdout (even with /nologo a
+# leftover copyright banner fills the 4 KiB buffer), the process blocks and
+# never drains its stderr output through the unread stdout pipe.
+p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                     universal_newlines=True, encoding='utf-8', errors='replace')
+with open(outfile + '.new', 'w', newline='', encoding='utf-8') as f:
+    for line in p.stdout:
+        if line.startswith(_NOTE_PREFIX):
+            # Record only workspace headers in the incstk (smaller file; the
+            # inclusion checker discards absolute/system paths anyway), but
+            # forward every include line to ninja's deps=msvc parser below.
+            hdr = line[len(_NOTE_PREFIX):].lstrip().rstrip('\r\n')
+            if not os.path.isabs(hdr) or _in_workspace(hdr):
+                f.write(line)
+        elif _BARE_FILENAME_RE.match(line.strip()):
+            continue  # echoed source/temp filename -- console noise, drop it
+        sys.stderr.write(line)
+        sys.stderr.flush()
+
+ec = p.wait()
+
+# Write-if-changed: keep mtime when the stack is unchanged, so ninja's
+# restat can prune the inclusion check. See issue #1161.
+try:
+    with open(outfile + '.new', 'rb') as nf:
+        new = nf.read()
+    try:
+        with open(outfile, 'rb') as of:
+            old = of.read()
+    except FileNotFoundError:
+        old = None
+    if new != old:
+        os.replace(outfile + '.new', outfile)
+    else:
+        os.unlink(outfile + '.new')
+except OSError:
+    pass
+
+sys.exit(ec)
+'''
+
+
 def _incs_list_to_string(incs):
     """Convert incs list to string.
 
@@ -116,6 +195,7 @@ class _NinjaFileHeaderGenerator:
         self.rules_buf = []
         self.__all_rule_names = set()
         self.__inclusion_wrapper_path = None
+        self.__msvc_wrapper_py_path = None
 
     def _inclusion_wrapper_script(self):
         """Path to the cc inclusion-stack splitter wrapper, written on first use.
@@ -130,6 +210,14 @@ class _NinjaFileHeaderGenerator:
             util.write_if_changed(path, _INCLUSION_WRAPPER_SCRIPT)
             self.__inclusion_wrapper_path = path
         return self.__inclusion_wrapper_path
+
+    def _msvc_tee_wrapper_py(self):
+        """Path to the MSVC Python stderr-tee wrapper, written on first use."""
+        if self.__msvc_wrapper_py_path is None:
+            path = os.path.join(self.build_dir, 'cc_wrapper.py')
+            util.write_if_changed(path, _MSVC_TEE_WRAPPER_PY)
+            self.__msvc_wrapper_py_path = path
+        return self.__msvc_wrapper_py_path
 
     def _add_line(self, rule):
         """Append one rule to buffer."""
@@ -330,31 +418,40 @@ class _NinjaFileHeaderGenerator:
         optimize_flags = windows_config['optimize']
         optimize = ' '.join(optimize_flags.get(self.options.profile, []))
 
-        cc_command = ('%s /nologo /c /showIncludes %s %s %s %s /Fo${out} ${c_warnings} ${in}' % (
+        # The Python stderr-tee wrapper captures /showIncludes output and tees
+        # it to both stderr (for Ninja's deps=msvc) and the inclusion stack
+        # file (for inclusion checking).
+        py = sys.executable
+        wrapper = self._msvc_tee_wrapper_py()
+        template = '"%s" -B %s ${inclusion_stack} -- ' % (py, wrapper)
+
+        cc_command = template + ('"%s" /nologo /c /showIncludes %s %s %s %s /Fo${out} ${c_warnings} ${in}' % (
             cc, optimize, ' '.join(cppflags), ' '.join(cflags), include_flags))
         self.generate_rule(name='cc',
                            command=cc_command,
                            description='CC ${in}',
-                           deps='msvc')
+                           deps='msvc',
+                           restat=True)
 
-        cxx_command = ('%s /nologo /c /showIncludes %s %s %s %s /Fo${out} ${cxx_warnings} ${in}' % (
+        cxx_command = template + ('"%s" /nologo /c /showIncludes %s %s %s %s /Fo${out} ${cxx_warnings} ${in}' % (
             cxx, optimize, ' '.join(cppflags), ' '.join(cxxflags), include_flags))
         self.generate_rule(name='cxx',
                            command=cxx_command,
                            description='CXX ${in}',
-                           deps='msvc')
+                           deps='msvc',
+                           restat=True)
 
-        # For cxxhdrs: use /showIncludes to generate inclusion info.
-        # /P preprocesses (like GCC -E), /Tp forces C++ treatment of .h files.
-        # Wrap with cmd /c because Ninja on Windows can't handle shell redirections directly.
-        # Fall back to empty output on failure so the build can continue.
-        hdrs_command = ('cmd /c "%s /nologo /P /Tp${in} /showIncludes %s %s %s %s /Fi${out}.pre 2> ${out}'
-                        ' || (echo. > ${out}.pre & echo. > ${out})"' % (
+        # For cxxhdrs: use /showIncludes to generate inclusion info for header
+        # files. /P preprocesses (like GCC -E), /Tp forces C++ treatment of .h.
+        # The Python wrapper captures /showIncludes to ${out} (.incstk file);
+        # /Fi writes the preprocessed body to ${out}.pre.
+        hdrs_template = '"%s" -B %s ${out} -- ' % (py, wrapper)
+        hdrs_command = hdrs_template + ('"%s" /nologo /P /Tp${in} /showIncludes %s %s %s %s /Fi${out}.pre' % (
             cxx, optimize, ' '.join(cppflags), ' '.join(cxxflags), include_flags))
         self.generate_rule(name='cxxhdrs',
                            command=hdrs_command,
                            description='CXX HDRS ${in}',
-                           depfile=None,
+                           deps='msvc',
                            restat=True)
 
     def _generate_windows_ar_rules(self):
@@ -988,8 +1085,6 @@ class _NinjaFileHeaderGenerator:
         NVCC on Windows delegates host code to cl.exe.  Flags that pass
         through to the host compiler via -Xcompiler must be MSVC-compatible.
         """
-        nvcc_cmd = '${cmd}'
-
         cc_config = config.get_section('cc_config')
         ms_config = config.get_section('msvc_config')
         cuda_config = config.get_section('cuda_config')
@@ -1025,20 +1120,27 @@ class _NinjaFileHeaderGenerator:
         include_flags = ' '.join(_quote_if_needed(inc) for inc in includes)
 
         # NVCC -Xcompiler /showIncludes lets Ninja deps=msvc track headers.
+        # The Python wrapper tees /showIncludes to both stderr (for Ninja) and
+        # the inclusion stack file.
+        py = sys.executable
+        wrapper = self._msvc_tee_wrapper_py()
+        template = '"%s" -B %s ${inclusion_stack} -- ' % (py, wrapper)
+
         _, cxx, _ = self.build_accelerator.get_cc_commands()
-        cu_command = ('%s -ccbin "%s" -o ${out} -c '
-                      '-Xcompiler /nologo -Xcompiler /showIncludes '
-                      '%s %s %s '
-                      '%s ${includes} %s ${cu_warnings} ${in}' % (
-                          nvcc_cmd, cxx,
-                          host_cppflags, host_cxxflags,
-                          ' '.join(cuflags),
-                          include_flags, '${cppflags}'))
+        cu_command = template + ('"${cmd}" -ccbin "%s" -o ${out} -c '
+                                 '-Xcompiler /nologo -Xcompiler /showIncludes '
+                                 '%s %s %s '
+                                 '%s ${includes} %s ${cu_warnings} ${in}' % (
+                                     cxx,
+                                     host_cppflags, host_cxxflags,
+                                     ' '.join(cuflags),
+                                     include_flags, '${cppflags}'))
         self.generate_rule(
             name='cudacc',
             command=cu_command,
             description='CUDA LIBRARY ${in}',
             deps='msvc',
+            restat=True,
         )
 
         # NVCC linking delegates to the host linker automatically.
@@ -1047,14 +1149,14 @@ class _NinjaFileHeaderGenerator:
                      '--options-file ${out}.rsp ${extra_linkflags}' % include_flags)
         self.generate_rule(
             name='cudalink',
-            command=nvcc_cmd + ' -ccbin "%s" ' % cxx + link_args,
+            command='"${cmd}" -ccbin "%s" ' % cxx + link_args,
             rspfile='${out}.rsp',
             rspfile_content='${target_linkflags} ${in}',
             description='CUDA LINK BINARY ${out}')
 
         self.generate_rule(
             name='cudasolink',
-            command=nvcc_cmd + ' -ccbin "%s" -shared ' % cxx + link_args,
+            command='"${cmd}" -ccbin "%s" -shared ' % cxx + link_args,
             rspfile='${out}.rsp',
             rspfile_content='${target_linkflags} ${in}',
             description='CUDA LINK SHARED ${out}')

--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -354,7 +354,8 @@ class _NinjaFileHeaderGenerator:
         self.generate_rule(name='cxxhdrs',
                            command=hdrs_command,
                            description='CXX HDRS ${in}',
-                           depfile=None)
+                           depfile=None,
+                           restat=True)
 
     def _generate_windows_ar_rules(self):
         """Generate Windows static library rules."""

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -637,12 +637,12 @@ class CcTarget(Target):
             implicit_deps.append(self._source_file_path(self.attr['secret_revision_file']))
 
         objs_dir = self._target_file_path(self.name + '.objs')
-        # The cc/cxx compile wrapper writes a `<src>.incstk` inclusion stack for
-        # real GCC/clang compiles; its name is independent of the object file, so
-        # the rule takes the path via the per-object `inclusion_stack` variable.
-        # Declaring it an implicit output (with `restat` on the rule) lets ninja
-        # prune the inclusion check when the stack is unchanged. See issue #1161.
-        # (Not produced for MSVC or compdb dump.)
+        # The compile wrapper writes a `<src>.incstk` inclusion stack (GCC via
+        # shell script with -H, MSVC via Python wrapper that tees /showIncludes).
+        # The file name is independent of the object suffix, so the rule takes
+        # the path via the per-object `inclusion_stack` variable. Declaring it
+        # an implicit output (with `restat` on the rule) lets ninja prune the
+        # inclusion check when the stack is unchanged. See issue #1161.
         emit_inclusion_stack = self._emits_inclusion_stack()
         objs = []
         inclusion_stacks = []
@@ -677,12 +677,10 @@ class CcTarget(Target):
     def _emits_inclusion_stack(self):
         """Whether the cc/cxx compile writes a `<src>.incstk` inclusion stack.
 
-        True only for real GCC/clang compiles (the wrapper emits it). False for
-        MSVC (no inclusion stack from compilation) and for compdb dump (the
-        wrapper, and thus `-H`, is bypassed). See issue #1161.
+        True for all real compiles (GCC via shell wrapper with -H, MSVC via
+        Python wrapper that tees /showIncludes). False for compdb dump where
+        the wrapper is bypassed. See issue #1161.
         """
-        if self.blade.get_build_toolchain().obj_suffix != '.o':
-            return False
         return not (self.blade.get_command() == 'dump' and
                     getattr(self.blade.get_options(), 'dump_compdb', False))
 
@@ -702,25 +700,11 @@ class CcTarget(Target):
             implicit_deps.append(output)
             self.generate_build('cxxhdrs', output, inputs=full_hdr,
                                 order_only_deps=order_only_deps, variables=vars, clean=[])
-        tc = self.blade.get_build_toolchain()
-        if tc.obj_suffix != '.o':
-            # MSVC does not generate inclusion stacks during compilation (unlike
-            # GCC's -H wrapper), so we need an explicit cxxhdrs preprocess step for
-            # source files too.
-            for src, full_src in self.attr['expanded_srcs']:
-                if path_under_dir(full_src, self.build_dir):
-                    continue
-                output = os.path.join(objs_dir, src) + '.incstk'
-                implicit_deps.append(output)
-                self.generate_build('cxxhdrs', output, inputs=full_src,
-                                    order_only_deps=order_only_deps, variables=vars, clean=[])
-            implicit_deps += objs
-        elif source_inclusion_stacks is not None:
-            # GCC/clang: each compile declares its `<obj>.H` inclusion stack as an
-            # implicit output (written write-if-changed, with `restat` on the rule).
-            # Triggering the check on those instead of the `.o` lets ninja prune it
-            # when the inclusion set is unchanged, while still ordering it after the
-            # compile. See issue #1161.
+        if source_inclusion_stacks is not None:
+            # Each compile declares its `<src>.incstk` as an implicit output
+            # (written write-if-changed, with `restat` on the rule). Triggering
+            # the check on those instead of the `.o` lets ninja prune it when
+            # the inclusion set is unchanged. See issue #1161.
             implicit_deps += source_inclusion_stacks
         else:
             # Fallback (e.g. cuda, or compdb dump where no `.H` is produced): the

--- a/src/blade/inclusion_check.py
+++ b/src/blade/inclusion_check.py
@@ -101,7 +101,7 @@ def path_under_dir(path, dir):
 
     Both must be normalized, and both relative or both absolute.
     """
-    return dir == '.' or path == dir or path.startswith(dir) and path[len(dir)] == os.path.sep
+    return dir == '.' or path == dir or path.startswith(dir) and path[len(dir)] == '/'
 
 
 def find_libs_by_header(hdr, hdr_targets_map, hdr_dir_targets_map):
@@ -213,10 +213,10 @@ def _parse_inclusion_stacks(path, build_dir):
             skip_level = level
         elif hdr.startswith(build_dir):
             skip_level = level
-            stacks.append(hdrs_stack + [_remove_build_dir_prefix(os.path.normpath(hdr), build_dir)])
+            stacks.append(hdrs_stack + [_remove_build_dir_prefix(posixpath.normpath(hdr), build_dir)])
         else:
             current_level = level
-            hdrs_stack.append(_remove_build_dir_prefix(os.path.normpath(hdr), build_dir))
+            hdrs_stack.append(_remove_build_dir_prefix(posixpath.normpath(hdr), build_dir))
             skip_level = -1
         return current_level, skip_level
 
@@ -234,7 +234,7 @@ def _parse_inclusion_stacks(path, build_dir):
                 console.log(f'{path}: Unrecognized line {line}')
                 break
             if level == 1 and not os.path.isabs(hdr):
-                direct_hdrs.append(_remove_build_dir_prefix(os.path.normpath(hdr), build_dir))
+                direct_hdrs.append(_remove_build_dir_prefix(posixpath.normpath(hdr), build_dir))
             if level > current_level:
                 if skip_level != -1 and level > skip_level:
                     continue
@@ -298,7 +298,7 @@ def _parse_msvc_hdr_level_line(line):
     # Normalize to Unix-style paths for consistency with GCC output
     hdr = to_unix_path(hdr)
     # Remove current working directory prefix if present
-    cwd = os.getcwd().lower()
+    cwd = to_unix_path(os.getcwd()).lower()
     if hdr.lower().startswith(cwd):
         hdr = hdr[len(cwd) + 1:]
     return level, hdr
@@ -309,7 +309,7 @@ def _remove_build_dir_prefix(path, build_dir):
     Args:
         path:str, the full path starts from the workspace root
     """
-    prefix = build_dir + os.sep
+    prefix = build_dir + '/'
     if path.startswith(prefix):
         return path[len(prefix):]
     return path
@@ -324,7 +324,7 @@ class Checker:
         self.path = target['path']
         self.key = target['key']
         self.deps = target['deps']
-        self.build_dir = target['build_dir']
+        self.build_dir = to_unix_path(target['build_dir'])
         self.expanded_srcs = target['expanded_srcs']
         self.expanded_hdrs = target['expanded_hdrs']
         self.source_location = target['source_location']
@@ -354,8 +354,8 @@ class Checker:
         https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html
         for details.
         """
-        objs_dir = os.path.join(self.build_dir, self.path, self.name + '.objs')
-        path = os.path.join(objs_dir, src) + '.incstk'
+        objs_dir = '/'.join([self.build_dir, self.path, self.name + '.objs'])
+        path = objs_dir + '/' + src + '.incstk'
         if not os.path.exists(path):
             return ''
         return path

--- a/src/blade/inclusion_check.py
+++ b/src/blade/inclusion_check.py
@@ -96,6 +96,29 @@ def to_unix_path(path):
     return path.replace('\\', '/')
 
 
+# The backend writes declaration data (`declared_hdrs`, `public_hdrs`, ...)
+# with `os.sep` -- backslashes on Windows -- but inclusion stacks are parsed to
+# forward slashes.  These helpers reconcile both sides here, in the consumer,
+# so the path comparisons work regardless of the platform that produced them.
+def _unix_path_set(paths):
+    """Normalize a set/list of paths to forward slashes (None passes through)."""
+    if paths is None:
+        return paths
+    return {to_unix_path(p) for p in paths}
+
+
+def _unix_path_dict(mapping):
+    """Normalize the path keys of a dict to forward slashes (None passes through)."""
+    if mapping is None:
+        return mapping
+    return {to_unix_path(k): v for k, v in mapping.items()}
+
+
+def _unix_path_pairs(pairs):
+    """Normalize a list of (name, full_path) pairs to forward slashes."""
+    return [(to_unix_path(name), to_unix_path(full)) for name, full in pairs]
+
+
 def path_under_dir(path, dir):
     """Check whether *path* is under *dir*.
 
@@ -133,11 +156,13 @@ class GlobalDeclaration:
         with open(self._declaration_file, 'rb') as f:
             declaration = pickle.load(f)
         # pylint: disable=attribute-defined-outside-init
-        self._hdr_targets_map = declaration['public_hdrs']
-        self._hdr_dir_targets_map = declaration['public_incs']
-        self._private_hdrs_target_map = declaration['private_hdrs']
+        # Normalize path keys to forward slashes (the backend writes them with
+        # os.sep). `header_less` holds target keys, not paths, so it is left as-is.
+        self._hdr_targets_map = _unix_path_dict(declaration['public_hdrs'])
+        self._hdr_dir_targets_map = _unix_path_dict(declaration['public_incs'])
+        self._private_hdrs_target_map = _unix_path_dict(declaration['private_hdrs'])
         self._header_less = declaration.get('header_less', set())
-        self._allowed_undeclared_hdrs = declaration['allowed_undeclared_hdrs']
+        self._allowed_undeclared_hdrs = _unix_path_set(declaration['allowed_undeclared_hdrs'])
         self._initialized = True
 
     def find_libs_by_header(self, hdr):
@@ -325,17 +350,20 @@ class Checker:
         self.key = target['key']
         self.deps = target['deps']
         self.build_dir = to_unix_path(target['build_dir'])
-        self.expanded_srcs = target['expanded_srcs']
-        self.expanded_hdrs = target['expanded_hdrs']
+        # Normalize all declared paths to forward slashes so they match the
+        # forward-slash header paths parsed from inclusion stacks. The backend
+        # writes them with os.sep (backslashes on Windows). See `to_unix_path`.
+        self.expanded_srcs = _unix_path_pairs(target['expanded_srcs'])
+        self.expanded_hdrs = _unix_path_pairs(target['expanded_hdrs'])
         self.source_location = target['source_location']
-        self.declared_hdrs = target['declared_hdrs']
-        self.declared_incs = target['declared_incs']
-        self.declared_genhdrs = target['declared_genhdrs']
-        self.declared_genincs = target['declared_genincs']
-        self.hdrs_deps = target['hdrs_deps']
-        self.private_hdrs_deps = target['private_hdrs_deps']
-        self.allowed_undeclared_hdrs = target['allowed_undeclared_hdrs']
-        self.suppress = target['suppress']
+        self.declared_hdrs = _unix_path_set(target['declared_hdrs'])
+        self.declared_incs = _unix_path_set(target['declared_incs'])
+        self.declared_genhdrs = _unix_path_set(target['declared_genhdrs'])
+        self.declared_genincs = _unix_path_set(target['declared_genincs'])
+        self.hdrs_deps = _unix_path_dict(target['hdrs_deps'])
+        self.private_hdrs_deps = _unix_path_dict(target['private_hdrs_deps'])
+        self.allowed_undeclared_hdrs = _unix_path_dict(target['allowed_undeclared_hdrs'])
+        self.suppress = _unix_path_dict(target['suppress'])
         self.severity = target['severity']
         # Unused-deps check (forward-compatible defaults for older incchk files).
         self.unused_deps_severity = target.get('unused_deps_severity', 'debug')

--- a/src/blade/inclusion_check.py
+++ b/src/blade/inclusion_check.py
@@ -100,22 +100,32 @@ def to_unix_path(path):
 # with `os.sep` -- backslashes on Windows -- but inclusion stacks are parsed to
 # forward slashes.  These helpers reconcile both sides here, in the consumer,
 # so the path comparisons work regardless of the platform that produced them.
+#
+# On POSIX every path is already '/'-separated (os.path generates '/', so does
+# `-H`), making normalization a pure no-op -- but one that would still rebuild
+# each container, including the potentially large global `public_hdrs` map on
+# every check. So skip it entirely off Windows and return the input unchanged.
+_PATHS_NEED_UNIX_NORM = os.sep != '/'
+
+
 def _unix_path_set(paths):
     """Normalize a set/list of paths to forward slashes (None passes through)."""
-    if paths is None:
+    if paths is None or not _PATHS_NEED_UNIX_NORM:
         return paths
     return {to_unix_path(p) for p in paths}
 
 
 def _unix_path_dict(mapping):
     """Normalize the path keys of a dict to forward slashes (None passes through)."""
-    if mapping is None:
+    if mapping is None or not _PATHS_NEED_UNIX_NORM:
         return mapping
     return {to_unix_path(k): v for k, v in mapping.items()}
 
 
 def _unix_path_pairs(pairs):
     """Normalize a list of (name, full_path) pairs to forward slashes."""
+    if not _PATHS_NEED_UNIX_NORM:
+        return pairs
     return [(to_unix_path(name), to_unix_path(full)) for name, full in pairs]
 
 

--- a/src/tests/unit/find_inclusion_file_test.py
+++ b/src/tests/unit/find_inclusion_file_test.py
@@ -23,10 +23,10 @@ from blade import inclusion_check  # noqa: E402
 
 class FindInclusionFileTest(unittest.TestCase):
     def setUp(self):
-        self.tmp = tempfile.mkdtemp()
+        self.tmp = tempfile.mkdtemp().replace('\\', '/')
         self.path = 'pkg'
         self.name = 'lib'
-        self.objs_dir = os.path.join(self.tmp, self.path, self.name + '.objs')
+        self.objs_dir = '/'.join([self.tmp, self.path, self.name + '.objs'])
         os.makedirs(self.objs_dir)
         self.checker = self._checker()
 
@@ -47,7 +47,7 @@ class FindInclusionFileTest(unittest.TestCase):
         return inclusion_check.Checker(target)
 
     def _touch(self, name: str) -> str:
-        path = os.path.join(self.objs_dir, name)
+        path = self.objs_dir + '/' + name
         open(path, 'w').close()
         return path
 
@@ -60,8 +60,8 @@ class FindInclusionFileTest(unittest.TestCase):
         self.assertEqual(self.checker._find_inclusion_file('foo.h'), expected)
 
     def test_source_in_subdir(self):
-        os.makedirs(os.path.join(self.objs_dir, 'sub'))
-        expected = self._touch(os.path.join('sub', 'foo.cc.incstk'))
+        os.makedirs(self.objs_dir + '/sub')
+        expected = self._touch('sub/foo.cc.incstk')
         self.assertEqual(self.checker._find_inclusion_file('sub/foo.cc'), expected)
 
     def test_missing_returns_empty(self):

--- a/src/tests/unit/source_includes_test.py
+++ b/src/tests/unit/source_includes_test.py
@@ -187,6 +187,7 @@ class ReadAllIncstkPathsTest(unittest.TestCase):
 
     # --- MSVC format paths ---
 
+    @unittest.skipUnless(os.name == 'nt', 'MSVC format only used on Windows')
     def test_msvc_format_collects_paths(self):
         path = self._write(
             'Note: including file:  pkg/a.h\n'
@@ -199,6 +200,7 @@ class ReadAllIncstkPathsTest(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    @unittest.skipUnless(os.name == 'nt', 'MSVC format only used on Windows')
     def test_msvc_format_strips_build_dir_prefix(self):
         path = self._write(
             'Note: including file:  pkg/a.h\n'

--- a/src/tests/unit/source_includes_test.py
+++ b/src/tests/unit/source_includes_test.py
@@ -21,8 +21,11 @@ _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..',
 sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
 
 from blade.inclusion_check import (  # noqa: E402
+    _parse_msvc_hdr_level_line,
     _read_all_incstk_paths,
+    _remove_build_dir_prefix,
     _scan_source_includes,
+    path_under_dir,
 )
 
 
@@ -181,6 +184,87 @@ class ReadAllIncstkPathsTest(unittest.TestCase):
         self.assertEqual(
             _read_all_incstk_paths('/nonexistent/path/xyz.incstk', 'build64_release'),
             set())
+
+    # --- MSVC format paths ---
+
+    def test_msvc_format_collects_paths(self):
+        path = self._write(
+            'Note: including file:  pkg/a.h\n'
+            'Note: including file:    pkg/b.h\n'
+        )
+        try:
+            self.assertEqual(
+                _read_all_incstk_paths(path, 'build64_release'),
+                {'pkg/a.h', 'pkg/b.h'})
+        finally:
+            os.unlink(path)
+
+    def test_msvc_format_strips_build_dir_prefix(self):
+        path = self._write(
+            'Note: including file:  pkg/a.h\n'
+            'Note: including file:    build64_release/proto/x.pb.h\n'
+        )
+        try:
+            self.assertEqual(
+                _read_all_incstk_paths(path, 'build64_release'),
+                {'pkg/a.h', 'proto/x.pb.h'})
+        finally:
+            os.unlink(path)
+
+
+class RemoveBuildDirPrefixTest(unittest.TestCase):
+    def test_strips_prefix_with_forward_slash(self):
+        self.assertEqual(
+            _remove_build_dir_prefix('build64_release/pkg/a.h', 'build64_release'),
+            'pkg/a.h')
+
+    def test_no_prefix_match_returns_unchanged(self):
+        self.assertEqual(
+            _remove_build_dir_prefix('pkg/a.h', 'build64_release'),
+            'pkg/a.h')
+
+    def test_partial_prefix_not_stripped(self):
+        # 'build64' is a substring but not the full dir component
+        self.assertEqual(
+            _remove_build_dir_prefix('build64/pkg/a.h', 'build64_release'),
+            'build64/pkg/a.h')
+
+
+class PathUnderDirTest(unittest.TestCase):
+    def test_sub_path_matches_with_forward_slash(self):
+        self.assertTrue(path_under_dir('pkg/sub/x.h', 'pkg'))
+
+    def test_exact_dir_matches(self):
+        self.assertTrue(path_under_dir('pkg', 'pkg'))
+
+    def test_dot_matches_any(self):
+        self.assertTrue(path_under_dir('anything.h', '.'))
+
+    def test_non_sub_path_returns_false(self):
+        self.assertFalse(path_under_dir('other/x.h', 'pkg'))
+
+    def test_sibling_dir_prefix_returns_false(self):
+        # 'pkg_extra' starts with 'pkg' but is not under 'pkg/'
+        self.assertFalse(path_under_dir('pkg_extra/x.h', 'pkg'))
+
+
+class ParseMsvcHdrLevelLineTest(unittest.TestCase):
+    def test_basic_level(self):
+        level, hdr = _parse_msvc_hdr_level_line(
+            'Note: including file:  pkg/a.h')
+        self.assertEqual(level, 2)
+        self.assertEqual(hdr, 'pkg/a.h')
+
+    def test_normalizes_backslash_to_forward(self):
+        _, hdr = _parse_msvc_hdr_level_line(
+            'Note: including file:  pkg\\sub\\a.h')
+        self.assertEqual(hdr, 'pkg/sub/a.h')
+
+    def test_deep_nesting(self):
+        level, hdr = _parse_msvc_hdr_level_line(
+            'Note: including file:          deep/nested.h')
+        self.assertEqual(level, 10)
+        self.assertEqual(hdr, 'deep/nested.h')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes the C/C++ header dependency check (hdrs check) on Windows/MSVC, where
it was effectively a no-op and, once made to run, mis-fired on path separators.

## What was broken

1. **Empty `.incstk` on MSVC.** The compile wrapper read only the child
   stderr; cl.exe fills its stdout pipe (a copyright/banner echo even under
   `/nologo`), the unread pipe deadlocks, and `/showIncludes` never drains —
   so every per-source `.incstk` came out empty and the check had nothing to
   verify.
2. **Separator mismatch.** Once the `.incstk` had content, the check ran but
   compared forward-slash paths (parsed from `/showIncludes`) against
   declaration paths the backend wrote with `os.sep` (backslashes), so every
   header looked "undeclared".

## The fix

- **Tee wrapper (`cc_wrapper.py`).** The MSVC `cc`/`cxx` rules wrap the
  compile, merge stdout+stderr into one pipe (no deadlock), stream every line
  to ninja's `deps=msvc` parser, and in parallel tee `Note: including file:`
  lines into the per-source `.incstk`. This removes the separate `cxxhdrs`
  preprocess for source files — the inclusion stack is now a by-product of the
  normal compile, exactly as `-H` is on GCC. `cxxhdrs` remains only for
  headers (never compiled) on every toolchain.
- **Filtering.** Bare echoed filenames (a cl.exe quirk ninja's `CLParser`
  filters for sources but not headers; nvcc also echoes `.cu` + temp names)
  are dropped from both the incstk and ninja. Absolute paths outside the
  workspace are dropped from the incstk only (still sent to ninja).
- **Path unification.** `inclusion_check.py` normalizes all declared paths to
  forward slashes as they are loaded, guarded by `os.sep != '/'` so it is a
  zero-cost no-op on POSIX.
- Removed the unused `_MSVC_TEE_WRAPPER_BAT`; updated the en/zh hdrs-check
  design docs.

Companion test fixtures: blade-build/blade-test#10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)