### PR TITLE
feat(proto): support java_multiple_files via a srcjar (#1054)

### DIFF
--- a/doc/en/develop/protobuf_build.md
+++ b/doc/en/develop/protobuf_build.md
@@ -23,9 +23,13 @@ A single proto file potentially produces multiple output sets:
   into a real `cc_library` output.
 - **Python**: `_pb2.py` files, gated by the target's `target_languages`
   attribute or the global `--generate-python` flag.
-- **Java**: `<Class>.java` files plus a packaged `.jar`, gated by
-  `target_languages='java'` / `--generate-java`. Path comes from the
-  proto's `option java_package`.
+- **Java**: a packaged `.jar`, gated by `target_languages='java'` /
+  `--generate-java`. protoc writes its `.java` into a per-proto gen dir which
+  the `protojava` rule zips into a `<proto>.srcjar` (the `proto_java_srcjar`
+  builtin); `javac_compile` then extracts and compiles those. The output `.java`
+  set is **not** predicted, so `option java_multiple_files = true;` (one `.java`
+  per top-level type, no outer class) works the same as the default single-file
+  layout. See issue #1054.
 - **Go**: `.pb.go`, gated similarly. Output path from `option go_package`.
 - **Descriptor set**: `.descriptors.pb` for tooling, on request.
 

--- a/doc/zh_CN/develop/protobuf_build.md
+++ b/doc/zh_CN/develop/protobuf_build.md
@@ -20,8 +20,12 @@ Python 库）给下游消费，所以 `cc_library` 直接 `deps = [':my_proto']`
   继承 `CcTarget`，把它们直接编进 `cc_library`。
 - **Python**：`_pb2.py`，由 target 的 `target_languages` 属性或全局
   `--generate-python` 控制。
-- **Java**：`<Class>.java` 加打包 `.jar`，受 `target_languages='java'`
-  / `--generate-java` 控制。路径来自 proto 的 `option java_package`。
+- **Java**：打包成 `.jar`，受 `target_languages='java'` / `--generate-java`
+  控制。protoc 把生成的 `.java` 写进每个 proto 各自的生成目录，`protojava`
+  规则再把它打成 `<proto>.srcjar`（`proto_java_srcjar` builtin）；`javac_compile`
+  随后解包并编译。生成的 `.java` 集合**不再被预测**，因此
+  `option java_multiple_files = true;`（每个顶层类型一个 `.java`、无外层类）
+  与默认的单文件布局一样可用。见 issue #1054。
 - **Go**：`.pb.go`，类似机制。输出路径来自 `option go_package`。
 - **Descriptor set**：`.descriptors.pb`，按需。
 

--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -798,10 +798,17 @@ class _NinjaFileHeaderGenerator:
                                    '--cpp_out=%s ${protocflags} ${protoccpppluginflags} ${in}' % (
                                        protoc, protobuf_incs, self.build_dir),
                            description='PROTOC CPP ${in}')
