### PR TITLE
fix(cc): reset export_map section at version-node end; harden parser tests

### DIFF
--- a/src/blade/builtin_tools.py
+++ b/src/blade/builtin_tools.py
@@ -247,8 +247,14 @@ def _parse_export_map(path):
             if tok == '{':
                 cpp = (pending_lang == 'C++') if pending_extern else cpp_stack[-1]
                 cpp_stack.append(cpp)
-            elif len(cpp_stack) > 1:
-                cpp_stack.pop()
+            else:  # '}'
+                if len(cpp_stack) > 1:
+                    cpp_stack.pop()
+                if len(cpp_stack) == 1:
+                    # Closed a version node: the next token (a named-version tag
+                    # like `VER_2`, or a `} VER_1;` dependency) must not be read
+                    # as a pattern under the previous node's section.
+                    section = None
             pending_extern, pending_lang = False, None
         elif tok == ';':
             continue

--- a/src/tests/unit/cc_def_test.py
+++ b/src/tests/unit/cc_def_test.py
@@ -106,6 +106,43 @@ class ExportMapParseTest(unittest.TestCase):
         globals_, _ = self._parse('{ global: my_c_func; local: *; };')
         self.assertEqual([('my_c_func', False, False)], globals_)
 
+    def test_extern_c_block_is_not_cpp(self):
+        globals_, _ = self._parse(
+            '{ global: extern "C" { c_api; }; local: *; };')
+        self.assertEqual([('c_api', False, False)], globals_)
+
+    def test_global_before_and_after_extern_block(self):
+        # A top-level pattern, then an extern "C++" block, then another
+        # top-level pattern -- cpp must toggle on entry and back off on exit.
+        globals_, _ = self._parse(
+            '{ global: top1; extern "C++" { ns::*; }; top2; local: *; };')
+        self.assertEqual(
+            [('top1', False, False), ('ns::*', True, False), ('top2', False, False)],
+            globals_)
+
+    def test_named_version_nodes_are_flattened(self):
+        # The node names (VER_1, VER_2) and the `} VER_1;` dependency must not
+        # be read as patterns; their global/local lists are unioned.
+        globals_, locals_ = self._parse(
+            'VER_1 { global: a; local: la; };\n'
+            'VER_2 { global: b; local: *; } VER_1;\n')
+        self.assertEqual([('a', False, False), ('b', False, False)], globals_)
+        self.assertEqual([('la', False, False), ('*', False, False)], locals_)
+
+    def test_line_comment_and_only_global(self):
+        globals_, locals_ = self._parse(
+            '{\n'
+            '  global:\n'
+            '    keep_me;  // keep this one\n'
+            '}; // no local section\n')
+        self.assertEqual([('keep_me', False, False)], globals_)
+        self.assertEqual([], locals_)
+
+    def test_specific_local_patterns(self):
+        _, locals_ = self._parse('{ local: secret_*; _internal; };')
+        self.assertEqual(
+            [('secret_*', False, False), ('_internal', False, False)], locals_)
+
 
 class ExportMapKeepsTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Follow-up to #1194 — more `_parse_export_map` unit tests, which surfaced a real bug.

## Bug
The parser didn't reset the current `global`/`local` section when a **version node** closed. In a multi-node script:

```ld
VER_1 { global: a; };
VER_2 { global: b; } VER_1;
```

after `VER_1`'s closing `}` the section stayed `global`, so the node name `VER_2` (and the `} VER_1;` dependency) were read as **global patterns**. Fix: reset `section` to `None` when brace depth returns to 0.

(Low real-world impact — `export_map` is normally a single anonymous node — but the parser should be robust, and the example surfaced it.)

## Tests added
Named version nodes (flattened, names not captured), `extern "C"` (not cpp), a `global:` section spanning before/after an `extern "C++"` block (cpp toggles correctly), `//` line comments, only-`global` (no `local`), and specific (non-`*`) `local` patterns. 16/16 in `cc_def_test.py`; pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)