### PR TITLE
docs: per-OS CI status badges with Linux/macOS/Windows logos

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -3,7 +3,6 @@
 [![license NewBSD](https://img.shields.io/badge/License-NewBSD-yellow.svg)](COPYING)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
 [![Code Style](https://img.shields.io/badge/code%20style-google-blue.svg)](https://google.github.io/styleguide/pyguide.html)
-[![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macos%20%7C%20windows-lightgrey.svg)](doc/zh_CN/prerequisites.md)
 
 ![Blade Build](image/blade-200x400.png "Blade Build")
 
@@ -13,7 +12,9 @@ Blade 是一款面向大规模 monorepo 环境和主干开发（trunk-based deve
 
 ## Build Status
 
-[![Build Status](https://github.com/blade-build/blade-build/actions/workflows/python-package.yml/badge.svg)](https://github.com/blade-build/blade-build/actions/workflows/python-package.yml)
+[![Linux](https://img.shields.io/github/actions/workflow/status/blade-build/blade-build/python-package.yml?branch=master&logo=linux&logoColor=white&label=Linux)](https://github.com/blade-build/blade-build/actions/workflows/python-package.yml)
+[![macOS](https://img.shields.io/github/actions/workflow/status/blade-build/blade-build/macos-ci.yml?branch=master&logo=apple&logoColor=white&label=macOS)](https://github.com/blade-build/blade-build/actions/workflows/macos-ci.yml)
+[![Windows](https://img.shields.io/github/actions/workflow/status/blade-build/blade-build/windows-ci.yml?branch=master&logo=windows&logoColor=white&label=Windows)](https://github.com/blade-build/blade-build/actions/workflows/windows-ci.yml)
 [![Coverage](https://coveralls.io/repos/blade-build/blade-build/badge.svg?branch=master)](https://coveralls.io/github/blade-build/blade-build)
 [![Downloads](https://img.shields.io/github/downloads/blade-build/blade-build/total.svg)](https://github.com/blade-build/blade-build/releases)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![license NewBSD](https://img.shields.io/badge/License-NewBSD-yellow.svg)](COPYING)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
 [![Code Style](https://img.shields.io/badge/code%20style-google-blue.svg)](https://google.github.io/styleguide/pyguide.html)
-[![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macos%20%7C%20windows-lightgrey.svg)](doc/en/prerequisites.md)
 
 ![Blade Build](image/blade-200x400.png "Blade Build")
 
@@ -13,7 +12,9 @@ A modern, high-performance build system optimized for trunk-based development in
 
 ## Build Status
 
-[![Build Status](https://github.com/blade-build/blade-build/actions/workflows/python-package.yml/badge.svg)](https://github.com/blade-build/blade-build/actions/workflows/python-package.yml)
+[![Linux](https://img.shields.io/github/actions/workflow/status/blade-build/blade-build/python-package.yml?branch=master&logo=linux&logoColor=white&label=Linux)](https://github.com/blade-build/blade-build/actions/workflows/python-package.yml)
+[![macOS](https://img.shields.io/github/actions/workflow/status/blade-build/blade-build/macos-ci.yml?branch=master&logo=apple&logoColor=white&label=macOS)](https://github.com/blade-build/blade-build/actions/workflows/macos-ci.yml)
+[![Windows](https://img.shields.io/github/actions/workflow/status/blade-build/blade-build/windows-ci.yml?branch=master&logo=windows&logoColor=white&label=Windows)](https://github.com/blade-build/blade-build/actions/workflows/windows-ci.yml)
 [![Coverage](https://coveralls.io/repos/blade-build/blade-build/badge.svg?branch=master)](https://coveralls.io/github/blade-build/blade-build)
 [![Downloads](https://img.shields.io/github/downloads/blade-build/blade-build/total.svg)](https://github.com/blade-build/blade-build/releases)
 

--- a/doc/en/prerequisites.md
+++ b/doc/en/prerequisites.md
@@ -5,9 +5,13 @@
 Blade requires the following core dependencies for basic operation:
 
 ### Operating System Support
+
+Linux is the primary, fully supported platform; macOS and Windows support is
+experimental.
+
 - **Linux:** All major distributions (Ubuntu, CentOS, Debian, etc.)
-- **macOS:** macOS 10.12+ with Xcode Command Line Tools
-- **Windows:** Windows 10/11 with Visual Studio Build Tools (MSVC toolchain)
+- **macOS** *(experimental)*: macOS 10.12+ with Xcode Command Line Tools
+- **Windows** *(experimental)*: Windows 10/11 with Visual Studio Build Tools (MSVC toolchain)
   - Developer Mode is recommended (Settings → Privacy & security → For developers)
     to enable NTFS symlink support; if not enabled, `blade-bin` symlink is skipped
 

--- a/doc/zh_CN/prerequisites.md
+++ b/doc/zh_CN/prerequisites.md
@@ -6,9 +6,11 @@ Blade 的基本运行需要以下核心依赖：
 
 ### 操作系统支持
 
+Linux 是主要且完整支持的平台；macOS 与 Windows 支持尚处于实验阶段。
+
 - **Linux：** 主流发行版（Ubuntu、CentOS、Debian 等）
-- **macOS：** macOS 10.12+，并安装 Xcode Command Line Tools
-- **Windows：** Windows 10/11，需安装 Visual Studio Build Tools（MSVC 工具链）
+- **macOS** *（实验性）*：macOS 10.12+，并安装 Xcode Command Line Tools
+- **Windows** *（实验性）*：Windows 10/11，需安装 Visual Studio Build Tools（MSVC 工具链）
   - 建议启用**开发人员模式**（设置 → 隐私和安全性 → 开发者选项）以支持 NTFS 符号链接
   - 如未启用开发人员模式，部分功能（如 `blade-bin` 符号链接）将降级为警告并跳过
 


### PR DESCRIPTION
Adds platform build-status badges for all three OSes, with their logos.

- **README / README-zh:** replace the single Linux build badge and the static
  `platform` badge with three per-OS workflow-status badges (Tux / Apple /
  Windows logos), each linking to its CI workflow:
  `python-package.yml` (Linux), `macos-ci.yml`, `windows-ci.yml`. The two old
  badges both just enumerated the platforms, so folding them into the logo'd
  status badges removes that duplication.
- **prerequisites (en/zh):** mark macOS and Windows as *experimental* in the
  OS-support list, which previously listed all three without the caveat. The
  README already states this (release highlights + Origin), so nothing is
  duplicated there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)