### PR TITLE
ci: update blade-test E2E target hello-bin -> hello-world

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -93,6 +93,11 @@ jobs:
     - name: Install toolchain dependencies
       run: |
         brew install ninja flex bison protobuf
+        # Homebrew's bison is keg-only (macOS ships its own bison 2.3, frozen
+        # at GPLv2), so it is not on PATH by default. Prepend it so the build
+        # uses bison 3.x — whose -d header declares yyparse, which the lex_yacc
+        # suite's driver relies on.
+        echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
     - name: Verify tools
       run: |
         javac -version

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -102,4 +102,4 @@ jobs:
     - name: Run blade-test suites
       working-directory: blade-test
       run: |
-        PYTHONPATH="$GITHUB_WORKSPACE/blade-build/src" ./blade.sh test //suites/cc_basic:hello_test //suites/cc_basic:hello-bin //suites/java_basic:greeter_test //suites/lex_yacc_basic:calc_test //suites/py_basic:greeter_test
+        PYTHONPATH="$GITHUB_WORKSPACE/blade-build/src" ./blade.sh test //suites/cc_basic:hello_test //suites/cc_basic:hello-world //suites/java_basic:greeter_test //suites/lex_yacc_basic:calc_test //suites/py_basic:greeter_test

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -115,4 +115,4 @@ jobs:
         rem Explicit targets — exclude cu_basic (CUDA toolkit not available on CI)
         set PYTHONPATH=%GITHUB_WORKSPACE%\blade-build\src
         cd /d %GITHUB_WORKSPACE%\blade-test
-        call %GITHUB_WORKSPACE%\blade-build\blade.bat test //suites/cc_basic:hello_test //suites/cc_basic:hello-bin //suites/java_basic:greeter_test //suites/lex_yacc_basic:calc_test //suites/py_basic:greeter_test //suites/resource_basic:greeter_test
+        call %GITHUB_WORKSPACE%\blade-build\blade.bat test //suites/cc_basic:hello_test //suites/cc_basic:hello-world //suites/java_basic:greeter_test //suites/lex_yacc_basic:calc_test //suites/py_basic:greeter_test //suites/resource_basic:greeter_test


### PR DESCRIPTION
blade-test renamed `//suites/cc_basic:hello-bin` to `:hello-world` (it now
depends on both `:hello` and `:world`). The macOS and Windows CI E2E smoke
steps still listed the old target by name, so every blade-build PR started
failing with:

```
Blade(error): Target "//suites/cc_basic:hello-bin" does not exist
```

Point both workflows at the new target name. (The Python-package E2E runs
`//suites/...` so it was unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)