### PR TITLE
test: cover the two 0%-coverage modules (dwp_wrapper, fatjar)

### DIFF
--- a/src/tests/unit/dwp_wrapper_test.py
+++ b/src/tests/unit/dwp_wrapper_test.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for blade.dwp_wrapper.
+
+The dwp wrapper collects ``.dwo`` files (split DWARF, DebugFission) for a
+binary and invokes the ``dwp`` tool. The tool invocation and ``ar t`` archive
+listing need real toolchain binaries, but the input plumbing -- response-file
+expansion, ``.o`` -> ``.dwo`` mapping, de-duplicated collection, and the
+empty-input short circuit -- is pure and is what these tests pin.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import dwp_wrapper  # noqa: E402  (sys.path tweak above)
+
+
+class ExpandResponseFilesTest(unittest.TestCase):
+    def test_plain_args_pass_through(self):
+        self.assertEqual(['a.o', 'b.o'],
+                         dwp_wrapper.expand_response_files(['a.o', 'b.o']))
+
+    def test_at_file_is_expanded_skipping_comments_and_blanks(self):
+        with tempfile.TemporaryDirectory() as d:
+            rsp = os.path.join(d, 'inputs.rsp')
+            with open(rsp, 'w') as f:
+                f.write('# a comment\n\nx.o y.o\nz.o\n')
+            self.assertEqual(
+                ['head.o', 'x.o', 'y.o', 'z.o', 'tail.o'],
+                dwp_wrapper.expand_response_files(['head.o', '@' + rsp, 'tail.o']))
+
+
+class FindDwoForObjectTest(unittest.TestCase):
+    def test_returns_path_when_dwo_exists(self):
+        with tempfile.TemporaryDirectory() as d:
+            obj = os.path.join(d, 'foo.o')
+            dwo = os.path.join(d, 'foo.dwo')
+            open(dwo, 'w').close()
+            self.assertEqual(dwo, dwp_wrapper.find_dwo_for_object(obj))
+
+    def test_returns_none_when_dwo_missing(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertIsNone(
+                dwp_wrapper.find_dwo_for_object(os.path.join(d, 'foo.o')))
+
+
+class CollectDwoFilesTest(unittest.TestCase):
+    def test_object_with_and_without_dwo(self):
+        with tempfile.TemporaryDirectory() as d:
+            have, lack = os.path.join(d, 'a.o'), os.path.join(d, 'b.o')
+            open(have, 'w').close()
+            open(lack, 'w').close()
+            open(os.path.join(d, 'a.dwo'), 'w').close()  # only a has a .dwo
+            self.assertEqual([os.path.join(d, 'a.dwo')],
+                             dwp_wrapper.collect_dwo_files([have, lack]))
+
+    def test_direct_dwo_and_dedup(self):
+        with tempfile.TemporaryDirectory() as d:
+            dwo = os.path.join(d, 'a.dwo')
+            obj = os.path.join(d, 'a.o')
+            open(dwo, 'w').close()
+            open(obj, 'w').close()
+            # The .o maps to a.dwo and the .dwo is passed directly -> one entry.
+            self.assertEqual([dwo], dwp_wrapper.collect_dwo_files([obj, dwo]))
+
+    def test_nonexistent_input_skipped(self):
+        self.assertEqual([], dwp_wrapper.collect_dwo_files(['/no/such/file.o']))
+
+
+class RunDwpTest(unittest.TestCase):
+    def test_empty_dwo_list_writes_empty_output(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, 'bin.dwp')
+            self.assertEqual(0, dwp_wrapper.run_dwp(out, []))
+            self.assertTrue(os.path.exists(out))
+            self.assertEqual(0, os.path.getsize(out))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/unit/fatjar_test.py
+++ b/src/tests/unit/fatjar_test.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for blade.fatjar.
+
+`fatjar` merges several jars into one, dropping per-jar manifests, signature
+files and license/notice boilerplate, recording conflicts when two jars supply
+the same path, and writing its own manifest + merge metadata. These tests
+cover the exclusion predicates and drive `generate_fat_jar` end to end over
+synthetic in-memory jars.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+import zipfile
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import fatjar  # noqa: E402  (sys.path tweak above)
+
+
+class ExclusionPredicateTest(unittest.TestCase):
+    def test_signature_files(self):
+        self.assertTrue(fatjar._is_signature_file('META-INF/FOO.SF'))
+        self.assertTrue(fatjar._is_signature_file('META-INF/foo.rsa'))
+        self.assertTrue(fatjar._is_signature_file('META-INF/SIG-bar'))
+        self.assertFalse(fatjar._is_signature_file('META-INF/services/x'))
+        self.assertFalse(fatjar._is_signature_file('pkg/A.class'))
+
+    def test_fat_jar_excluded(self):
+        for name in ('META-INF/MANIFEST.MF', 'META-INF/LICENSE', 'README',
+                     'NOTICE', 'META-INF/INDEX.LIST', 'META-INF/app.DSA'):
+            self.assertTrue(fatjar._is_fat_jar_excluded(name), name)
+        self.assertFalse(fatjar._is_fat_jar_excluded('pkg/A.class'))
+        self.assertFalse(fatjar._is_fat_jar_excluded('META-INF/services/x'))
+
+
+def _make_jar(path, entries):
+    with zipfile.ZipFile(path, 'w') as z:
+        for name, data in entries.items():
+            z.writestr(name, data)
+
+
+class GenerateFatJarTest(unittest.TestCase):
+    def _build(self, severity):
+        d = self._dir
+        jar1 = os.path.join(d, 'a.jar')
+        jar2 = os.path.join(d, 'b.jar')
+        _make_jar(jar1, {
+            'pkg/A.class': 'A',
+            'common/Shared.class': 'from-a',     # conflicts with jar2
+            'META-INF/MANIFEST.MF': 'per-jar manifest',
+            'META-INF/LICENSE': 'license text',
+        })
+        _make_jar(jar2, {
+            'pkg/B.class': 'B',
+            'common/Shared.class': 'from-b',     # duplicate path -> conflict
+            'META-INF/app.SF': 'signature',
+        })
+        out = os.path.join(d, 'out.fat.jar')
+        fatjar.generate_fat_jar(out, severity, '1', [jar1, jar2])
+        return out
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._dir = self._tmp.name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_merge_excludes_and_metadata(self):
+        out = self._build('warning')
+        with zipfile.ZipFile(out, 'r') as z:
+            names = set(z.namelist())
+            # real classes merged from both jars
+            self.assertIn('pkg/A.class', names)
+            self.assertIn('pkg/B.class', names)
+            # first jar wins the conflicting path
+            self.assertEqual(b'from-a', z.read('common/Shared.class'))
+            # per-jar boilerplate dropped
+            self.assertNotIn('META-INF/LICENSE', names)
+            self.assertNotIn('META-INF/app.SF', names)
+            # fat jar writes its own manifest + merge metadata
+            self.assertIn('Created-By: Python.Zipfile (Blade)',
+                          z.read('META-INF/MANIFEST.MF').decode())
+            jar_list = z.read('META-INF/blade/JAR.LIST').decode()
+            self.assertIn(os.path.join(self._dir, 'a.jar'), jar_list)
+            self.assertIn(os.path.join(self._dir, 'b.jar'), jar_list)
+            merge_info = z.read('META-INF/blade/MERGE-INFO').decode()
+            self.assertIn('[conflict]', merge_info)
+            self.assertIn('common/Shared.class', merge_info)
+
+    def test_conflict_severity_error_raises(self):
+        with self.assertRaises(RuntimeError):
+            self._build('error')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
[Coveralls build 79751413](https://coveralls.io/builds/79751413) flagged exactly two files at **0%**:

| file | lines | was | now |
|---|---|---|---|
| `src/blade/dwp_wrapper.py` | 83 | 0% | **55%** |
| `src/blade/fatjar.py` | 75 | 0% | **88%** |

Both are real features the suite simply never exercised (DebugFission `.dwp` packaging; Java fat-jar) — so the fix is tests, not deletion/omit.

- **dwp_wrapper:** response-file (`@file`) expansion (comments/blanks/multi-arg lines), `.o`→`.dwo` mapping, de-duplicated `collect_dwo_files`, and the empty-input short circuit (writes an empty `.dwp`, returns 0). The remainder (`ar t`, the `dwp` subprocess) needs real binaries.
- **fatjar:** the `_is_signature_file` / `_is_fat_jar_excluded` predicates, plus `generate_fat_jar` driven **end to end** over synthetic in-memory jars — verifying merge, first-jar-wins on a conflicting path, dropped per-jar manifest / `.SF` / `LICENSE`, the generated manifest + `META-INF/blade` merge metadata, and that `conflict_severity='error'` raises.

12 new tests; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)