### PR TITLE
fix(cc): exempt windows_resources from the unused-deps check

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -123,8 +123,10 @@ def declare_private_hdrs(target, hdrs):
         _private_hdrs_target_map[hdr].add(target.key)
 
 
-def declare_header_less(target: 'CcTarget') -> None:
-    """Declare a library as having no public headers (explicit `hdrs = []`)."""
+def declare_header_less(target: 'Target') -> None:
+    """Declare a target as having no public headers, exempting it from the
+    unused-deps check. Used for cc_libraries with an explicit `hdrs = []` and
+    for link-only targets like windows_resources (`.res`, no headers)."""
     _header_less_target_keys.add(target.key)
 
 

--- a/src/blade/windows_resources_target.py
+++ b/src/blade/windows_resources_target.py
@@ -69,6 +69,15 @@ class WindowsResourcesTarget(Target):
             kwargs=kwargs)
         self._add_tags('type:windows_resources')
 
+        # A windows_resources target is a link-only dependency: it contributes a
+        # compiled `.res`, never a public C/C++ header a dependent would
+        # `#include`. So exempt it from the unused-deps check (which is
+        # header-inclusion based) -- otherwise every `cc_binary` that links a
+        # resource is flagged "Unused dependency". Declare it header-less, the
+        # same exemption header-less cc_libraries use.
+        from blade.cc_targets import declare_header_less  # noqa: E402  (avoid import cycle)
+        declare_header_less(self)
+
         self.attr['rc_files'] = rc_files
         self.attr['hdrs'] = hdrs
         self.attr['resources'] = resources


### PR DESCRIPTION
A `windows_resources` target is a **link-only** dependency — it contributes a compiled `.res`, never a public C/C++ header a dependent `#include`s. But the unused-deps check is header-inclusion based, so it flagged every `cc_binary` that links a resource:

```
suites/win_basic/BUILD:1: warning: hello_gui: Unused dependency (declared in "deps" but none of its public headers is directly included):
  ":hello_res"
```

even though the `.res` is genuinely linked in.

Fix: declare `windows_resources` targets **header-less** — the same exemption header-less `cc_library`s (`hdrs = []`) already get — so `_check_unused_deps` skips them. Also widens `declare_header_less`'s annotation from `CcTarget` to `Target` (it only needs `.key`, and now serves a non-cc target).

`is_header_less` is consumed *only* by the unused-deps check, so there's no other behavioral effect. Verified on `//suites/win_basic`: the false-positive warning is gone.
