### PR TITLE
fix(hdrs): tolerate depth gaps in the inclusion stack instead of crashing (#953)

### DIFF
--- a/src/blade/inclusion_check.py
+++ b/src/blade/inclusion_check.py
@@ -256,10 +256,9 @@ def _parse_inclusion_stacks(path, build_dir):
         return current_level, skip_level
 
     current_level = 0
-    current_line = ''
     skip_level = -1
     with open(path) as f:
-        for index, line in enumerate(f):
+        for line in f:
             line = line.rstrip()  # Strip `\n`
             if not _is_inclusion_line(line):
                 # The remaining lines are useless for us
@@ -273,25 +272,23 @@ def _parse_inclusion_stacks(path, build_dir):
             if level > current_level:
                 if skip_level != -1 and level > skip_level:
                     continue
-                try:
-                    assert level == current_level + 1
-                except AssertionError:
-                    console.error(
-                        'path: %s, line_number: %d\n'
-                        'level: %d, current_level: %d\n'
-                        'line: %s\ncurrent_line: %s' % (
-                            path, index+1,
-                            level, current_level,
-                            line, current_line))
-                    raise
+                if level > current_level + 1:
+                    # Depth gap: the intervening header(s) (levels
+                    # current_level+1 .. level-1) are absolute/system headers
+                    # that were filtered out of the incstk (GCC awk `[^/]`;
+                    # MSVC in-workspace filter). This header is reached only
+                    # through them, so -- like an absolute header -- it and its
+                    # subtree are not tracked includes of this TU. Skip the
+                    # subtree instead of aborting the whole build. See #953.
+                    if skip_level == -1:
+                        skip_level = current_level + 1
+                    continue
                 current_level, skip_level = _process_hdr(level, hdr, current_level)
-                current_line = line
             else:
                 while current_level >= level:
                     current_level -= 1
                     hdrs_stack.pop()
                 current_level, skip_level = _process_hdr(level, hdr, current_level)
-                current_line = line
 
     return direct_hdrs, stacks
 

--- a/src/tests/unit/parse_inclusion_stacks_test.py
+++ b/src/tests/unit/parse_inclusion_stacks_test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for blade.inclusion_check._parse_inclusion_stacks.
+
+The `.incstk` file omits absolute/system headers (the GCC awk splitter keeps
+only paths not starting with `/`; the MSVC wrapper keeps only in-workspace
+paths) but preserves the compiler's original nesting depth. So a kept header
+nested under a filtered system header shows up with a **depth gap**. The parser
+must tolerate that gap (treat the subtree as untracked) instead of aborting the
+build with an AssertionError -- the bug in #953.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import inclusion_check  # noqa: E402  (sys.path tweak above)
+
+_BUILD_DIR = 'build64_release'
+
+
+def _parse(content):
+    with tempfile.NamedTemporaryFile('w', suffix='.incstk', delete=False) as f:
+        f.write(content)
+        path = f.name
+    try:
+        return inclusion_check._parse_inclusion_stacks(path, _BUILD_DIR)
+    finally:
+        os.unlink(path)
+
+
+class ParseInclusionStacksTest(unittest.TestCase):
+    def test_contiguous_stack_is_parsed(self):
+        # Happy path (the function's docstring example): no gaps.
+        direct, stacks = _parse(
+            '. ./app/example/foo.h\n'
+            '.. build64_release/app/example/proto/foo.pb.h\n'
+            '... build64_release/common/rpc/rpc_service.pb.h\n'
+            '. build64_release/app/example/proto/bar.pb.h\n'
+            '. ./common/rpc/rpc_client.h\n'
+            '.. build64_release/common/rpc/rpc_options.pb.h\n')
+        self.assertEqual(
+            ['app/example/foo.h', 'app/example/proto/bar.pb.h', 'common/rpc/rpc_client.h'],
+            direct)
+        self.assertEqual(
+            [['app/example/foo.h', 'app/example/proto/foo.pb.h'],
+             ['app/example/proto/bar.pb.h'],
+             ['common/rpc/rpc_client.h', 'common/rpc/rpc_options.pb.h']],
+            stacks)
+
+    def test_depth_gap_does_not_crash(self):
+        # #953: a.h (level 1) -> [system header at level 2, filtered out] ->
+        # b.h (level 3). The jump 1->3 must not raise; b.h is reached only via
+        # the system header, so it is not tracked.
+        direct, stacks = _parse('. foo/a.h\n... foo/b.h\n')
+        self.assertEqual(['foo/a.h'], direct)
+        self.assertEqual([], stacks)
+
+    def test_gap_on_first_line_does_not_crash(self):
+        # The first kept header is already nested under a filtered system one.
+        direct, stacks = _parse('.. foo/a.h\n')
+        self.assertEqual([], direct)
+        self.assertEqual([], stacks)
+
+    def test_parsing_resumes_after_a_gap(self):
+        # After skipping the gap subtree, a later level-1 include is tracked.
+        direct, stacks = _parse('. foo/a.h\n... foo/deep.h\n. foo/c.h\n')
+        self.assertEqual(['foo/a.h', 'foo/c.h'], direct)
+        self.assertEqual([], stacks)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #953 (relabeled enhancement → bug — it's a real crash).

## Bug
`_parse_inclusion_stacks` did `assert level == current_level + 1` and **re-raised** on failure, aborting the inclusion check (and the build) with an `AssertionError`.

## Why it fires "randomly"
The `.incstk` file deliberately **omits absolute/system headers** — the GCC awk splitter keeps only stack lines whose path doesn't start with `/` (`/^\.+ [^\/]/`), and the MSVC wrapper keeps only in-workspace headers — yet it preserves the compiler's **original depth numbers**. So a kept header (a workspace or generated `build64_release/...` header) nested under a filtered system header shows up with a **depth gap** (e.g. level 1 → level 3). The assert then trips. Whether it trips depends on each TU's include-graph shape, which is exactly the "random" failures the reporter saw in their boost/protobuf-heavy build.

Reproduced directly: an incstk of `. foo/a.h` then `... foo/b.h` raises `AssertionError`.

## Fix
A forward gap means the intervening levels were filtered system headers, so the deeper header is reached only through them — and, consistent with how absolute headers are already handled, it and its subtree are **not tracked includes** of this TU. Skip the subtree (`skip_level`) instead of aborting. Removed the now-dead `current_line`/`enumerate` bookkeeping.

## Tests
`parse_inclusion_stacks_test.py`: the contiguous happy-path still parses to the right `direct_hdrs`/`stacks`, and the gap cases (mid-stack, first line, resume-after-gap) no longer crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
