### PR TITLE
fix(cc): don't leak -rdynamic into the MSVC link for export_dynamic

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1683,7 +1683,19 @@ class CcBinary(CcTarget):
                 and sys.platform != 'darwin'):
             linkflags += ['-static-libgcc', '-static-libstdc++']
         if self.attr.get('export_dynamic'):
-            linkflags.append('-rdynamic')
+            # `-rdynamic` is a GNU-ld / ld64 (ELF/Mach-O) flag. MSVC link.exe
+            # has no equivalent -- it just answers LNK4044 and ignores it -- so
+            # don't emit it there; warn that the option has no effect instead of
+            # leaking a bogus flag. Explicit exe symbol export on Windows is
+            # tracked in #1201.
+            if toolchain.cc_is('msvc'):
+                self.warning(
+                    'export_dynamic has no effect on the MSVC toolchain; an '
+                    'executable does not export its symbols. Export them '
+                    'explicitly with /EXPORT linker options (linkflags) or a '
+                    '.def file. See issue #1201.')
+            else:
+                linkflags.append('-rdynamic')
         linkflags += self._generate_link_flags()
         for rpath_link in self._get_rpath_links():
             linkflags.append('-Wl,--rpath-link=%s' % rpath_link)


### PR DESCRIPTION
`cc_binary.export_dynamic` appended `-rdynamic` unconditionally — a GNU-ld / ld64 (ELF/Mach-O) flag. On **MSVC** it was passed straight to `link.exe`, which answered:

```
LINK : warning LNK4044: unrecognized option '/rdynamic'; ignored
```

So on Windows the option silently did nothing and just added warning noise (confirmed: `target_linkflags = -rdynamic` reached the link command).

## Fix
Gate it: on the MSVC toolchain, don't emit `-rdynamic`; instead emit a one-time warning that `export_dynamic` has no effect there, pointing at the explicit alternatives (`/EXPORT` via `linkflags`, or a `.def`). GCC/Clang behavior is unchanged.

```
hello-world: export_dynamic has no effect on the MSVC toolchain; an executable
does not export its symbols. Export them explicitly with /EXPORT linker options
(linkflags) or a .def file. See issue #1201.
```

Verified on MSVC: the warning shows, the build still succeeds, and `-rdynamic` no longer appears in the link command or the generated ninja.

## Not in scope
Actually supporting selective symbol export from a `cc_binary` on Windows (the real `export_dynamic` equivalent) — design + rationale captured in #1201. We deliberately do **not** auto-export via `cc_windef` (exporting all of an exe's symbols is a Windows anti-pattern); the Windows contract is explicit, selective export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
