### PR TITLE
feat(cc): warn when export_map is set on the MSVC toolchain

### DIFF
--- a/doc/en/build_rules/cc.md
+++ b/doc/en/build_rules/cc.md
@@ -531,7 +531,7 @@ Attributes:
 - `export_map`: str, a single [linker "version" script](https://sourceware.org/binutils/docs/ld/VERSION.html) used to control which symbols the shared library exports.
   Despite the linker term "version script", the mechanism here is *export filtering*, not ABI versioning — hence the name `export_map` (the industry term for a symbol-export control file). Use the anonymous-version form (no version id) to control visibility only.
   Only a single file is accepted (GNU ld rejects more than one anonymous version node). It is available on `cc_library`, `cc_binary` and `cc_plugin`. It is passed to GNU ld's `--version-script`; the export-map files usually have the extension `.exp`, `.sym`, `.ver` or `.map`. See [the C++ example below](#controlling-which-symbols-a-shared-library-exports).
-  > **GNU-ld feature.** Like `linker_script`, this is a GNU-ld option. Full symbol versioning is ELF-only; MSVC uses a generated `.def` instead (see [Windows DLL support](#windows-dll-support)).
+  > **GNU-ld feature.** Like `linker_script`, this is a GNU-ld option. Full symbol versioning is ELF-only; on MSVC the map is **not** honored (exports come from a generated `.def` — see [Windows DLL support](#windows-dll-support)) and Blade warns so it is not silently dropped.
   > The plural `version_scripts` (a list) is a **deprecated alias** for `export_map`; using it emits a warning and only the first file is used.
 
 `prefix` and `suffix` control the file name of the generated dynamic library. Assuming `name='file'`, on a Linux toolchain the default output is `libfile.so`;

--- a/doc/zh_CN/build_rules/cc.md
+++ b/doc/zh_CN/build_rules/cc.md
@@ -517,7 +517,7 @@ cc_plugin(
 - `export_map`: str，单个[链接器“版本”脚本](https://sourceware.org/binutils/docs/ld/VERSION.html)，用来控制共享库导出哪些符号。
   虽然链接器术语叫“版本脚本”，但这里的机制是*导出过滤*而非 ABI 版本管理，因此命名为 `export_map`（业界对符号导出控制文件的通称）。使用匿名版本形式（不指定版本号）即可只控制可见性。
   只接受单个文件（GNU ld 不允许多于一个匿名版本节点）。可用于 `cc_library`、`cc_binary` 和 `cc_plugin`。会传给 GNU ld 的 `--version-script`；导出映射文件的扩展名一般为 `.exp`、`.sym`、`.ver` 或者 `.map`。参见[下文的 C++ 示例](#控制共享库导出哪些符号)。
-  > **GNU ld 特性。** 与 `linker_script` 一样，这是 GNU ld 选项。完整的符号版本管理仅限 ELF；MSVC 改用自动生成的 `.def`（参见 [Windows DLL 支持](#windows-dll-支持)）。
+  > **GNU ld 特性。** 与 `linker_script` 一样，这是 GNU ld 选项。完整的符号版本管理仅限 ELF；在 MSVC 上该映射**不会**生效（导出由自动生成的 `.def` 决定，参见 [Windows DLL 支持](#windows-dll-支持)），Blade 会告警以免被静默忽略。
   > 复数形式 `version_scripts`（列表）是 `export_map` 的**已废弃别名**，使用时会告警，且只取第一个文件。
 
 `prefix` 和 `suffix` 控制生成的动态库的文件名。假设 `name='file'`，在 Linux 工具链上默认生成 `libfile.so`；设置 `prefix=''` 则变为 `file.so`。传入已带共享库后缀的 `name`（如 `name='file.so'`）不再被隐式识别为"输出文件全名"，如需完全自定义输出文件名，请改用 `prefix=''` 与 `suffix='.so'` 显式表达。

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -785,6 +785,15 @@ class CcTarget(Target):
         (`<name>.dll.lib`); `DYNAMIC_LIB_LABEL` therefore points at the import
         lib, while the DLL is recorded separately as the runtime artifact.
         """
+        if self.attr.get('export_map_fullpath'):
+            # `export_map` is a GNU-ld `--version-script`; MSVC has no
+            # equivalent. Here exports are derived from the object files into an
+            # auto-generated `.def` (see cc_windef), so the map is not applied.
+            # Warn rather than silently ignore it. Translating a version script
+            # into a `.def` (undname + glob matching) is tracked separately.
+            self.warning('export_map is not honored on the MSVC toolchain; '
+                         'the DLL exports are derived from the object files. '
+                         'The export map is ignored.')
         try:
             dll = self._target_file_path(_windows_dll_basename(self.path, self.name))
         except ValueError as e:


### PR DESCRIPTION
Closes the silent-ignore gap surfaced after #1182.

`export_map` is a GNU-ld `--version-script`. MSVC has no equivalent — the Windows DLL path (`_dynamic_cc_library_windows`) derives exports from the object files into an auto-generated `.def` (COMDAT-filtered), so a user who set `export_map` on Windows had it **silently dropped**, getting an unfiltered DLL with no indication.

This emits a warning at that point:

```
api: export_map is not honored on the MSVC toolchain; the DLL exports are
derived from the object files. The export map is ignored.
```

The build still succeeds (the auto-`.def` exports are used). Docs (en/zh) note the warning.

**Verified on MSVC** via `//suites/cc_export_map:api_test` (the example from blade-test#15): the warning fires and the DLL builds.

### Out of scope (future work)
Actually translating a version script into a `.def` is genuinely hard: GNU version-script patterns are written against **Itanium-demangled** names (`mylib::Api::Greet(...)`), while MSVC's `undname`/`UnDecorateSymbolName` produces a different spelling, and `UNDNAME_NAME_ONLY` drops the signature that quoted patterns rely on. That cross-demangler matching deserves its own design pass — flagging here rather than rushing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)