### PR TITLE
docs: lex_yacc_library generated header, attributes, and bison 3.0+ requirement

### DIFF
--- a/doc/en/build_rules/lexyacc.md
+++ b/doc/en/build_rules/lexyacc.md
@@ -17,7 +17,14 @@ This rule will generate a library and a header file.
 
 Attributes:
 
-- recursive=True Generate resursice C scanner
+- `recursive=True` — generate a reentrant C scanner.
+- `prefix='xxx'` — rename the `yy` symbol prefix (passed as flex `-P` / bison
+  `-p`), so several parsers can coexist in one binary without their `yyparse`
+  / `yylval` / ... globals colliding.
+- `lexflags=[...]` / `yaccflags=[...]` — extra flags passed straight through to
+  flex / bison. Note that flags which change the names of the generated files
+  are not supported: blade derives those names by its own rule and will not see
+  the override.
 
 lex_yacc_library also support most [cc_library attributes](cc.md#cc_library).
 
@@ -36,3 +43,22 @@ lex_yacc_library(
      recursive = True
 )
 ```
+
+### The generated header
+
+The header `bison -d` emits is named after the yacc source: `<yacc_file>.hh`
+for a C++ grammar (`.yy`), or `<yacc_file>.h` for a C grammar (`.y`). For the
+example above it is `line_parser.yy.hh`, and it declares the tokens and
+`yyparse`.
+
+A target that uses the parser includes it by its workspace-relative path, the
+same as any other generated header:
+
+```c++
+#include "path/to/line_parser.yy.hh"
+```
+
+Including it is also what lets the header dependency check see that your target
+genuinely uses the `lex_yacc_library`; relying only on the symbols (via your
+own forward declarations) without including this header would make the
+dependency look unused.

--- a/doc/en/prerequisites.md
+++ b/doc/en/prerequisites.md
@@ -40,7 +40,9 @@ Blade integrates with the following tools for enhanced build performance:
 ### Code Generation Tools
 - **SWIG:** Version 2.0+ (required for `swig_library` targets)
 - **Flex:** Version 2.5+ (required for `lex_yacc` targets)
-- **Bison:** Version 2.1+ (required for `lex_yacc` targets)
+- **Bison:** Version 3.0+ (required for `lex_yacc` targets). Bison 2.x is no
+  longer supported: its `-d` header omits the `yyparse` prototype, which
+  downstream code needs. See the macOS note below.
 
 ## Platform-Specific Notes
 
@@ -53,6 +55,12 @@ Blade integrates with the following tools for enhanced build performance:
 - **Xcode:** Install Xcode Command Line Tools (`xcode-select --install`)
 - **Homebrew:** Recommended for package management
 - **Python:** Use Homebrew Python or system Python with pip
+- **Bison** *(only for `lex_yacc_library` targets)*: macOS ships bison 2.3
+  (frozen at GPLv2 and too old — see above). Install a current one with
+  `brew install bison`. Homebrew keeps it keg-only (so it does not shadow the
+  system bison), so add it to `PATH` ahead of `/usr/bin`:
+  `export PATH="$(brew --prefix bison)/bin:$PATH"`. `flex` from Homebrew is fine
+  as-is.
 
 ### Windows Installation
 
@@ -72,6 +80,8 @@ Blade integrates with the following tools for enhanced build performance:
 | Ninja | 1.10 | 1.11+ | Build backend; 1.10+ required for multi-output rules with depslog |
 | GCC | 4.0 | 7.0+ | Clang 6.0+ also supported |
 | JDK | 1.6 | 11+ | LTS versions recommended |
+| Bison | 3.0 | 3.8+ | For `lex_yacc` targets; macOS stock 2.3 is too old (see macOS notes) |
+| Flex | 2.5 | 2.6+ | For `lex_yacc` targets |
 
 ## Verification Commands
 

--- a/doc/zh_CN/build_rules/lexyacc.md
+++ b/doc/zh_CN/build_rules/lexyacc.md
@@ -10,7 +10,11 @@
 
 属性：
 
-- recursive=True 生成可重入的 C scanner。
+- `recursive=True` — 生成可重入的 C scanner。
+- `prefix='xxx'` — 修改 `yy` 符号前缀（传给 flex `-P` / bison `-p`），让多个
+  parser 可在同一个二进制中共存，避免 `yyparse` / `yylval` 等全局符号冲突。
+- `lexflags=[...]` / `yaccflags=[...]` — 直接透传给 flex / bison 的额外参数。
+  注意：改变生成文件名的参数不受支持——blade 按自己的规则推算这些文件名，不会感知到此类覆盖。
 
 也支持大部分 [cc_library 的属性](cc.md#cc_library)。
 
@@ -29,3 +33,19 @@ lex_yacc_library(
      recursive = True
 )
 ```
+
+### 生成的头文件
+
+`bison -d` 生成的头文件以 yacc 源文件命名：C++ 语法（`.yy`）为 `<yacc 文件>.hh`，
+C 语法（`.y`）为 `<yacc 文件>.h`。上例即 `line_parser.yy.hh`，其中声明了 token
+和 `yyparse`。
+
+使用该 parser 的目标按工作区相对路径 `#include` 它，与引用其它生成头文件一样：
+
+```c++
+#include "path/to/line_parser.yy.hh"
+```
+
+include 这个头文件也是头文件依赖检查识别"你的目标确实用到了该 `lex_yacc_library`"
+的依据；如果只靠自己的前向声明使用其中的符号而不 include 此头文件，这条依赖会被
+判定为未使用。

--- a/doc/zh_CN/prerequisites.md
+++ b/doc/zh_CN/prerequisites.md
@@ -46,7 +46,8 @@ Blade 可与以下工具集成，从而提升构建性能：
 
 - **SWIG：** 2.0+（`swig_library` 目标必需）
 - **Flex：** 2.5+（`lex_yacc` 目标必需）
-- **Bison：** 2.1+（`lex_yacc` 目标必需）
+- **Bison：** 3.0+（`lex_yacc` 目标必需）。不再支持 bison 2.x：它的 `-d` 头文件
+  不声明 `yyparse` 原型，而下游代码需要它。详见下方 macOS 说明。
 
 ## 平台相关说明
 
@@ -61,6 +62,10 @@ Blade 可与以下工具集成，从而提升构建性能：
 - **Xcode：** 安装 Xcode Command Line Tools（`xcode-select --install`）
 - **Homebrew：** 推荐用于包管理
 - **Python：** 使用 Homebrew 提供的 Python，或系统自带 Python 配合 `pip`
+- **Bison** *（仅 `lex_yacc_library` 目标需要）*：macOS 自带的是 bison 2.3
+  （停留在 GPLv2、版本过老，见上文），需用 `brew install bison` 装新版。Homebrew
+  将其设为 keg-only（避免覆盖系统 bison），所以要把它加到 `PATH` 中、排在 `/usr/bin`
+  之前：`export PATH="$(brew --prefix bison)/bin:$PATH"`。Homebrew 的 `flex` 直接可用。
 
 ### Windows 安装
 
@@ -80,6 +85,8 @@ Blade 可与以下工具集成，从而提升构建性能：
 | Ninja | 1.10 | 1.11+ | 构建后端；含 depslog 的多输出规则需要 1.10+ |
 | GCC | 4.0 | 7.0+ | 也支持 Clang 6.0+ |
 | JDK | 1.6 | 11+ | 推荐使用 LTS 版本 |
+| Bison | 3.0 | 3.8+ | `lex_yacc` 目标需要；macOS 自带 2.3 过老（见 macOS 说明） |
+| Flex | 2.5 | 2.6+ | `lex_yacc` 目标需要 |
 
 ## 环境校验命令
 


### PR DESCRIPTION
Documentation follow-up to the lex_yacc work.

**`doc/{en,zh_CN}/build_rules/lexyacc.md`**
- Generated-header section: `bison -d` emits `<yacc_file>.hh` (C++) /
  `<yacc_file>.h` (C); how downstream targets `#include` it; and that including
  it is what makes the hdrs check see the `lex_yacc_library` as a used dep.
- Document previously-undocumented attributes: `prefix`, `lexflags`,
  `yaccflags` (with a note that flags changing generated file names are
  unsupported).

**`doc/{en,zh_CN}/prerequisites.md`**
- Bump the bison requirement to 3.0+ (2.x's `-d` header omits the `yyparse`
  prototype downstream code needs), add it to the version matrix, and add a
  macOS note: stock macOS ships bison 2.3, so install Homebrew bison and put
  its keg-only bin dir on PATH ahead of `/usr/bin` — matching what macOS CI now
  does (blade-build#1175).

🤖 Generated with [Claude Code](https://claude.com/claude-code)