### PR TITLE
fix(msvc): stop DLLs relinking every build (def write-if-changed + restat)

### DIFF
--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -555,16 +555,25 @@ class _NinjaFileHeaderGenerator:
         # is always created for a DLL, so it always prints). See
         # `_MSVC_LINK_WRAPPER_PY`.
         link_wrapper = self._msvc_link_wrapper_py()
+        # restat: link.exe doesn't rewrite the import library (`/IMPLIB`) when
+        # the DLL's exports are unchanged, so its mtime can lag; re-stat outputs
+        # after linking so an unchanged DLL/implib prunes dependent relinks.
         self.generate_rule(name='solink',
                            command=f'"{sys.executable}" -B {link_wrapper} -- {ld} /nologo /DLL ${{dllflags}} /out:${{out}} ${{linkflags}} {libpath_flags} ${{target_linkflags}} ${{extra_linkflags}} ${{in}}',
-                           description='LINK DLL ${out}')
+                           description='LINK DLL ${out}',
+                           restat=True)
 
         # Synthesize the auto-export `.def` from the object files (see the
         # `cc_windef` builtin tool). Windows-only; nothing emits this edge
         # elsewhere.
+        # restat: the `.def` is written write-if-changed, so when the export set
+        # is unchanged ninja keeps its old mtime and prunes the downstream DLL
+        # relink (the import lib stays newer than the def). See the
+        # incremental-build fix / issue #1161 pattern.
         self.generate_rule(name='cc_windef',
                            command=self._builtin_command('cc_windef', '${defflags} ${out} ${in}'),
-                           description='CC WINDEF ${out}')
+                           description='CC WINDEF ${out}',
+                           restat=True)
 
     def _generate_cc_vars(self):
         warnings, cxx_warnings, c_warnings, cu_warnings = self._get_warning_flags()

--- a/src/blade/builtin_tools.py
+++ b/src/blade/builtin_tools.py
@@ -389,10 +389,14 @@ def generate_cc_windef(args, export_map=None):
             seen.setdefault(name, is_data)
     if export_map:
         seen = _filter_exports_by_map(seen, export_map)
-    with open(output, 'w', encoding='utf-8') as f:
-        f.write('EXPORTS\n')
-        for name, is_data in seen.items():
-            f.write('    %s%s\n' % (name, ' DATA' if is_data else ''))
+    lines = ['EXPORTS']
+    lines += ['    %s%s' % (name, ' DATA' if is_data else '') for name, is_data in seen.items()]
+    # Write-if-changed: keep the .def's mtime when the export set is unchanged.
+    # Otherwise every build rewrites it, making it newer than the import library
+    # (which link.exe does NOT rewrite when exports are unchanged), so `solink`
+    # would relink the DLL on every build. Paired with restat on the cc_windef /
+    # solink rules. See the incremental-build fix.
+    util.write_if_changed(output, '\n'.join(lines) + '\n')
     return None
 
 


### PR DESCRIPTION
**Cause 2 of the "every DLL relinks on every build" problem** (Windows/MSVC). `ninja -d explain` showed:

```
output ...hello.dll.lib older than most recent input ...hello.def
...hello.dll.lib is dirty      <- then drags in hello_dynamic_test, cross_package_dynamic_test
```

`link.exe` does **not** rewrite the import library (`.dll.lib`) when a DLL's exports are unchanged, so its mtime lags. Meanwhile `cc_windef` rewrote the `.def` every build (plain `open('w')`), making it newer than the implib → `solink` was perpetually "stale", and the "dirty" implib then marked every dependent test exe dirty too.

Fix:
- `cc_windef` writes the `.def` **write-if-changed**, so an unchanged export set keeps the `.def`'s mtime.
- `restat=True` on **`cc_windef`** and **`solink`**, so ninja re-stats outputs and prunes downstream relinks when the `.def` / DLL / implib didn't change. (Same write-if-changed + restat pattern already used for `.incstk`, #1161.)

**Verified on MSVC:** `//suites/cc_basic/...` and `//suites/cc_export_map/...` now rebuild to `ninja: no work to do` (explain shows no `dll.lib`/`.def` staleness) — previously every DLL + dependent test relinked.

This is one of two independent causes; the CUDA one (nvcc temp files leaking into the dep list) is a separate follow-up PR.
