### PR TITLE
fix(msvc): force English /showIncludes via VSLANG=1033 in cc_wrapper (#1154)

### DIFF
--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -119,11 +119,20 @@ def _in_workspace(hdr):
     except ValueError:  # different drive -> outside the workspace
         return False
 
+# Force the English "Note: including file:" prefix. cl.exe (and nvcc's cl)
+# localize /showIncludes on a non-English Visual Studio, which would silently
+# break both the inclusion stack written below and Ninja's deps=msvc header
+# tracking (the prefix _NOTE_PREFIX above and Ninja's msvc_deps_prefix are both
+# the English string). VSLANG=1033 is the en-US LCID; set it on the child only,
+# not the whole build, so nothing else is affected. See issue #1154.
+env = dict(os.environ)
+env['VSLANG'] = '1033'
+
 # Merge stdout+stderr into one pipe (like Ninja).  Reading only stderr risks
 # a pipe deadlock: if cl.exe writes enough to stdout (even with /nologo a
 # leftover copyright banner fills the 4 KiB buffer), the process blocks and
 # never drains its stderr output through the unread stdout pipe.
-p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+p = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                      universal_newlines=True, encoding='utf-8', errors='replace')
 with open(outfile + '.new', 'w', newline='', encoding='utf-8') as f:
     for line in p.stdout:


### PR DESCRIPTION
Fixes #1154.

On a **non-English Visual Studio**, `cl.exe` localizes the `/showIncludes` prefix (`Note: including file:` → its German/Japanese/Chinese/… translation). Both the inclusion-stack filter in `cc_wrapper.py` (`_NOTE_PREFIX`) and Ninja's `deps = msvc` header tracking match that prefix as the **English** string, so a localized prefix silently drops header dependencies — editing a header then does **not** trigger a rebuild. That is a correctness bug.

## Fix
Every MSVC compile rule (`cc` / `cxx` / `cxxhdrs`, and nvcc) already runs through the Python tee wrapper, which spawns `cl.exe`/`nvcc` via `subprocess.Popen`. Set **`VSLANG=1033`** (en-US LCID) on that child's environment:

```python
env = dict(os.environ)
env['VSLANG'] = '1033'
p = subprocess.Popen(cmd, env=env, ...)
```

- Fixes **both** consumers (the wrapper's incstk filter and Ninja's `deps=msvc`) in one place.
- Scoped to the compile child only — no global build-env mutation, no toolchain gating (the wrapper is MSVC-only by construction).
- Avoids the fragile alternative of setting Ninja's `msvc_deps_prefix` to a localized, code-page-sensitive string (rejected in the issue).

## Verification
On MSVC (English VS): clean and incremental (touch → rebuild) compiles succeed with header deps tracked; the generated `cc_wrapper.py` carries `VSLANG=1033`. The localized-prefix case can't be reproduced without a non-English VS, but forcing en-US is exactly what makes the hardcoded English prefix correct everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)