### PR TITLE
docs: note gen_rule is not supported on Windows yet (#1204)

### DIFF
--- a/doc/en/build_rules/gen_rule.md
+++ b/doc/en/build_rules/gen_rule.md
@@ -2,6 +2,8 @@
 
 ## gen\_rule
 
+> **Not supported on the Windows (MSVC) toolchain yet.** `gen_rule` runs its command through a POSIX shell — the scaffold uses `ls` / `/dev/null`, and commands are typically written for `sh` — which Windows `cmd.exe` does not provide. Tracked in [#1204](https://github.com/blade-build/blade-build/issues/1204).
+
 Used to customize your own construction rules, parameters:
 
 - src_exts: list(str) The list of file extensions allowed in `src`.

--- a/doc/zh_CN/build_rules/gen_rule.md
+++ b/doc/zh_CN/build_rules/gen_rule.md
@@ -2,6 +2,8 @@
 
 ## gen\_rule
 
+> **暂不支持 Windows（MSVC）工具链。** `gen_rule` 的命令通过 POSIX shell 执行——脚手架用到 `ls` / `/dev/null`，且命令通常按 `sh` 编写——而 Windows 的 `cmd.exe` 不提供这些。进展见 [#1204](https://github.com/blade-build/blade-build/issues/1204)。
+
 用于定制自己的构建规则，参数：
 
 - src_exts: list(str) `src` 里允许的文件扩展名列表。


### PR DESCRIPTION
Records that `gen_rule` doesn't work on the Windows (MSVC) toolchain yet.

The rule template wraps the user command in a POSIX-shell scaffold (`src/blade/gen_rule_target.py`):

```
command = <user cmd> && cd <dir> && ls ${out} > /dev/null
```

`ls` / `/dev/null` are POSIX-only (Windows `cmd.exe` would need `dir`/`NUL`), and user `cmd`s are typically written for `sh` — so `gen_rule` targets fail under Windows' default interpreter.

Adds a note to the en/zh `gen_rule.md`, pointing at #1204 (which captures possible fixes: a portable builtin output-existence check to drop blade's own `ls`/`/dev/null` dependency, plus the inherently shell-specific user command). Doc-only.
