### PR TITLE
feat(cc): per-target generate_dynamic tri-state opt-out on cc_library

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -941,6 +941,7 @@ class CcLibrary(CcTarget):
                  allow_undefined: bool,
                  secret: bool,
                  secret_revision_file: str | None,
+                 generate_dynamic: bool | None,
                  kwargs: dict[str, object]):
         """Init method.
 
@@ -983,6 +984,16 @@ class CcLibrary(CcTarget):
         self.attr['always_optimize'] = always_optimize
         self.attr['deprecated'] = deprecated
         self.attr['allow_undefined'] = allow_undefined
+        # `generate_dynamic` is a tri-state: None inherits the global default
+        # (already computed in CcTarget.__init__ from --generate-dynamic /
+        # cc_library_config.generate_dynamic); an explicit True/False overrides
+        # it per target. An explicit False additionally opts the library out of
+        # the implicit "generate_dynamic = True" a dynamic_link binary forces on
+        # its deps (see Target._expand_deps_generation), so it is always linked
+        # statically (the static archive is produced unconditionally).
+        if generate_dynamic is not None:
+            self.attr['generate_dynamic'] = generate_dynamic
+            self.attr['generate_dynamic_forced_off'] = generate_dynamic is False
         self._add_tags('lang:cc', 'type:library')
         self._set_secret(secret, secret_revision_file)
         self._set_hdrs(hdrs)
@@ -1220,6 +1231,7 @@ def cc_library(
         secret: bool = False,
         secret_revision_file: str | None = None,
         secure: bool = False,
+        generate_dynamic: bool | None = None,
         **kwargs: object):
     """cc_library target.
 
@@ -1276,6 +1288,7 @@ def cc_library(
             allow_undefined=allow_undefined,
             secret=secret or secure,
             secret_revision_file=secret_revision_file,
+            generate_dynamic=generate_dynamic,
             kwargs=kwargs)
     target.attr['keep_deps'] = [target._unify_dep(d) for d in keep_deps]
     build_manager.instance.register_target(target)
@@ -1516,6 +1529,11 @@ class CcBinary(CcTarget):
             build_targets = self.blade.get_build_targets()
             assert self.expanded_deps is not None, 'expanded_deps not expanded'
             for dep in self.expanded_deps:
+                # Respect a library's explicit `generate_dynamic = False`: such a
+                # dep is never built as a shared library and is linked statically
+                # even into a dynamic_link binary.
+                if build_targets[dep].attr.get('generate_dynamic_forced_off'):
+                    continue
                 build_targets[dep].attr['generate_dynamic'] = True
 
     def _get_rpath_links(self):

--- a/src/tests/unit/cc_generate_dynamic_test.py
+++ b/src/tests/unit/cc_generate_dynamic_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 
 """Unit tests for the per-target ``generate_dynamic`` tri-state opt-out.

--- a/src/tests/unit/cc_generate_dynamic_test.py
+++ b/src/tests/unit/cc_generate_dynamic_test.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+
+"""Unit tests for the per-target ``generate_dynamic`` tri-state opt-out.
+
+A ``dynamic_link`` binary/test forces ``generate_dynamic = True`` onto every
+dependency so each is built as a shared library. A ``cc_library`` may opt out
+with an explicit ``generate_dynamic = False`` (recorded as
+``generate_dynamic_forced_off``); such a library is then linked statically even
+into a dynamic_link binary. These tests pin that
+``CcBinary._expand_deps_generation`` honors the opt-out.
+"""
+
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import cc_targets  # noqa: E402  (sys.path tweak above)
+
+
+def _bare_binary(dynamic_link, expanded_deps, build_targets):
+    """A ``CcBinary`` with just the fields ``_expand_deps_generation`` reads."""
+    binary = cc_targets.CcBinary.__new__(cc_targets.CcBinary)
+    binary.attr = {'dynamic_link': dynamic_link}
+    binary.expanded_deps = expanded_deps
+    binary.blade = mock.Mock()
+    binary.blade.get_build_targets.return_value = build_targets
+    return binary
+
+
+def _dep(**attr):
+    return types.SimpleNamespace(attr=dict(attr))
+
+
+class ExpandDepsGenerationTest(unittest.TestCase):
+    def test_dynamic_link_forces_generate_dynamic_on_plain_deps(self):
+        normal = _dep()
+        binary = _bare_binary(True, ['//a:normal'], {'//a:normal': normal})
+        binary._expand_deps_generation()
+        self.assertIs(True, normal.attr['generate_dynamic'])
+
+    def test_explicit_opt_out_is_not_forced_on(self):
+        normal = _dep()
+        opted_out = _dep(generate_dynamic=False, generate_dynamic_forced_off=True)
+        binary = _bare_binary(
+            True, ['//a:normal', '//a:opted_out'],
+            {'//a:normal': normal, '//a:opted_out': opted_out})
+        binary._expand_deps_generation()
+        # The plain dep is forced on...
+        self.assertIs(True, normal.attr['generate_dynamic'])
+        # ...but the opted-out library stays False (never a shared library).
+        self.assertIs(False, opted_out.attr['generate_dynamic'])
+
+    def test_static_link_binary_touches_nothing(self):
+        normal = _dep()
+        binary = _bare_binary(False, ['//a:normal'], {'//a:normal': normal})
+        binary._expand_deps_generation()
+        self.assertNotIn('generate_dynamic', normal.attr)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
First slice (PR-A) of #1181.

`cc_library` gains a **`generate_dynamic`** attribute — a tri-state
(`None` / `True` / `False`, default `None`):

- **`None`** — inherit the global default (`--generate-dynamic` /
  `cc_library_config.generate_dynamic`); unchanged behavior.
- **`True`** — always build the shared library.
- **`False`** — never build a shared library, and **opt out** of the implicit
  `generate_dynamic = True` that a `dynamic_link` binary forces onto its deps
  (`CcBinary._expand_deps_generation`). The library is then linked statically
  even into a dynamic-link binary (its static archive is produced
  unconditionally regardless).

This gives DLL-unsafe libraries — those that export global **data** across a
DLL boundary, or would exceed the Windows 65,535-export limit — a way to stay
static once the Windows DLL pipeline (later PRs of #1181) lands. Behavior on
Linux/macOS is unchanged at the default.

**Tests:** `src/tests/unit/cc_generate_dynamic_test.py` pins that
`_expand_deps_generation` forces plain deps on but honors an explicit
opt-out, and does nothing for a static-link binary. Verified end-to-end on
Windows/MSVC (a `cc_library(generate_dynamic=False)` builds as a static lib
and links into its binary).

Docs for the attribute are deferred to the docs/smoke PR (PR-E) of #1181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)