### PR TITLE
ci: run dynamic_link DLL smoke; restore Windows blade-test run block

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -107,4 +107,4 @@ jobs:
     - name: Run blade-test suites
       working-directory: blade-test
       run: |
-        PYTHONPATH="$GITHUB_WORKSPACE/blade-build/src" ./blade.sh test //suites/cc_basic:hello_test //suites/cc_basic:hello-world //suites/java_basic:greeter_test //suites/lex_yacc_basic:calc_test //suites/py_basic:greeter_test
+        PYTHONPATH="$GITHUB_WORKSPACE/blade-build/src" ./blade.sh test //suites/cc_basic:hello_test //suites/cc_basic:hello_dynamic_test //suites/cc_basic:hello-world //suites/java_basic:greeter_test //suites/lex_yacc_basic:calc_test //suites/py_basic:greeter_test

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -111,3 +111,8 @@ jobs:
         win_bison --version
     - name: Run blade-test suites
       shell: cmd
+      run: |
+        rem Explicit targets — exclude cu_basic (CUDA toolkit not available on CI)
+        set PYTHONPATH=%GITHUB_WORKSPACE%\blade-build\src
+        cd /d %GITHUB_WORKSPACE%\blade-test
+        call %GITHUB_WORKSPACE%\blade-build\blade.bat test //suites/cc_basic:hello_test //suites/cc_basic:hello_dynamic_test //suites/cc_basic:hello-world //suites/java_basic:greeter_test //suites/lex_yacc_basic:calc_test //suites/py_basic:greeter_test //suites/resource_basic:greeter_test


### PR DESCRIPTION
Final piece of #1181 (PR-E), plus a regression fix.

## Restore (regression from #1187)

#1187 accidentally dropped the `run:` block of the Windows **Run blade-test suites** step (an over-broad `git add -A` committed a stray truncation of `windows-ci.yml`). The step became a no-op, so the Windows E2E smoke silently stopped running blade-test (visible as the check count falling 27→21). This PR restores it.

## Add the DLL smoke

Adds `//suites/cc_basic:hello_dynamic_test` (blade-test #13) to the **Windows** and **macOS** explicit target lists, so the Windows DLL path — auto-export `.def`, import-library link, runtime DLL discovery — is exercised end to end with real test cases. The **Linux** e2e already globs `//suites/...`, so it picks the target up automatically.

Depends on blade-test #13 (merged) and #1187 (merged): the dynamic test links its static-kept test framework via the new static-only-dep fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)