### PR TITLE
ci: run cross-package dynamic_link DLL smoke on Windows/macOS

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -107,4 +107,4 @@ jobs:
     - name: Run blade-test suites
       working-directory: blade-test
       run: |
-        PYTHONPATH="$GITHUB_WORKSPACE/blade-build/src" ./blade.sh test //suites/cc_basic:hello_test //suites/cc_basic:hello_dynamic_test //suites/cc_basic:hello-world //suites/java_basic:greeter_test //suites/lex_yacc_basic:calc_test //suites/py_basic:greeter_test
+        PYTHONPATH="$GITHUB_WORKSPACE/blade-build/src" ./blade.sh test //suites/cc_basic:hello_test //suites/cc_basic:hello_dynamic_test //suites/cc_basic:cross_package_dynamic_test //suites/cc_basic:hello-world //suites/java_basic:greeter_test //suites/lex_yacc_basic:calc_test //suites/py_basic:greeter_test

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -115,4 +115,4 @@ jobs:
         rem Explicit targets — exclude cu_basic (CUDA toolkit not available on CI)
         set PYTHONPATH=%GITHUB_WORKSPACE%\blade-build\src
         cd /d %GITHUB_WORKSPACE%\blade-test
-        call %GITHUB_WORKSPACE%\blade-build\blade.bat test //suites/cc_basic:hello_test //suites/cc_basic:hello_dynamic_test //suites/cc_basic:hello-world //suites/java_basic:greeter_test //suites/lex_yacc_basic:calc_test //suites/py_basic:greeter_test //suites/resource_basic:greeter_test
+        call %GITHUB_WORKSPACE%\blade-build\blade.bat test //suites/cc_basic:hello_test //suites/cc_basic:hello_dynamic_test //suites/cc_basic:cross_package_dynamic_test //suites/cc_basic:hello-world //suites/java_basic:greeter_test //suites/lex_yacc_basic:calc_test //suites/py_basic:greeter_test //suites/resource_basic:greeter_test


### PR DESCRIPTION
Adds `//suites/cc_basic:cross_package_dynamic_test` (blade-test #14) to the **Windows** and **macOS** explicit target lists.

This is the test whose dependency DLL is **not** next to the exe (it lives in a separate package's output dir), so it resolves only via blade's runtime DLL discovery — flattened runfiles + `PATH`. Running it in CI guards that path, which the same-package `hello_dynamic_test` does not exercise (its DLL is found by the default exe-directory search).

The **Linux** e2e globs `//suites/...` and already picks the target up.

Depends on blade-test #14 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)