+        # Generate Java into a per-proto gen dir (${javagen}) and zip whatever
+        # protoc produced into a single `.srcjar` (${out}). This handles an
+        # unpredictable output set -- e.g. `option java_multiple_files = true;`
+        # emits one .java per top-level type -- without predicting filenames.
+        # The Java protoc plugins also target ${javagen} (see
+        # _protoc_plugin_parameters) so insertion points still resolve. #1054.
+        protojava_cmd = '%s --proto_path=. %s --java_out=${javagen} ${protocjavapluginflags} ${in}' % (
+            protoc_java, protobuf_java_incs)
         self.generate_rule(name='protojava',
-                           command='%s --proto_path=. %s --java_out=%s/${srcdir} '
-                                   '${protocjavapluginflags} ${in}' % (
-                                       protoc_java, protobuf_java_incs, self.build_dir),
+                           command=self._builtin_command(
+                               'proto_java_srcjar', '${out} ${javagen} -- ' + protojava_cmd),
                            description='PROTOC JAVA ${in}')
         self.generate_rule(name='protopython',
                            command='%s --proto_path=. %s -I=${srcdir} '

--- a/src/blade/builtin_tools.py
+++ b/src/blade/builtin_tools.py
@@ -583,10 +583,68 @@ def generate_javac_compile(args):
     shutil.rmtree(classes_dir, ignore_errors=True)
     os.makedirs(classes_dir, exist_ok=True)
 
+    # A source input may be a `.srcjar` (a jar of generated `.java`, e.g. from
+    # proto_library) rather than a plain `.java` file. javac can't compile a
+    # srcjar directly, so extract its `.java` and compile those. This is how
+    # we support an unpredictable generated-source set (e.g. proto
+    # `java_multiple_files`). See issue #1054.
+    sources = _expand_java_srcjars(sources, classes_dir + '.srcs')
+
     cmd = ['javac', '-encoding', source_encoding, '-d', classes_dir,
            '-classpath', classpath] + javacflags + sources
     subprocess.check_call(cmd)
     subprocess.check_call(['jar', 'cf', output, '-C', classes_dir, '.'])
+
+
+def _expand_java_srcjars(sources, extract_dir):
+    """Replace any `.srcjar`/`.jar` entry in `sources` with the `.java` files it
+    contains (extracted under `extract_dir`); plain sources pass through."""
+    import zipfile  # pylint: disable=import-outside-toplevel
+    if not any(s.endswith(('.srcjar', '.jar')) for s in sources):
+        return sources
+    shutil.rmtree(extract_dir, ignore_errors=True)
+    os.makedirs(extract_dir, exist_ok=True)
+    expanded = []
+    for s in sources:
+        if s.endswith(('.srcjar', '.jar')):
+            with zipfile.ZipFile(s) as z:
+                for name in z.namelist():
+                    if name.endswith('.java'):
+                        z.extract(name, extract_dir)
+                        expanded.append(os.path.join(extract_dir, name))
+        else:
+            expanded.append(s)
+    return expanded
+
+
+def generate_proto_java_srcjar(args):
+    """Run protoc to generate Java, then zip the result into a `.srcjar`.
+
+    Invoked as: ``proto_java_srcjar <out.srcjar> <gendir> -- <protoc cmd...>``.
+
+    protoc emits an unpredictable set of `.java` files (one outer class, or --
+    with ``option java_multiple_files = true;`` -- one per top-level type), so
+    instead of predicting filenames we collect everything protoc wrote under
+    ``gendir`` into a single srcjar. See issue #1054.
+    """
+    import subprocess  # pylint: disable=import-outside-toplevel
+    import zipfile  # pylint: disable=import-outside-toplevel
+    srcjar = args[0]
+    gendir = args[1]
+    assert args[2] == '--', 'proto_java_srcjar: expected "--" before the protoc command'
+    cmd = args[3:]
+    _declare_outputs(srcjar)
+    shutil.rmtree(gendir, ignore_errors=True)
+    os.makedirs(gendir, exist_ok=True)
+    subprocess.check_call(cmd)
+    with zipfile.ZipFile(srcjar, 'w', zipfile.ZIP_DEFLATED) as z:
+        for root, _, files in os.walk(gendir):
+            for name in sorted(files):
+                if name.endswith('.java'):
+                    full = os.path.join(root, name)
+                    # Jar entries always use '/' (Windows relpath yields '\').
+                    arcname = os.path.relpath(full, gendir).replace(os.sep, '/')
+                    z.write(full, arcname)
 
 
 def generate_java_jar(compression_level, args):
@@ -976,6 +1034,7 @@ _BUILTIN_TOOLS = {
     'scm': generate_scm,
     'package': generate_package,
     'javac_compile': generate_javac_compile,
+    'proto_java_srcjar': generate_proto_java_srcjar,
     'cc_inclusion_check': generate_cc_inclusion_check,
     'cc_windef': generate_cc_windef,
     'resource': generate_resource,

--- a/src/blade/proto_library_target.py
+++ b/src/blade/proto_library_target.py
@@ -174,7 +174,6 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
             cpp_headers.extend(headers)
         self.attr['generated_hdrs'] = full_cpp_headers
         self._set_hdrs(cpp_headers)
-        self.src_java_info = {}
         if self.attr['generate_java']:
             self.update_java_gen_info()
 
@@ -228,15 +227,16 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
         self._check_proto_deps()
 
     def update_java_gen_info(self):
-        """Update java package name and source path for java target for fingerprint."""
+        """Record the per-proto Java srcjar outputs for the target fingerprint.
+
+        The actual generated `.java` set is produced by protoc into the srcjar
+        at build time and is not predicted here (it depends on
+        `java_multiple_files` etc.) -- see _proto_java_rules / #1054.
+        """
         if "generated_java_sources" in self.attr:
             return
-        self.attr["generated_java_sources"] = []
-        for src in self.srcs:
-            input = self._source_file_path(src)
-            package_dir, java_name = self._proto_java_gen_file(src)
-            self.src_java_info[src] = (package_dir, java_name)
-            self.attr["generated_java_sources"].append(f"{input}__{package_dir}__{java_name}")
+        self.attr["generated_java_sources"] = [
+            self._target_file_path(src + '.srcjar') for src in self.srcs]
 
     def _expand_deps_generation(self):
         if self.attr['generate_java']:
@@ -269,20 +269,6 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
     def _get_java_pack_deps(self):
         return self._get_pack_deps()
 
-    def _get_java_package_name(self, content):
-        """Get the java package name from proto file if it is specified."""
-        java_package_pattern = r'^\s*option\s+java_package\s*=\s*["\']([\w.]+)'
-        m = re.search(java_package_pattern, content, re.MULTILINE)
-        if m:
-            return m.group(1)
-
-        package_pattern = r'^\s*package\s+([\w.]+)'
-        m = re.search(package_pattern, content, re.MULTILINE)
-        if m:
-            return m.group(1)
-
-        return ''
-
     def _get_go_package_name(self, path):
         with open(path) as f:
             content = f.read()
@@ -293,25 +279,6 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
         self.error('"go_package" is mandatory to generate golang code '
                    'in protocol buffers but is missing in %s.' % path)
         return ''
-
-    def _proto_java_gen_class_name(self, src, content):
-        """Get generated java class name"""
-        pattern = r'^\s*option\s+java_outer_classname\s*=\s*[\'"](\w+)["\']'
-        m = re.search(pattern, content, re.MULTILINE)
-        if m:
-            return m.group(1)
-        proto_name = src[:-6]
-        base_name = os.path.basename(proto_name)
-        return ''.join([p[0].upper() + p[1:] for p in base_name.split('_') if p])
-
-    def _proto_java_gen_file(self, src):
-        """Generate the java files name of the proto library."""
-        with open(self._source_file_path(src), encoding='utf-8') as f:
-            content = f.read()
-        package_dir = self._get_java_package_name(content).replace('.', '/')
-        class_name = self._proto_java_gen_class_name(src, content)
-        java_name = '%s.java' % class_name
-        return package_dir, java_name
 
     def protoc_direct_dependencies(self):
         """
@@ -350,12 +317,13 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
             if language in p.code_generation:
                 paths.append(p.path)
                 flag_key = 'protoc%spluginflags' % language
-                # For Java, we need to be consistent with native java output directory
-                # which is the build target directory for insertion points to be effected.
-                # See `protojava` rules for details
+                # For Java the plugin must write into the same dir as the
+                # native `--java_out` so insertion points resolve. Both are the
+                # per-proto gen dir `${javagen}` (a ninja var set per edge in
+                # _proto_java_rules), which is then zipped into the srcjar. #1054
                 plugin_opts = self.attr["plugin_opts"].get(p.name, [])
                 if language == 'java':
-                    flag_value = p.protoc_plugin_flag(self._target_dir(), plugin_opts)
+                    flag_value = p.protoc_plugin_flag('${javagen}', plugin_opts)
                 else:
                     flag_value = p.protoc_plugin_flag(self.build_dir, plugin_opts)
                 vars[flag_key] = vars[flag_key] + ' ' + flag_value if flag_key in vars else flag_value
@@ -393,17 +361,22 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
         plugin_paths, vars = self._protoc_plugin_parameters('java')
         implicit_deps = self.protoc_direct_dependencies()
         implicit_deps.extend(plugin_paths)
-        java_sources = []
+        srcjars = []
         for src in self.srcs:
             input = self._source_file_path(src)
-            package_dir, java_name = self.src_java_info[src]
-            output = self._target_file_path(os.path.join(os.path.dirname(src), package_dir, java_name))
-            vars['srcdir'] = to_unix_path(os.path.dirname(input))
-            self.generate_build('protojava', output, inputs=input,
-                                implicit_deps=implicit_deps, variables=vars)
-            java_sources.append(output)
+            # protoc writes its (unpredictable) `.java` set into ${javagen};
+            # the protojava rule then zips it into this `.srcjar`. The output
+            # set is not predicted, so `option java_multiple_files = true;`
+            # works the same as the single-outer-class layout. See #1054.
+            srcjar = self._target_file_path(src + '.srcjar')
+            javagen = self._target_file_path(src + '.javagen')
+            self.generate_build('protojava', srcjar, inputs=input,
+                                implicit_deps=implicit_deps,
+                                variables=dict(vars, javagen=javagen))
+            srcjars.append(srcjar)
 
-        jar = self._build_jar(inputs=java_sources, source_encoding=self.attr.get('source_encoding'))
+        # javac_compile extracts the `.java` from each srcjar and compiles them.
+        jar = self._build_jar(inputs=srcjars, source_encoding=self.attr.get('source_encoding'))
         self._add_target_file('jar', jar)
 
     def _proto_python_rules(self):

--- a/src/blade/util.py
+++ b/src/blade/util.py
@@ -366,7 +366,15 @@ def parse_command_line(argv):
     """
     options = {}
     args = []
-    for arg in argv:
+    for i, arg in enumerate(argv):
+        if arg == '--':
+            # Stop option parsing: everything from here on is positional (GNU
+            # convention). The `--` is kept in args so callers can split on it
+            # (javac_compile, proto_java_srcjar). This lets a forwarded
+            # sub-command carry its own `--flag=value` (e.g. protoc's
+            # `--java_out=...`) without it being eaten as an option here.
+            args.extend(argv[i:])
+            break
         if arg.startswith('--'):
             pos = arg.find('=')
             if pos < 0:

--- a/src/tests/unit/proto_java_srcjar_test.py
+++ b/src/tests/unit/proto_java_srcjar_test.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for the proto -> Java srcjar plumbing (issue #1054).
+
+`generate_proto_java_srcjar` runs protoc (here a stand-in that just writes
+`.java` files) and zips whatever it produced into a `.srcjar` -- so an
+unpredictable output set (e.g. `option java_multiple_files = true;`) is handled
+without predicting filenames. `_expand_java_srcjars` is the inverse on the
+javac side: it turns a `.srcjar` input back into its `.java` files.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+import zipfile
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import builtin_tools  # noqa: E402  (sys.path tweak above)
+
+# A stand-in for protoc: writes N .java files (in a package subdir) into the
+# gen dir passed as argv[1]. Lets us exercise the wrapper without a real protoc.
+_FAKE_PROTOC = (
+    'import os,sys; g=sys.argv[1]; d=os.path.join(g,"mypkg"); os.makedirs(d,exist_ok=True);'
+    '[open(os.path.join(d,n),"w").write("//"+n) for n in ("A.java","B.java","C.java")]'
+)
+
+
+class GenerateProtoJavaSrcjarTest(unittest.TestCase):
+    def test_zips_all_generated_java_with_forward_slashes(self):
+        with tempfile.TemporaryDirectory() as d:
+            srcjar = os.path.join(d, 'out.srcjar')
+            gendir = os.path.join(d, 'gen')
+            cmd = [sys.executable, '-c', _FAKE_PROTOC, gendir]
+            builtin_tools.generate_proto_java_srcjar([srcjar, gendir, '--'] + cmd)
+            self.assertTrue(os.path.exists(srcjar))
+            with zipfile.ZipFile(srcjar) as z:
+                names = set(z.namelist())
+            # All three "messages" captured -- the multiple-files case -- with
+            # POSIX separators (valid jar entries).
+            self.assertEqual({'mypkg/A.java', 'mypkg/B.java', 'mypkg/C.java'}, names)
+
+    def test_stale_gendir_is_cleared(self):
+        with tempfile.TemporaryDirectory() as d:
+            srcjar = os.path.join(d, 'out.srcjar')
+            gendir = os.path.join(d, 'gen')
+            os.makedirs(gendir)
+            open(os.path.join(gendir, 'Stale.java'), 'w').close()  # leftover
+            cmd = [sys.executable, '-c', _FAKE_PROTOC, gendir]
+            builtin_tools.generate_proto_java_srcjar([srcjar, gendir, '--'] + cmd)
+            with zipfile.ZipFile(srcjar) as z:
+                names = set(z.namelist())
+            self.assertNotIn('Stale.java', names)  # cleared before protoc
+
+
+class ExpandJavaSrcjarsTest(unittest.TestCase):
+    def test_srcjar_input_expands_to_extracted_java(self):
+        with tempfile.TemporaryDirectory() as d:
+            srcjar = os.path.join(d, 'in.srcjar')
+            with zipfile.ZipFile(srcjar, 'w') as z:
+                z.writestr('p/A.java', '//a')
+                z.writestr('p/B.java', '//b')
+                z.writestr('p/notes.txt', 'ignored')
+            out = builtin_tools._expand_java_srcjars([srcjar], os.path.join(d, 'x'))
+            self.assertEqual(2, len(out))
+            self.assertTrue(all(s.endswith('.java') and os.path.isfile(s) for s in out))
+
+    def test_plain_sources_pass_through_untouched(self):
+        srcs = ['a/Foo.java', 'b/Bar.java']
+        self.assertEqual(srcs, builtin_tools._expand_java_srcjars(srcs, '/unused'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implements #1054 (Option A from the issue design).

## Problem
proto_library predicted a single `<package>/<ClassName>.java` per proto. `option java_multiple_files = true;` makes protoc emit **one `.java` per top-level type** (no outer class), so the predicted output never appeared → ninja "missing output" and an incomplete jar.

## Fix — stop predicting, use a srcjar
- The `protojava` rule runs protoc into a per-proto gen dir `${javagen}`, then **zips whatever it produced** into `<proto>.srcjar` (new `proto_java_srcjar` builtin).
- `javac_compile` extracts and compiles the `.java` from any `.srcjar`/`.jar` source input.
- Java protoc-plugin output is pointed at the same `${javagen}` so **insertion points** still resolve.
- Deleted the fragile prediction (`_proto_java_gen_file` / `_proto_java_gen_class_name` / `_get_java_package_name`); `update_java_gen_info` now keys the fingerprint off the srcjar outputs.

This handles single-file and multiple-files **uniformly, with no detection**.

`util.parse_command_line` now honors a `--` stop sentinel (GNU convention) so the forwarded protoc command's own `--java_out=...` flags aren't eaten as builtin options (existing callers like `javac_compile` already place only file args after `--`, so they're unaffected).

## Verification
On Windows + real protoc:
- `java_multiple_files = true` → srcjar contains `Person.java`, `PersonOrBuilder.java`, `Contact.java` (the old code would have produced only `Contact.java`);
- default layout → srcjar contains the single `Contact.java`.

Unit tests cover the srcjar wrapper (incl. stale-gendir clearing, `/`-separated entries) and the javac-side extraction; pyright clean; no unit regressions. Full srcjar→jar compilation needs the protobuf-java runtime, which the Linux proto integration test (`proto_library_test.py`, `--generate-java`) exercises.

Closes #1054.
