### PR TITLE
refactor(cc): rename internal keys to match export_map/linker_script; expand docs

### DIFF
--- a/doc/en/build_rules/cc.md
+++ b/doc/en/build_rules/cc.md
@@ -524,43 +524,72 @@ Attributes:
   Its role is mainly to specify how to put the sections in the input file into the output file and to control the layout of the sections in the input file in the program address space.
   The linker has a default built-in linking script, which can be viewed with `ld --verbose`. This option will replace the system's default linking script.
   The linker script file usually has the extension `.ld` or `.lds`.
-  Only a single file is accepted: a SECTIONS script replaces the default, so multiple `-T` scripts do not meaningfully combine. This is a GNU-ld / ELF (Linux) feature only — macOS `ld64` and Windows `link.exe` have no `-T` equivalent.
+  Only a single file is accepted: a SECTIONS script replaces the default, so multiple `-T` scripts do not meaningfully combine.
   Linker scripts are usually quite complex, so if you just want to control the visibility of the symbols, use the `export_map` option below.
+  > **GNU-ld feature.** `linker_script` is the GNU-ld `-T` option. It works with a GNU-ld-compatible linker: GNU `ld` / `ld.lld` on ELF (Linux), and **MinGW's GNU `ld`** when targeting Windows. It is **not** supported by MSVC `link.exe` or Apple's `ld64` (passing it there makes the link fail).
   > The plural `linker_scripts` (a list) is a **deprecated alias**; using it emits a warning and only the first file is used.
 - `export_map`: str, a single [linker "version" script](https://sourceware.org/binutils/docs/ld/VERSION.html) used to control which symbols the shared library exports.
   Despite the linker term "version script", the mechanism here is *export filtering*, not ABI versioning — hence the name `export_map` (the industry term for a symbol-export control file). Use the anonymous-version form (no version id) to control visibility only.
-  Only a single file is accepted (GNU ld rejects more than one anonymous version node). It is available on `cc_library`, `cc_binary` and `cc_plugin`. On Linux it is passed to `--version-script`; the export-map files usually have the extension `.exp`, `.sym`, `.ver` or `.map`.
+  Only a single file is accepted (GNU ld rejects more than one anonymous version node). It is available on `cc_library`, `cc_binary` and `cc_plugin`. It is passed to GNU ld's `--version-script`; the export-map files usually have the extension `.exp`, `.sym`, `.ver` or `.map`. See [the C++ example below](#controlling-which-symbols-a-shared-library-exports).
+  > **GNU-ld feature.** Like `linker_script`, this is a GNU-ld option. Full symbol versioning is ELF-only; MSVC uses a generated `.def` instead (see [Windows DLL support](#windows-dll-support)).
   > The plural `version_scripts` (a list) is a **deprecated alias** for `export_map`; using it emits a warning and only the first file is used.
 
 `prefix` and `suffix` control the file name of the generated dynamic library. Assuming `name='file'`, on a Linux toolchain the default output is `libfile.so`;
 setting `prefix=''` makes it `file.so`. Passing a `name` that already carries a shared-library extension (e.g. `name='file.so'`) is no longer implicitly treated as "the full output file name"; to fully customize the output name, pass `prefix=''` and `suffix='.so'` explicitly.
 
-### Controlling the visibility of symbols in dynamic libraries
+### Controlling which symbols a shared library exports
 
-To control the external visibility of symbols in the linking result, you can use [GCC extended attributes in the source code or command line options](https://gcc.gnu.org/wiki/Visibility).
+To control the external visibility of symbols in the linking result, you can use [GCC extended attributes in the source code or command line options](https://gcc.gnu.org/wiki/Visibility). When you don't want to (or can't) annotate the sources, `export_map` does the same from the link line: it lists the symbols to keep `global` (exported); everything under `local` becomes hidden.
 
-With the linker version file, it is possible to control or override the visibility settings in the source code when linking,eg:
+#### A C++ example
+
+Suppose a library should expose only the `mylib::Api` class and the `mylib::Create()` factory, and hide everything else (helpers, third-party symbols pulled in statically, etc.):
+
+```cpp
+// api.h
+namespace mylib {
+class Api {
+ public:
+    void Run();
+};
+Api* Create();
+}  // namespace mylib
+```
+
+Because C++ symbols are mangled, list the *demangled* names inside an `extern "C++"` block. Write the `export_map` file (e.g. `api.map`):
 
 ```ld
 {
-global:  # Globally visible
-    # Support wildcards
-    Name1;
-    _Name2*;
-    extern "C++" {  # C++ symbols
-        # Quoted strings do not match wildcards
-        "a()";
-        "a(int)";
-        "operator<<(std::ostream&, B const&)";
+global:
+    extern "C++" {
+        # Quoted names are matched literally (no wildcard) -- use this when
+        # the exact signature matters or to avoid matching overloads.
+        "mylib::Create()";
 
-        # Unquoted strings match wildcards
-        B::*;
-        typeinfo?for?magic::*;
-        vtable?for?magic::*;"
+        # Unquoted names allow wildcards: export every member of mylib::Api
+        # (constructors, Run(), ...).
+        mylib::Api::*;
+
+        # vtable / typeinfo are needed by code that inherits from or
+        # dynamic_casts the class across the library boundary. The demangler
+        # prints a space here; match it with the '?' single-char wildcard.
+        typeinfo?for?mylib::Api;
+        vtable?for?mylib::Api;
     };
-local:  # The rest are local symbols, not visible
-    *;
+local:
+    *;  # hide everything not listed above
 };
+```
+
+Wire it into the BUILD file (only the shared library is affected; the static archive is unchanged):
+
+```python
+cc_library(
+    name = 'mylib',
+    srcs = ['api.cc'],
+    hdrs = ['api.h'],
+    export_map = 'api.map',
+)
 ```
 
 To see the visibility of symbols in the library, you can use the `nm` command.

--- a/doc/zh_CN/build_rules/cc.md
+++ b/doc/zh_CN/build_rules/cc.md
@@ -510,42 +510,70 @@ cc_plugin(
   它的作用主要是规定如何把输入文件内的 section 放入输出文件内，并控制输入文件内各部分在程序地址空间内的布局。
   链接器有个默认的内置链接脚本，可用 `ld --verbose` 查看。此选项将会替换系统的默认链接脚本。
   链接器脚本文件的扩展名一般为 `.ld` 或者 `.lds`。
-  只接受单个文件：SECTIONS 脚本会替换默认脚本，多个 `-T` 脚本无法有意义地组合。该特性仅限 GNU ld / ELF（Linux）；macOS `ld64` 和 Windows `link.exe` 没有 `-T` 的对应物。
+  只接受单个文件：SECTIONS 脚本会替换默认脚本，多个 `-T` 脚本无法有意义地组合。
   链接器脚本通常相当复杂，如果只是想控制符号的可见性，请使用下面的 `export_map` 选项。
+  > **GNU ld 特性。** `linker_script` 就是 GNU ld 的 `-T` 选项，需要 GNU ld 兼容的链接器：ELF（Linux）上的 GNU `ld` / `ld.lld`，以及面向 Windows 时 **MinGW 的 GNU `ld`**。MSVC `link.exe` 和 Apple `ld64` **不支持**（传给它们会导致链接失败）。
   > 复数形式 `linker_scripts`（列表）是**已废弃的别名**，使用时会告警，且只取第一个文件。
 - `export_map`: str，单个[链接器“版本”脚本](https://sourceware.org/binutils/docs/ld/VERSION.html)，用来控制共享库导出哪些符号。
   虽然链接器术语叫“版本脚本”，但这里的机制是*导出过滤*而非 ABI 版本管理，因此命名为 `export_map`（业界对符号导出控制文件的通称）。使用匿名版本形式（不指定版本号）即可只控制可见性。
-  只接受单个文件（GNU ld 不允许多于一个匿名版本节点）。可用于 `cc_library`、`cc_binary` 和 `cc_plugin`。在 Linux 上传给 `--version-script`；导出映射文件的扩展名一般为 `.exp`、`.sym`、`.ver` 或者 `.map`。
+  只接受单个文件（GNU ld 不允许多于一个匿名版本节点）。可用于 `cc_library`、`cc_binary` 和 `cc_plugin`。会传给 GNU ld 的 `--version-script`；导出映射文件的扩展名一般为 `.exp`、`.sym`、`.ver` 或者 `.map`。参见[下文的 C++ 示例](#控制共享库导出哪些符号)。
+  > **GNU ld 特性。** 与 `linker_script` 一样，这是 GNU ld 选项。完整的符号版本管理仅限 ELF；MSVC 改用自动生成的 `.def`（参见 [Windows DLL 支持](#windows-dll-支持)）。
   > 复数形式 `version_scripts`（列表）是 `export_map` 的**已废弃别名**，使用时会告警，且只取第一个文件。
 
 `prefix` 和 `suffix` 控制生成的动态库的文件名。假设 `name='file'`，在 Linux 工具链上默认生成 `libfile.so`；设置 `prefix=''` 则变为 `file.so`。传入已带共享库后缀的 `name`（如 `name='file.so'`）不再被隐式识别为"输出文件全名"，如需完全自定义输出文件名，请改用 `prefix=''` 与 `suffix='.so'` 显式表达。
 
-### 控制动态库中符号的可见性
+### 控制共享库导出哪些符号
 
-要控制链接结果中符号是否对外可见，可以通过[源代码中的 GCC 扩展属性或者命令行选项](https://gcc.gnu.org/wiki/Visibility)来进行。
+要控制链接结果中符号是否对外可见，可以通过[源代码中的 GCC 扩展属性或者命令行选项](https://gcc.gnu.org/wiki/Visibility)来进行。当你不想（或无法）改动源码时，`export_map` 能在链接阶段做同样的事：列出要保持 `global`（导出）的符号，其余落入 `local` 的一律隐藏。
 
-用链接器版本文件，则可以在链接时控制或者覆盖源代码中的可见性设置：
+#### C++ 示例
+
+假设某个库只想对外暴露 `mylib::Api` 类和工厂函数 `mylib::Create()`，而隐藏其余一切（辅助函数、被静态链入的第三方符号等）：
+
+```cpp
+// api.h
+namespace mylib {
+class Api {
+ public:
+    void Run();
+};
+Api* Create();
+}  // namespace mylib
+```
+
+由于 C++ 符号会被名字修饰（mangle），需要把*反修饰后*的名字写在 `extern "C++"` 块里。编写 `export_map` 文件（如 `api.map`）：
 
 ```ld
 {
-global:  # 全局可见
-    # 支持通配符
-    Name1;
-    _Name2*;
-    extern "C++" {  # C++ 符号
-        # 引号内的表示不匹配通配符
-        "a()";
-        "a(int)";
-        "operator<<(std::ostream&, B const&)";
+global:
+    extern "C++" {
+        # 加引号表示按字面精确匹配（不走通配符）——用于在意确切签名、
+        # 或避免误匹配重载的场合。
+        "mylib::Create()";
 
-        # 引号外的匹配通配符
-        B::*;
-        typeinfo?for?magic::*;
-        vtable?for?magic::*;"
+        # 不加引号则可用通配符：导出 mylib::Api 的全部成员
+        # （构造函数、Run() ……）。
+        mylib::Api::*;
+
+        # 跨库继承或 dynamic_cast 时需要 vtable / typeinfo。反修饰器在此
+        # 处会打印一个空格，用单字符通配符 '?' 去匹配它。
+        typeinfo?for?mylib::Api;
+        vtable?for?mylib::Api;
     };
-local:  # 其余为局部符号，对外不可见
-    *;
+local:
+    *;  # 隐藏上面未列出的一切
 };
+```
+
+在 BUILD 文件中接上（只影响共享库，静态库不变）：
+
+```python
+cc_library(
+    name = 'mylib',
+    srcs = ['api.cc'],
+    hdrs = ['api.h'],
+    export_map = 'api.map',
+)
 ```
 
 要查看库中的符号的可见性，可以用 nm 命令：

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -772,7 +772,7 @@ class CcTarget(Target):
         if inclusion_check_result:
             incchk_deps.append(inclusion_check_result)
         self._cc_link(output, 'solink', objs=objs, deps=usr_libs, sys_libs=sys_libs,
-                      version_scripts=self.attr.get('vers_fullpath'),
+                      version_scripts=self.attr.get('export_map_fullpath'),
                       order_only_deps=incchk_deps, target_linkflags=target_linkflags)
         self._add_target_file(tc.DYNAMIC_LIB_LABEL, output)
 
@@ -831,7 +831,7 @@ class CcTarget(Target):
 
         Returns the full paths as a list with at most one entry (kept as a
         list so it splices straight into the existing list-shaped
-        ``lds_fullpath`` / ``vers_fullpath`` handling and ``_cc_link``).
+        ``linker_script_fullpath`` / ``export_map_fullpath`` handling and ``_cc_link``).
 
         Emits a deprecation warning when the plural alias is used, and warns
         when more than one file is given -- a single file is the only
@@ -1093,7 +1093,7 @@ class CcLibrary(CcTarget):
         # the shared library exports; passed to `--version-script` on Linux when
         # the dynamic library is built (see `_dynamic_cc_library`). No deprecated
         # plural alias here -- `cc_library` never had `version_scripts`.
-        self.attr['vers_fullpath'] = self._resolve_linker_input_file(
+        self.attr['export_map_fullpath'] = self._resolve_linker_input_file(
             export_map, None, 'export_map', 'version_scripts')
         # `generate_dynamic` is a tri-state: None inherits the global default
         # (already computed in CcTarget.__init__ from --generate-dynamic /
@@ -1624,9 +1624,9 @@ class CcBinary(CcTarget):
                 kwargs=kwargs)
         self.attr['embed_version'] = embed_version
         self.attr['dynamic_link'] = dynamic_link
-        self.attr['lds_fullpath'] = self._resolve_linker_input_file(
+        self.attr['linker_script_fullpath'] = self._resolve_linker_input_file(
             linker_script, linker_scripts, 'linker_script', 'linker_scripts')
-        self.attr['vers_fullpath'] = self._resolve_linker_input_file(
+        self.attr['export_map_fullpath'] = self._resolve_linker_input_file(
             export_map, version_scripts, 'export_map', 'version_scripts')
         self.attr['export_dynamic'] = export_dynamic
         self.attr['dwp'] = is_fission() and need_dwp()
@@ -1703,8 +1703,8 @@ class CcBinary(CcTarget):
         output = self._target_file_path(
             self.blade.get_build_toolchain().executable_file_name(self.name))
         self._cc_link(output, 'link', objs=objs, deps=usr_libs, sys_libs=sys_libs,
-                      linker_scripts=self.attr.get('lds_fullpath'),
-                      version_scripts=self.attr.get('vers_fullpath'),
+                      linker_scripts=self.attr.get('linker_script_fullpath'),
+                      version_scripts=self.attr.get('export_map_fullpath'),
                       target_linkflags=target_linkflags,
                       implicit_deps=implicit_deps,
                       order_only_deps=order_only_deps)
@@ -1894,9 +1894,9 @@ class CcPlugin(CcTarget):
         self.attr['suffix'] = suffix
         self.attr['allow_undefined'] = allow_undefined
         self.attr['strip'] = strip
-        self.attr['lds_fullpath'] = self._resolve_linker_input_file(
+        self.attr['linker_script_fullpath'] = self._resolve_linker_input_file(
             linker_script, linker_scripts, 'linker_script', 'linker_scripts')
-        self.attr['vers_fullpath'] = self._resolve_linker_input_file(
+        self.attr['export_map_fullpath'] = self._resolve_linker_input_file(
             export_map, version_scripts, 'export_map', 'version_scripts')
         self._add_tags('lang:cc', 'type:plugin')
 
@@ -1930,8 +1930,8 @@ class CcPlugin(CcTarget):
             else:
                 link_output = output
             self._cc_link(link_output, 'solink', objs=objs, deps=usr_libs, sys_libs=sys_libs,
-                          linker_scripts=self.attr.get('lds_fullpath'),
-                          version_scripts=self.attr.get('vers_fullpath'),
+                          linker_scripts=self.attr.get('linker_script_fullpath'),
+                          version_scripts=self.attr.get('export_map_fullpath'),
                           target_linkflags=target_linkflags,
                           implicit_deps=link_all_symbols_libs, order_only_deps=incchk_deps)
             if self.attr['strip']:

--- a/src/blade/cu_targets.py
+++ b/src/blade/cu_targets.py
@@ -375,8 +375,8 @@ class CuBinary(CuTarget):
         output = self._target_file_path(self.blade.get_build_toolchain().executable_file_name(self.name))
         self._cc_link(output, 'cudalink', objs=objs, deps=usr_libs,
                       sys_libs=sys_libs,
-                      linker_scripts=self.attr.get('lds_fullpath'),
-                      version_scripts=self.attr.get('vers_fullpath'),
+                      linker_scripts=self.attr.get('linker_script_fullpath'),
+                      version_scripts=self.attr.get('export_map_fullpath'),
                       target_linkflags=target_linkflags,
                       implicit_deps=implicit_deps,
                       order_only_deps=order_only_deps,


### PR DESCRIPTION
Follow-up to #1182 / #1190.

## Internal rename (no behavior change)
The internal `attr` keys still carried the old names. Rename them to match the public attributes:
- `vers_fullpath` → `export_map_fullpath`
- `lds_fullpath` → `linker_script_fullpath`

(`cc_targets.py`, `cu_targets.py`.)

## Docs
- **Corrected platform note.** `linker_script` (`-T`) is a **GNU-ld** feature — supported by GNU `ld` / `ld.lld` on ELF *and* by **MinGW's GNU `ld`** on Windows; not MSVC `link.exe` or Apple `ld64`. The earlier "Linux only" wording was wrong for MinGW. `export_map` framed the same way (full symbol versioning is ELF; MSVC uses a generated `.def`).
- **Added a worked C++ `export_map` example** (demangled names in an `extern "C++"` block, `vtable`/`typeinfo` matching, BUILD wiring) under a renamed *"Controlling which symbols a shared library exports"* section. en + zh.

pyright clean; resolver tests pass; blade-test smoke build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)