### PR TITLE
feat(cc): singularize linker-input attrs (export_map, linker_script) (#1182)

### DIFF
--- a/doc/en/build_rules/cc.md
+++ b/doc/en/build_rules/cc.md
@@ -520,15 +520,17 @@ Attributes:
   host process at runtime, the definition of these symbols does not exist in the link phase.
 - `strip`: bool = False, whether to remove the debugging symbol information. If enabled, the size of the generated library can be reduced, but symbolic debugging
   cannot be performed.
-- `linker_scripts`: list(string), uses linker scripts.
-  The [linker script](https://sourceware.org/binutils/docs/ld/Scripts.html) is a script used to control the linking process.
+- `linker_script`: str, a single [linker script](https://sourceware.org/binutils/docs/ld/Scripts.html) used to control the linking process.
   Its role is mainly to specify how to put the sections in the input file into the output file and to control the layout of the sections in the input file in the program address space.
   The linker has a default built-in linking script, which can be viewed with `ld --verbose`. This option will replace the system's default linking script.
-  The linker script files usually have the extension `.ld` or `.lds`.
-  Linker scripts are usually quite complex, so if you just want to control the version or visibility of the symbols, use the `version_scripts` option below.
-- `version_scripts`: list(string), using [linker "version" script](https://sourceware.org/binutils/docs/ld/VERSION.html).
-  The linker version script is used to control the version and visibility of the symbol, if no version id is specified, it only to control the visibility of the symbol.
-  Linker version script files usually have the extension `exp`, `sym`, `.ver` or `.map`.
+  The linker script file usually has the extension `.ld` or `.lds`.
+  Only a single file is accepted: a SECTIONS script replaces the default, so multiple `-T` scripts do not meaningfully combine. This is a GNU-ld / ELF (Linux) feature only — macOS `ld64` and Windows `link.exe` have no `-T` equivalent.
+  Linker scripts are usually quite complex, so if you just want to control the visibility of the symbols, use the `export_map` option below.
+  > The plural `linker_scripts` (a list) is a **deprecated alias**; using it emits a warning and only the first file is used.
+- `export_map`: str, a single [linker "version" script](https://sourceware.org/binutils/docs/ld/VERSION.html) used to control which symbols the shared library exports.
+  Despite the linker term "version script", the mechanism here is *export filtering*, not ABI versioning — hence the name `export_map` (the industry term for a symbol-export control file). Use the anonymous-version form (no version id) to control visibility only.
+  Only a single file is accepted (GNU ld rejects more than one anonymous version node). It is available on `cc_library`, `cc_binary` and `cc_plugin`. On Linux it is passed to `--version-script`; the export-map files usually have the extension `.exp`, `.sym`, `.ver` or `.map`.
+  > The plural `version_scripts` (a list) is a **deprecated alias** for `export_map`; using it emits a warning and only the first file is used.
 
 `prefix` and `suffix` control the file name of the generated dynamic library. Assuming `name='file'`, on a Linux toolchain the default output is `libfile.so`;
 setting `prefix=''` makes it `file.so`. Passing a `name` that already carries a shared-library extension (e.g. `name='file.so'`) is no longer implicitly treated as "the full output file name"; to fully customize the output name, pass `prefix=''` and `suffix='.so'` explicitly.

--- a/doc/zh_CN/build_rules/cc.md
+++ b/doc/zh_CN/build_rules/cc.md
@@ -506,15 +506,17 @@ cc_plugin(
 - `suffix`: str | None, 生成的动态库的文件名后缀。默认为 `None`，表示沿用当前工具链的平台默认后缀（Linux 为 `.so`，macOS 为 `.dylib`，Windows 为 `.dll`）。
 - `allow_undefined`: bool, 链接时是否允许未定义的符号。因为很多插件库运行时依赖宿主进程提供的符号名，链接阶段并不存在这些符号的定义。
 - `strip`: bool, 是否去除调试符号信息，开启后可以减少生成的库的大小，但是无法进行符号化调试。
-- `linker_scripts`: list(string)，使用链接器脚本。
-  [链接器脚本](https://sourceware.org/binutils/docs/ld/Scripts.html)是用来控制链接过程的脚本。
+- `linker_script`: str，单个[链接器脚本](https://sourceware.org/binutils/docs/ld/Scripts.html)，用来控制链接过程。
   它的作用主要是规定如何把输入文件内的 section 放入输出文件内，并控制输入文件内各部分在程序地址空间内的布局。
   链接器有个默认的内置链接脚本，可用 `ld --verbose` 查看。此选项将会替换系统的默认链接脚本。
   链接器脚本文件的扩展名一般为 `.ld` 或者 `.lds`。
-  链接器脚本通常相当复杂，如果只是想控制符号的版本和可见性，请使用下面的 `version_script` 选项。
-- `version_scripts`: list(string)，使用[链接器“版本”脚本](https://sourceware.org/binutils/docs/ld/VERSION.html)。
-  链接器版本脚本用来控制符号的版本及可见性，内容仅限于完整的链接脚本里 `VERSION {};` 内的部分，如果不指定版本号，那么可以只用来控制符号的可见性。
-  链接器版本脚本文件的扩展名一般为 `exp`、`sym`、`.ver` 或者 `.map`。
+  只接受单个文件：SECTIONS 脚本会替换默认脚本，多个 `-T` 脚本无法有意义地组合。该特性仅限 GNU ld / ELF（Linux）；macOS `ld64` 和 Windows `link.exe` 没有 `-T` 的对应物。
+  链接器脚本通常相当复杂，如果只是想控制符号的可见性，请使用下面的 `export_map` 选项。
+  > 复数形式 `linker_scripts`（列表）是**已废弃的别名**，使用时会告警，且只取第一个文件。
+- `export_map`: str，单个[链接器“版本”脚本](https://sourceware.org/binutils/docs/ld/VERSION.html)，用来控制共享库导出哪些符号。
+  虽然链接器术语叫“版本脚本”，但这里的机制是*导出过滤*而非 ABI 版本管理，因此命名为 `export_map`（业界对符号导出控制文件的通称）。使用匿名版本形式（不指定版本号）即可只控制可见性。
+  只接受单个文件（GNU ld 不允许多于一个匿名版本节点）。可用于 `cc_library`、`cc_binary` 和 `cc_plugin`。在 Linux 上传给 `--version-script`；导出映射文件的扩展名一般为 `.exp`、`.sym`、`.ver` 或者 `.map`。
+  > 复数形式 `version_scripts`（列表）是 `export_map` 的**已废弃别名**，使用时会告警，且只取第一个文件。
 
 `prefix` 和 `suffix` 控制生成的动态库的文件名。假设 `name='file'`，在 Linux 工具链上默认生成 `libfile.so`；设置 `prefix=''` 则变为 `file.so`。传入已带共享库后缀的 `name`（如 `name='file.so'`）不再被隐式识别为"输出文件全名"，如需完全自定义输出文件名，请改用 `prefix=''` 与 `suffix='.so'` 显式表达。
 

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -772,6 +772,7 @@ class CcTarget(Target):
         if inclusion_check_result:
             incchk_deps.append(inclusion_check_result)
         self._cc_link(output, 'solink', objs=objs, deps=usr_libs, sys_libs=sys_libs,
+                      version_scripts=self.attr.get('vers_fullpath'),
                       order_only_deps=incchk_deps, target_linkflags=target_linkflags)
         self._add_target_file(tc.DYNAMIC_LIB_LABEL, output)
 
@@ -823,6 +824,36 @@ class CcTarget(Target):
         self._static_cc_library(objs, inclusion_check_result)
         if self.attr.get('generate_dynamic'):
             self._dynamic_cc_library(objs, inclusion_check_result)
+
+    def _resolve_linker_input_file(self, singular, plural, singular_name, plural_name):
+        """Resolve a single linker-input file from the canonical singular
+        attribute and its deprecated plural alias.
+
+        Returns the full paths as a list with at most one entry (kept as a
+        list so it splices straight into the existing list-shaped
+        ``lds_fullpath`` / ``vers_fullpath`` handling and ``_cc_link``).
+
+        Emits a deprecation warning when the plural alias is used, and warns
+        when more than one file is given -- a single file is the only
+        meaningful count for both a ``--version-script`` export map (GNU ld
+        rejects two anonymous version nodes) and a ``-T`` linker script
+        (a SECTIONS script replaces the default; multiple conflict).
+        """
+        files = var_to_list(singular)
+        plural_files = var_to_list(plural)
+        if plural_files:
+            self.warning('"%s" is deprecated, use "%s" (a single file) instead' %
+                         (plural_name, singular_name))
+            if files:
+                self.warning('both "%s" and "%s" are given, "%s" is ignored' %
+                             (singular_name, plural_name, plural_name))
+            else:
+                files = plural_files
+        if len(files) > 1:
+            self.warning('"%s" expects a single file, but %d were given; '
+                         'only the first is used' % (singular_name, len(files)))
+            files = files[:1]
+        return self._fullpath_sources(files)
 
     def _cc_link(self, output, rule, objs, deps, sys_libs, linker_scripts=None, version_scripts=None,
                  target_linkflags=None, implicit_deps=None,
@@ -1015,6 +1046,7 @@ class CcLibrary(CcTarget):
                  secret: bool,
                  secret_revision_file: str | None,
                  generate_dynamic: bool | None,
+                 export_map: StrOrListOpt,
                  kwargs: dict[str, object]):
         """Init method.
 
@@ -1057,6 +1089,12 @@ class CcLibrary(CcTarget):
         self.attr['always_optimize'] = always_optimize
         self.attr['deprecated'] = deprecated
         self.attr['allow_undefined'] = allow_undefined
+        # `export_map` (a single linker version script) controls which symbols
+        # the shared library exports; passed to `--version-script` on Linux when
+        # the dynamic library is built (see `_dynamic_cc_library`). No deprecated
+        # plural alias here -- `cc_library` never had `version_scripts`.
+        self.attr['vers_fullpath'] = self._resolve_linker_input_file(
+            export_map, None, 'export_map', 'version_scripts')
         # `generate_dynamic` is a tri-state: None inherits the global default
         # (already computed in CcTarget.__init__ from --generate-dynamic /
         # cc_library_config.generate_dynamic); an explicit True/False overrides
@@ -1305,6 +1343,7 @@ def cc_library(
         secret_revision_file: str | None = None,
         secure: bool = False,
         generate_dynamic: bool | None = None,
+        export_map: StrOrListOpt = None,
         **kwargs: object):
     """cc_library target.
 
@@ -1362,6 +1401,7 @@ def cc_library(
             secret=secret or secure,
             secret_revision_file=secret_revision_file,
             generate_dynamic=generate_dynamic,
+            export_map=export_map,
             kwargs=kwargs)
     target.attr['keep_deps'] = [target._unify_dep(d) for d in keep_deps]
     build_manager.instance.register_target(target)
@@ -1541,7 +1581,9 @@ class CcBinary(CcTarget):
                  linkflags: StrOrListOpt,
                  extra_cppflags: StrOrListOpt,
                  extra_linkflags: StrOrListOpt,
+                 linker_script: StrOrListOpt,
                  linker_scripts: StrOrListOpt,
+                 export_map: StrOrListOpt,
                  version_scripts: StrOrListOpt,
                  export_dynamic: bool,
                  kwargs: dict[str, object]):
@@ -1561,8 +1603,6 @@ class CcBinary(CcTarget):
         incs = var_to_list(incs)
         extra_cppflags = var_to_list(extra_cppflags)
         extra_linkflags = var_to_list(extra_linkflags)
-        linker_scripts = var_to_list(linker_scripts)
-        version_scripts = var_to_list(version_scripts)
         visibility_list = var_to_list_or_none(visibility)
         optimize_list = var_to_list_or_none(optimize)
         linkflags_list = var_to_list_or_none(linkflags)
@@ -1584,8 +1624,10 @@ class CcBinary(CcTarget):
                 kwargs=kwargs)
         self.attr['embed_version'] = embed_version
         self.attr['dynamic_link'] = dynamic_link
-        self.attr['lds_fullpath'] = self._fullpath_sources(linker_scripts)
-        self.attr['vers_fullpath'] = self._fullpath_sources(version_scripts)
+        self.attr['lds_fullpath'] = self._resolve_linker_input_file(
+            linker_script, linker_scripts, 'linker_script', 'linker_scripts')
+        self.attr['vers_fullpath'] = self._resolve_linker_input_file(
+            export_map, version_scripts, 'export_map', 'version_scripts')
         self.attr['export_dynamic'] = export_dynamic
         self.attr['dwp'] = is_fission() and need_dwp()
         self._add_tags('lang:cc', 'type:binary')
@@ -1717,7 +1759,9 @@ def cc_binary(name: str,
               linkflags: StrOrListOpt = None,
               extra_cppflags: StrOrListOpt = None,
               extra_linkflags: StrOrListOpt = None,
+              linker_script: StrOrListOpt = None,
               linker_scripts: StrOrListOpt = None,
+              export_map: StrOrListOpt = None,
               version_scripts: StrOrListOpt = None,
               export_dynamic: bool = False,
               **kwargs: object):
@@ -1738,7 +1782,9 @@ def cc_binary(name: str,
             linkflags=linkflags,
             extra_cppflags=extra_cppflags,
             extra_linkflags=extra_linkflags,
+            linker_script=linker_script,
             linker_scripts=linker_scripts,
+            export_map=export_map,
             version_scripts=version_scripts,
             export_dynamic=export_dynamic,
             kwargs=kwargs)
@@ -1785,7 +1831,9 @@ class CcPlugin(CcTarget):
                  linkflags: 'StrOrListOpt',
                  extra_cppflags: 'StrOrListOpt',
                  extra_linkflags: 'StrOrListOpt',
+                 linker_script: 'StrOrListOpt',
                  linker_scripts: 'StrOrListOpt',
+                 export_map: 'StrOrListOpt',
                  version_scripts: 'StrOrListOpt',
                  allow_undefined: bool,
                  strip: bool,
@@ -1807,8 +1855,6 @@ class CcPlugin(CcTarget):
         incs = var_to_list(incs)
         extra_cppflags = var_to_list(extra_cppflags)
         extra_linkflags = var_to_list(extra_linkflags)
-        linker_scripts = var_to_list(linker_scripts)
-        version_scripts = var_to_list(version_scripts)
         visibility = var_to_list_or_none(visibility)
         optimize = var_to_list_or_none(optimize)
         linkflags = var_to_list_or_none(linkflags)
@@ -1848,8 +1894,10 @@ class CcPlugin(CcTarget):
         self.attr['suffix'] = suffix
         self.attr['allow_undefined'] = allow_undefined
         self.attr['strip'] = strip
-        self.attr['lds_fullpath'] = self._fullpath_sources(linker_scripts)
-        self.attr['vers_fullpath'] = self._fullpath_sources(version_scripts)
+        self.attr['lds_fullpath'] = self._resolve_linker_input_file(
+            linker_script, linker_scripts, 'linker_script', 'linker_scripts')
+        self.attr['vers_fullpath'] = self._resolve_linker_input_file(
+            export_map, version_scripts, 'export_map', 'version_scripts')
         self._add_tags('lang:cc', 'type:plugin')
 
     def _before_generate(self):  # override
@@ -1910,7 +1958,9 @@ def cc_plugin(
         linkflags: 'StrOrListOpt' = None,
         extra_cppflags: 'StrOrListOpt' = None,
         extra_linkflags: 'StrOrListOpt' = None,
+        linker_script: 'StrOrListOpt' = None,
         linker_scripts: 'StrOrListOpt' = None,
+        export_map: 'StrOrListOpt' = None,
         version_scripts: 'StrOrListOpt' = None,
         allow_undefined: bool = True,
         strip: bool = False,
@@ -1932,7 +1982,9 @@ def cc_plugin(
             linkflags=linkflags,
             extra_cppflags=extra_cppflags,
             extra_linkflags=extra_linkflags,
+            linker_script=linker_script,
             linker_scripts=linker_scripts,
+            export_map=export_map,
             version_scripts=version_scripts,
             allow_undefined=allow_undefined,
             strip=strip,
@@ -1994,7 +2046,9 @@ class CcTest(CcBinary):
                 dynamic_link=dynamic_link,
                 extra_cppflags=extra_cppflags,
                 extra_linkflags=extra_linkflags,
+                linker_script=None,
                 linker_scripts=[],
+                export_map=None,
                 version_scripts=[],
                 export_dynamic=export_dynamic,
                 kwargs=kwargs)

--- a/src/tests/unit/cc_targets_test.py
+++ b/src/tests/unit/cc_targets_test.py
@@ -126,5 +126,54 @@ class GenerateLinkAllSymbolsLinkFlagsTest(unittest.TestCase):
             )
 
 
+class ResolveLinkerInputFileTest(unittest.TestCase):
+    """Cover the singular/deprecated-plural resolver used by export_map and
+    linker_script (and their plural aliases version_scripts / linker_scripts).
+    """
+
+    def _target(self):
+        target = _bare_cc_target()
+        target.warnings = []
+        target.warning = target.warnings.append
+        # _fullpath_sources is exercised elsewhere; here we only care about the
+        # selection/warning logic, so make it an identity over the file list.
+        target._fullpath_sources = lambda files: list(files)
+        return target
+
+    def test_singular_only_no_warning(self):
+        target = self._target()
+        self.assertEqual(['a.map'],
+                         target._resolve_linker_input_file('a.map', None, 'export_map', 'version_scripts'))
+        self.assertEqual([], target.warnings)
+
+    def test_none_returns_empty(self):
+        target = self._target()
+        self.assertEqual([],
+                         target._resolve_linker_input_file(None, None, 'export_map', 'version_scripts'))
+        self.assertEqual([], target.warnings)
+
+    def test_plural_alias_warns_and_is_used(self):
+        target = self._target()
+        result = target._resolve_linker_input_file(None, ['old.map'], 'export_map', 'version_scripts')
+        self.assertEqual(['old.map'], result)
+        self.assertEqual(1, len(target.warnings))
+        self.assertIn('version_scripts', target.warnings[0])
+        self.assertIn('export_map', target.warnings[0])
+
+    def test_both_given_prefers_singular(self):
+        target = self._target()
+        result = target._resolve_linker_input_file('new.map', ['old.map'], 'export_map', 'version_scripts')
+        self.assertEqual(['new.map'], result)
+        # Deprecation warning + a notice that the plural is ignored.
+        self.assertEqual(2, len(target.warnings))
+        self.assertTrue(any('ignored' in w for w in target.warnings))
+
+    def test_more_than_one_file_keeps_first(self):
+        target = self._target()
+        result = target._resolve_linker_input_file(['a.map', 'b.map'], None, 'export_map', 'version_scripts')
+        self.assertEqual(['a.map'], result)
+        self.assertTrue(any('single file' in w for w in target.warnings))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Implements #1182.

Singularizes the two "file passed to the linker" attributes, with the old plural names kept as **deprecated aliases**:

| old (plural list) | new (single file) | notes |
|---|---|---|
| `version_scripts` | **`export_map`** | semantic rename — it is export *filtering*, not ABI versioning; now also available on `cc_library` |
| `linker_scripts` | **`linker_script`** | `-T` scripts don't combine; GNU-ld / ELF only |

### Why single file
- `export_map`: GNU ld rejects more than one anonymous version node (`anonymous version tag cannot be combined`).
- `linker_script`: a SECTIONS script *replaces* the default; multiple `-T` conflict.

### Implementation
- A shared `CcTarget._resolve_linker_input_file(singular, plural, …)` resolves the canonical singular value and its deprecated plural alias: it **warns** when the plural is used, **warns and keeps the first** when more than one file is given, and returns a 0/1-element list — so the existing list-shaped `lds_fullpath` / `vers_fullpath` storage, `_cc_link`, and `cu_targets` are untouched.
- `export_map` added to `cc_library` (wired into the `.so` build via `--version-script`), `cc_binary`, `cc_plugin`.
- Existing Linux `--version-script` / `-T` behavior unchanged. Cross-platform translation of `export_map` (macOS `-exported_symbols_list`, Windows generated `.def`) stays out of scope, tracked in #1181.

### Tests / docs
- `ResolveLinkerInputFileTest` (5 cases: singular-only, none, deprecated-plural-warns, both-prefers-singular, >1-keeps-first). pyright clean.
- Documented `export_map` / `linker_script` and the deprecated aliases in `doc/{en,zh_CN}/build_rules/cc.md`.

Verified on MSVC: the deprecated `version_scripts` emits `"version_scripts" is deprecated, use "export_map" (a single file) instead`, and targets using the new attrs construct and build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)