### PR TITLE
ci: restore Coveralls upload (unit + integration coverage)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,6 +31,28 @@ jobs:
     - name: Run integration tests
       run: |
         src/test/runall.sh
+    - name: Add unit-test coverage and upload to Coveralls
+      # Only from a single matrix entry, so the branch gets one Coveralls build
+      # rather than five competing ones. (The upload step was dropped in the v3
+      # CI rewrite, which is why the badge went grey.)
+      #
+      # `src/test/run.sh` already left a combined $PWD/.coverage from the
+      # integration tests. Run the unit tests under coverage too and merge them
+      # in with `combine --append`, so Coveralls reflects both suites.
+      #
+      # Non-fatal: coverage upload is informational and integration-tests gates
+      # e2e-smoke, so a Coveralls hiccup must not turn the whole build red.
+      if: matrix.python-version == '3.12'
+      continue-on-error: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        pip install pytest
+        PYTHONPATH=src python -m coverage run --rcfile=.coveragerc \
+            --source="$PWD/src/blade" -m pytest src/tests/unit
+        python -m coverage combine --append --rcfile=.coveragerc
+        python -m coverage report --rcfile=.coveragerc
+        coveralls --service=github
 
   unit-tests:
     name: Unit tests (Python ${{ matrix.python-version }})


### PR DESCRIPTION
The coverage badge went grey because the v3 CI rewrite dropped the
`Coveralls` upload step the pre-v3 workflow had (commit 2236cf8). `coverage`
data is still produced by `src/test/run.sh` (coverage run + combine), it was
just never uploaded.

This restores the upload, and improves on the old behavior:

- Upload from a **single** matrix entry (Python 3.12) so the branch gets one
  Coveralls build instead of five competing ones.
- Also run the **unit tests** under coverage and merge them into the existing
  integration `.coverage` with `coverage combine --append`, so the reported
  number reflects both suites (previously only integration was measured).
- `continue-on-error: true` — coverage upload is informational and
  `integration-tests` gates `e2e-smoke`, so a Coveralls hiccup must not turn
  the whole build red.

Note: if coveralls.io has not been linked to `blade-build/blade-build` since
the migration from `chen3feng/blade-build`, the first upload may need the repo
enabled once in the Coveralls dashboard; the GitHub-token upload otherwise
auto-registers public repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)