### PR TITLE
fix(console): harden progress bar (cursor hide, residue clear, locking)

### DIFF
--- a/src/blade/console.py
+++ b/src/blade/console.py
@@ -146,9 +146,9 @@ def set_log_file(log_file):
     if _log is not None:
         # Close any previously opened log to avoid leaking the file descriptor.
         _log.close()
-    _log = open(log_file, 'w', 1)
-    # Make sure the tail of the log is flushed and the fd released even when the
-    # process exits abnormally (uncaught exception, sys.exit, etc.).
+    # File lifetime is process-wide on purpose; close is performed by the
+    # atexit hook below (and by the re-set guard above on a subsequent call).
+    _log = open(log_file, 'w', 1)  # lgtm[py/file-not-closed]
     atexit.register(_log.close)
 
 
@@ -220,10 +220,13 @@ _MAX_PROGRESS_BAR_WIDTH = 60
 # to avoid flooding the terminal when actions complete in bursts.
 _PROGRESS_REFRESH_INTERVAL = 0.2
 
-_need_clear_line = False  # Whether the last output is progress bar
 _last_progress_value = -1  # The last progress bar value, -1 means none
 _last_progress_time = 0
-_cursor_hidden = False  # Whether we've emitted _HIDE_CURSOR and still owe a _SHOW_CURSOR.
+# True iff a progress frame is currently on screen and we owe both a clear
+# (\r + \033[K) and a show-cursor (\033[?25h). Tracks "there's a frame to wipe"
+# and "we hid the cursor" together because those two facts are flipped in
+# lockstep — see show_progress_bar.
+_cursor_hidden = False
 
 
 def _compute_progress_bar_width(total):
@@ -264,16 +267,8 @@ def _hide_cursor_locked():
         _cursor_hidden = True
 
 
-def _show_cursor_locked():
-    """Reverse a prior _hide_cursor_locked. Caller holds _print_lock."""
-    global _cursor_hidden
-    if _cursor_hidden:
-        sys.stderr.write(_SHOW_CURSOR)
-        _cursor_hidden = False
-
-
 def show_progress_bar(current, total):
-    global _need_clear_line, _last_progress_value, _last_progress_time
+    global _last_progress_value, _last_progress_time
     if total <= 0 or not _cursor_control:
         # No real terminal -> don't dump repeated bar lines into a log file or pipe.
         return
@@ -287,21 +282,17 @@ def show_progress_bar(current, total):
         sys.stderr.flush()
         _last_progress_value = current
         _last_progress_time = now
-        _need_clear_line = True
 
 
 def _clear_progress_bar_locked():
     """Erase the progress bar in place. Caller must hold _print_lock."""
-    global _need_clear_line, _last_progress_value, _last_progress_time
-    if _need_clear_line and _cursor_control:
-        sys.stderr.write('\r' + _CLEAR_TO_EOL)
-    # Hand the cursor back to the foreground stream before any non-progress
-    # output appears, otherwise a normal printed message would land where the
-    # cursor is invisible.
-    _show_cursor_locked()
-    if _need_clear_line and _cursor_control:
+    global _cursor_hidden, _last_progress_value, _last_progress_time
+    if _cursor_hidden and _cursor_control:
+        # Wipe the frame and hand the cursor back, in a single flush so that
+        # any subsequent message lands on a clean line with a visible cursor.
+        sys.stderr.write('\r' + _CLEAR_TO_EOL + _SHOW_CURSOR)
         sys.stderr.flush()
-    _need_clear_line = False
+    _cursor_hidden = False
     _last_progress_value = -1
     _last_progress_time = 0
 

--- a/src/blade/console.py
+++ b/src/blade/console.py
@@ -13,10 +13,12 @@ This is the util module which provides command functions.
 """
 
 
+import atexit
 import datetime
 import os
-import subprocess
+import shutil
 import sys
+import threading
 import time
 from typing import TYPE_CHECKING
 
@@ -33,8 +35,9 @@ def _windows_console_support_ansi_color():
     from ctypes import byref, windll, wintypes
     ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
     INVALID_HANDLE_VALUE = -1
+    STD_OUTPUT_HANDLE = -11  # Win32 GetStdHandle id; defined locally so we don't depend on subprocess internals.
 
-    handle = windll.kernel32.GetStdHandle(subprocess.STD_OUTPUT_HANDLE)
+    handle = windll.kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
     if handle == INVALID_HANDLE_VALUE:
         return False
 
@@ -57,8 +60,23 @@ def _console_support_ansi_color():
     return sys.stdout.isatty() and os.environ.get('TERM') not in ('emacs', 'dumb')
 
 
+def _console_support_cursor_control():
+    """Whether the stream that carries the progress bar can interpret \\r and cursor escapes."""
+    if os.name == 'nt':
+        # On Windows, VTP gates both color and cursor escapes; if it's off, neither works.
+        return _windows_console_support_ansi_color() and sys.stderr.isatty()
+    return sys.stderr.isatty() and os.environ.get('TERM') not in ('emacs', 'dumb', '')
+
+
 # Global color enabled or not
 _color_enabled = _console_support_ansi_color()
+
+# Whether the terminal supports cursor control (\r, \033[K, ...).
+# Conceptually independent from color support, even if they coincide on most terminals.
+_cursor_control = _console_support_cursor_control()
+
+# Serializes writes to stdout/stderr so the progress bar and messages don't interleave.
+_print_lock = threading.Lock()
 
 # See http://en.wikipedia.org/wiki/ANSI_escape_code
 # colors
@@ -77,8 +95,17 @@ _COLORS = {
     'end': '\033[0m',
 }
 
-# cursor movement
-_CLEAR_LINE = '\033[2K'
+# Clears from the cursor to end of line. Always emit \r first so the cursor is at
+# column 0 and the whole visible line is wiped, including any tail left by a
+# previous, longer frame (e.g. "99/100 99%" -> "1/100 1%").
+_CLEAR_TO_EOL = '\033[K'
+
+# Cursor visibility. Hide while the progress bar owns the last line so the
+# blinking block at the end of the bar doesn't sit there looking sloppy.
+# The matching show MUST run no matter how the process exits — see the atexit
+# and signal hooks at the bottom of this section.
+_HIDE_CURSOR = '\033[?25l'
+_SHOW_CURSOR = '\033[?25h'
 
 
 def color_enabled():
@@ -116,7 +143,13 @@ _log = None
 def set_log_file(log_file):
     """Set the global log file."""
     global _log
-    _log = open(log_file, 'w', 1)  # kept open for process lifetime
+    if _log is not None:
+        # Close any previously opened log to avoid leaking the file descriptor.
+        _log.close()
+    _log = open(log_file, 'w', 1)
+    # Make sure the tail of the log is flushed and the fd released even when the
+    # process exits abnormally (uncaught exception, sys.exit, etc.).
+    atexit.register(_log.close)
 
 
 def get_log_file():
@@ -178,53 +211,125 @@ def verbosity_ge(expected):
 # Progress bar
 ##############################################################################
 
-# Fit with the 80 columns terminal, leave some spaces for other parts such as the numbers.
-_PROGRESS_BAR_WIDTH = 60
-_PROGRESS_REFRESH_INTERVAL = 1 if sys.stdout.isatty() else 3
+# Sane bounds for the bar's filled-area width. Narrow terminals would otherwise
+# get a wrap-around (which kills cursor-based redraw); very wide terminals would
+# get a uselessly stretched bar.
+_MIN_PROGRESS_BAR_WIDTH = 10
+_MAX_PROGRESS_BAR_WIDTH = 60
+# Throttle progress bar refresh. Short enough that the bar feels alive; long enough
+# to avoid flooding the terminal when actions complete in bursts.
+_PROGRESS_REFRESH_INTERVAL = 0.2
 
-# TODO(chen3feng): Add lock
 _need_clear_line = False  # Whether the last output is progress bar
 _last_progress_value = -1  # The last progress bar value, -1 means none
 _last_progress_time = 0
+_cursor_hidden = False  # Whether we've emitted _HIDE_CURSOR and still owe a _SHOW_CURSOR.
+
+
+def _compute_progress_bar_width(total):
+    """Pick a bar width that fits the current terminal, bounded by [MIN, MAX]."""
+    cols = shutil.get_terminal_size((80, 24)).columns
+    # Layout: "[<bar>] <current>/<total> <p>%". len(current) <= len(total) and
+    # p ranges 0..100 (<=3 chars). Non-bar chars = 5 fixed + 2*len(total) + 3 = 8 + 2*len(total).
+    # Add 1 column of margin so the line stays strictly under `cols`; hitting the
+    # right edge would auto-wrap and break the single-line \r redraw.
+    overhead = 9 + 2 * len(str(total))
+    return max(_MIN_PROGRESS_BAR_WIDTH, min(_MAX_PROGRESS_BAR_WIDTH, cols - overhead - 1))
 
 
 def _progress_bar(progress, current, total):
     """Progress bar drawing text, like this:
     [===========================================================----] 46/50 92%
     """
-    width = progress * _PROGRESS_BAR_WIDTH // 100
-    return '[{}{}] {}/{} {:g}%'.format('=' * width, '-' * (_PROGRESS_BAR_WIDTH - width),
+    bar_width = _compute_progress_bar_width(total)
+    filled = progress * bar_width // 100
+    return '[{}{}] {}/{} {:g}%'.format('=' * filled, '-' * (bar_width - filled),
                                   current, total, progress)
 
 
-def _need_refresh_pgogress_bar(progress, current, now):
-    return (now - _last_progress_time >= _PROGRESS_REFRESH_INTERVAL and
-            _last_progress_value != current)
+def _need_refresh_progress_bar(current, total, now):
+    if _last_progress_value == current:
+        return False
+    if current == total:
+        # Always paint the final 100% frame, even if it would otherwise be throttled away.
+        return True
+    return now - _last_progress_time >= _PROGRESS_REFRESH_INTERVAL
+
+
+def _hide_cursor_locked():
+    """Emit _HIDE_CURSOR exactly once per hide/show cycle. Caller holds _print_lock."""
+    global _cursor_hidden
+    if not _cursor_hidden:
+        sys.stderr.write(_HIDE_CURSOR)
+        _cursor_hidden = True
+
+
+def _show_cursor_locked():
+    """Reverse a prior _hide_cursor_locked. Caller holds _print_lock."""
+    global _cursor_hidden
+    if _cursor_hidden:
+        sys.stderr.write(_SHOW_CURSOR)
+        _cursor_hidden = False
 
 
 def show_progress_bar(current, total):
     global _need_clear_line, _last_progress_value, _last_progress_time
+    if total <= 0 or not _cursor_control:
+        # No real terminal -> don't dump repeated bar lines into a log file or pipe.
+        return
     progress = current * 100 // total
     now = time.time()
-    if _need_refresh_pgogress_bar(progress, current, now):
-        line = _progress_bar(progress, current, total)
-        line += '\r' if _color_enabled else '\n'
-        print(line, end='')
-        sys.stdout.flush()
+    with _print_lock:
+        if not _need_refresh_progress_bar(current, total, now):
+            return
+        _hide_cursor_locked()
+        sys.stderr.write('\r' + _progress_bar(progress, current, total) + _CLEAR_TO_EOL)
+        sys.stderr.flush()
         _last_progress_value = current
         _last_progress_time = now
         _need_clear_line = True
 
 
-def clear_progress_bar():
+def _clear_progress_bar_locked():
+    """Erase the progress bar in place. Caller must hold _print_lock."""
     global _need_clear_line, _last_progress_value, _last_progress_time
-    if _need_clear_line:
-        if _color_enabled:
-            print(_CLEAR_LINE, end='')
-        _need_clear_line = False
-        _last_progress_value = -1
-        _last_progress_time = 0
-        sys.stdout.flush()
+    if _need_clear_line and _cursor_control:
+        sys.stderr.write('\r' + _CLEAR_TO_EOL)
+    # Hand the cursor back to the foreground stream before any non-progress
+    # output appears, otherwise a normal printed message would land where the
+    # cursor is invisible.
+    _show_cursor_locked()
+    if _need_clear_line and _cursor_control:
+        sys.stderr.flush()
+    _need_clear_line = False
+    _last_progress_value = -1
+    _last_progress_time = 0
+
+
+def clear_progress_bar():
+    with _print_lock:
+        _clear_progress_bar_locked()
+
+
+def _restore_cursor_at_exit():
+    """Ensure the cursor is visible no matter how the process exits.
+
+    atexit covers normal exit, sys.exit, and exceptions propagating to the
+    top of the stack (including KeyboardInterrupt from Ctrl+C). Without this
+    hook, an interrupted Blade build would leave the user's terminal with no
+    visible cursor until they ran ``reset`` or ``stty echo``.
+    """
+    if _cursor_hidden:
+        try:
+            sys.stderr.write(_SHOW_CURSOR)
+            sys.stderr.flush()
+        except (OSError, ValueError):
+            # stderr may already be closed during interpreter shutdown.
+            pass
+
+
+if _cursor_control:
+    atexit.register(_restore_cursor_at_exit)
 
 
 ##############################################################################
@@ -233,8 +338,11 @@ def clear_progress_bar():
 
 
 def _do_print(msg, file=sys.stdout):
-    clear_progress_bar()
-    print(msg, file=file)
+    # Hold the lock across "clear" and "print" so the progress refresh path can't
+    # squeeze a redraw between them and split the message.
+    with _print_lock:
+        _clear_progress_bar_locked()
+        print(msg, file=file)
 
 
 def _print(msg, verbosity):

--- a/src/tests/unit/console_test.py
+++ b/src/tests/unit/console_test.py
@@ -52,7 +52,6 @@ class _ConsoleStateMixin:
         self._saved = {
             '_cursor_control': console._cursor_control,
             '_color_enabled': console._color_enabled,
-            '_need_clear_line': console._need_clear_line,
             '_last_progress_value': console._last_progress_value,
             '_last_progress_time': console._last_progress_time,
             '_cursor_hidden': console._cursor_hidden,
@@ -60,7 +59,6 @@ class _ConsoleStateMixin:
         }
         console._cursor_control = True
         console._color_enabled = True
-        console._need_clear_line = False
         console._last_progress_value = -1
         console._last_progress_time = 0
         console._cursor_hidden = False
@@ -200,7 +198,6 @@ class ClearProgressBarTest(_ConsoleStateMixin, unittest.TestCase):
         # Minimal clear sequence: cursor to col 0, then EOL clear, then show
         # cursor (cursor was hidden while the bar was on screen).
         self.assertEqual(self.stderr.getvalue(), '\r\x1b[K\x1b[?25h')
-        self.assertFalse(console._need_clear_line)
         self.assertEqual(console._last_progress_value, -1)
         self.assertFalse(console._cursor_hidden)
 
@@ -209,10 +206,11 @@ class ClearProgressBarTest(_ConsoleStateMixin, unittest.TestCase):
         self.assertEqual(self.stderr.getvalue(), '')
 
     def test_noop_when_cursor_control_disabled(self):
-        # Even if _need_clear_line gets stuck at True somehow, we must not
-        # emit escape codes into a non-tty stream.
+        # Even if _cursor_hidden gets stuck at True somehow (e.g. cursor
+        # control was toggled off mid-build), we must not emit escape codes
+        # into what is now a non-tty stream.
         console._cursor_control = False
-        console._need_clear_line = True
+        console._cursor_hidden = True
         console.clear_progress_bar()
         self.assertEqual(self.stderr.getvalue(), '')
 

--- a/src/tests/unit/console_test.py
+++ b/src/tests/unit/console_test.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors
+# All rights reserved.
+#
+# Unit tests for blade.console: progress bar drawing, throttling,
+# terminal-width adaptation, and log file lifecycle.
+
+"""Tests for :mod:`blade.console`.
+
+The progress bar is the only piece of cursor-controlled UI in Blade. Bugs here
+are highly visible (residue characters on screen, log files filled with escape
+codes, lost output during concurrent prints) and easy to introduce by accident,
+so we pin down the load-bearing invariants:
+
+* every frame starts with ``\\r`` and ends with a clear-to-EOL escape, so that
+  a shorter frame never leaves residue from a previous longer frame;
+* the 100% frame is always painted even when it falls inside the throttle
+  window of the previous redraw;
+* the bar width tracks the terminal width without ever crossing the right
+  edge (an over-wide line wraps, and a wrapped line breaks ``\\r`` redraw);
+* writes from ``show_progress_bar`` and from ``_do_print`` are serialized so
+  that messages never appear in the middle of a frame;
+* ``set_log_file`` releases the previously held fd and registers the new one
+  with ``atexit`` so the tail of the log is flushed on abnormal exit.
+"""
+
+import io
+import os
+import sys
+import tempfile
+import threading
+import unittest
+from unittest.mock import patch
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import console  # noqa: E402
+
+
+class _ConsoleStateMixin:
+    """Save and restore module-level console state around each test.
+
+    ``blade.console`` is intentionally a singleton — it matches the rest of
+    Blade's runtime model — so tests have to discipline themselves about state
+    leakage. Default state for each test: cursor control on, no prior frame,
+    stdout/stderr captured into in-memory buffers.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self._saved = {
+            '_cursor_control': console._cursor_control,
+            '_color_enabled': console._color_enabled,
+            '_need_clear_line': console._need_clear_line,
+            '_last_progress_value': console._last_progress_value,
+            '_last_progress_time': console._last_progress_time,
+            '_cursor_hidden': console._cursor_hidden,
+            '_log': console._log,
+        }
+        console._cursor_control = True
+        console._color_enabled = True
+        console._need_clear_line = False
+        console._last_progress_value = -1
+        console._last_progress_time = 0
+        console._cursor_hidden = False
+        self._real_stderr = sys.stderr
+        self._real_stdout = sys.stdout
+        self.stderr = io.StringIO()
+        self.stdout = io.StringIO()
+        sys.stderr = self.stderr
+        sys.stdout = self.stdout
+
+    def tearDown(self):
+        sys.stderr = self._real_stderr
+        sys.stdout = self._real_stdout
+        for k, v in self._saved.items():
+            setattr(console, k, v)
+        super().tearDown()
+
+
+class ProgressBarFrameTest(_ConsoleStateMixin, unittest.TestCase):
+    """A drawn frame must start with ``\\r`` and end with ``\\033[K``."""
+
+    def test_frame_starts_with_cr_and_ends_with_clear_to_eol(self):
+        # The "residue" bug — a previous, longer frame leaves tail characters
+        # that the current shorter frame can't overwrite — is prevented by
+        # leading \r (to ensure column 0) plus trailing \033[K (to wipe the
+        # leftover tail). The hide-cursor escape sits in front of the \r but
+        # doesn't affect the redraw geometry.
+        console.show_progress_bar(5, 10)
+        out = self.stderr.getvalue()
+        self.assertIn('\r[', out,
+                      f'expected CR + [ inside the frame, got {out!r}')
+        self.assertTrue(out.endswith('\x1b[K'),
+                        f'expected trailing \\033[K, got {out[-6:]!r}')
+
+    def test_shorter_frame_emits_eol_clear_after_long_one(self):
+        console.show_progress_bar(99, 100)
+        # Defeat the dedup + throttle so the next call paints.
+        console._last_progress_value = -1
+        console._last_progress_time = 0
+        console.show_progress_bar(1, 100)
+        # Each frame must end with the clear sequence — that's what wipes the
+        # leftover "9%" tail from the previous longer frame.
+        self.assertEqual(self.stderr.getvalue().count('\x1b[K'), 2)
+
+    def test_total_zero_does_not_crash(self):
+        # total == 0 used to ZeroDivisionError on `current * 100 // total`.
+        console.show_progress_bar(0, 0)
+        console.show_progress_bar(5, 0)
+        self.assertEqual(self.stderr.getvalue(), '')
+
+    def test_no_output_without_cursor_control(self):
+        # Non-tty (CI logs, piped output) must not get raw bar lines dumped
+        # into them — the previous behavior of falling back to "\n" mode
+        # produced unreadable log files.
+        console._cursor_control = False
+        for i in range(10):
+            console.show_progress_bar(i, 10)
+        self.assertEqual(self.stderr.getvalue(), '')
+
+
+class ProgressBarRefreshLogicTest(_ConsoleStateMixin, unittest.TestCase):
+    """Throttling, dedup, and the always-paint-100%-frame rule."""
+
+    def test_same_value_is_deduped(self):
+        console.show_progress_bar(5, 10)
+        first = self.stderr.getvalue()
+        console.show_progress_bar(5, 10)
+        self.assertEqual(self.stderr.getvalue(), first,
+                         'duplicate value should not redraw')
+
+    def test_distinct_value_within_throttle_window_is_dropped(self):
+        console.show_progress_bar(1, 100)
+        # Immediately push a distinct value — still within the 200ms window.
+        console.show_progress_bar(2, 100)
+        self.assertEqual(self.stderr.getvalue().count('\r['), 1,
+                         'second frame within throttle window should be dropped')
+
+    def test_100_percent_is_always_painted_even_when_throttled(self):
+        # Without the current==total override, a build that races from 50% to
+        # 100% inside 200ms would leave the user staring at "50%" forever.
+        console.show_progress_bar(50, 100)
+        console.show_progress_bar(100, 100)  # would normally be throttled
+        self.assertIn('100/100', self.stderr.getvalue())
+
+
+class ProgressBarWidthTest(unittest.TestCase):
+    """``_compute_progress_bar_width`` must adapt to terminal size without
+    crossing the right edge or shrinking below a usable minimum.
+    """
+
+    def _width_with_cols(self, cols, total):
+        # shutil.get_terminal_size reads $COLUMNS / $LINES first, which lets
+        # us pin terminal size deterministically without a pty.
+        with patch.dict(os.environ, {'COLUMNS': str(cols), 'LINES': '24'}):
+            return console._compute_progress_bar_width(total)
+
+    def test_caps_at_max_for_wide_terminals(self):
+        self.assertEqual(self._width_with_cols(200, 100),
+                         console._MAX_PROGRESS_BAR_WIDTH)
+
+    def test_shrinks_on_narrow_terminals(self):
+        narrow = self._width_with_cols(40, 100)
+        self.assertLess(narrow, console._MAX_PROGRESS_BAR_WIDTH)
+        self.assertGreaterEqual(narrow, console._MIN_PROGRESS_BAR_WIDTH)
+
+    def test_floors_at_min_on_pathologically_narrow_terminals(self):
+        # 5-col terminals don't really exist, but the formatter must still
+        # produce *something* renderable rather than crash or return <=0.
+        self.assertEqual(self._width_with_cols(5, 100),
+                         console._MIN_PROGRESS_BAR_WIDTH)
+
+    def test_full_line_fits_strictly_within_terminal(self):
+        # Invariant: total rendered line length is strictly less than the
+        # reported terminal width. Hitting the right edge wraps the line,
+        # which breaks the single-line \r redraw model.
+        for cols in (40, 60, 80, 120):
+            for total in (10, 100, 9999):
+                with self.subTest(cols=cols, total=total):
+                    with patch.dict(os.environ,
+                                    {'COLUMNS': str(cols), 'LINES': '24'}):
+                        # 100/100 is the longest numeric suffix possible.
+                        line = console._progress_bar(100, total, total)
+                        self.assertLess(
+                            len(line), cols,
+                            f'cols={cols} total={total}: line is '
+                            f'{len(line)} chars: {line!r}')
+
+
+class ClearProgressBarTest(_ConsoleStateMixin, unittest.TestCase):
+    """``clear_progress_bar`` wipes the line, resets state, and is a no-op
+    when there's nothing to clear."""
+
+    def test_clears_after_a_drawn_frame(self):
+        console.show_progress_bar(5, 10)
+        self.stderr.truncate(0); self.stderr.seek(0)
+        console.clear_progress_bar()
+        # Minimal clear sequence: cursor to col 0, then EOL clear, then show
+        # cursor (cursor was hidden while the bar was on screen).
+        self.assertEqual(self.stderr.getvalue(), '\r\x1b[K\x1b[?25h')
+        self.assertFalse(console._need_clear_line)
+        self.assertEqual(console._last_progress_value, -1)
+        self.assertFalse(console._cursor_hidden)
+
+    def test_noop_without_a_prior_frame(self):
+        console.clear_progress_bar()
+        self.assertEqual(self.stderr.getvalue(), '')
+
+    def test_noop_when_cursor_control_disabled(self):
+        # Even if _need_clear_line gets stuck at True somehow, we must not
+        # emit escape codes into a non-tty stream.
+        console._cursor_control = False
+        console._need_clear_line = True
+        console.clear_progress_bar()
+        self.assertEqual(self.stderr.getvalue(), '')
+
+
+class DoPrintClearsProgressBarTest(_ConsoleStateMixin, unittest.TestCase):
+    """``_do_print`` is the join point that makes "errors scroll up, progress
+    stays at the bottom" work — it must clear the progress bar before
+    writing the message."""
+
+    def test_clears_then_prints(self):
+        console.show_progress_bar(5, 10)
+        self.stderr.truncate(0); self.stderr.seek(0)
+        self.stdout.truncate(0); self.stdout.seek(0)
+        console._do_print('hello', file=sys.stderr)
+        # Clear sequence + show-cursor first, then the message; nothing else.
+        self.assertEqual(self.stderr.getvalue(), '\r\x1b[K\x1b[?25hhello\n')
+
+
+class CursorVisibilityTest(_ConsoleStateMixin, unittest.TestCase):
+    """Hide the cursor while a progress bar owns the bottom line; restore it
+    before any non-progress output (or process exit) so the user never finds
+    their terminal cursor-less."""
+
+    def test_first_frame_emits_hide_cursor(self):
+        console.show_progress_bar(5, 10)
+        # The hide must come *before* the redraw, otherwise the blink is
+        # visible for one frame.
+        out = self.stderr.getvalue()
+        self.assertTrue(out.startswith('\x1b[?25l'),
+                        f'first frame must lead with hide-cursor, got {out[:8]!r}')
+        self.assertTrue(console._cursor_hidden)
+
+    def test_hide_cursor_emitted_only_once_across_redraws(self):
+        # The hide is sticky: subsequent redraws inside the same "progress
+        # active" stretch must not re-emit it, or the terminal sees a stream
+        # of redundant escapes.
+        console.show_progress_bar(1, 100)
+        # Defeat dedup + throttle so the next draw really runs.
+        console._last_progress_value = -1
+        console._last_progress_time = 0
+        console.show_progress_bar(2, 100)
+        self.assertEqual(self.stderr.getvalue().count('\x1b[?25l'), 1)
+
+    def test_clear_progress_bar_restores_cursor(self):
+        console.show_progress_bar(5, 10)
+        self.assertTrue(console._cursor_hidden)
+        console.clear_progress_bar()
+        self.assertFalse(console._cursor_hidden)
+        self.assertIn('\x1b[?25h', self.stderr.getvalue())
+
+    def test_no_cursor_escapes_without_cursor_control(self):
+        # Non-tty must not see any cursor-visibility escapes either.
+        console._cursor_control = False
+        for i in range(5):
+            console.show_progress_bar(i, 5)
+        console.clear_progress_bar()
+        self.assertNotIn('\x1b[?25', self.stderr.getvalue())
+        self.assertFalse(console._cursor_hidden)
+
+    def test_atexit_handler_restores_hidden_cursor(self):
+        # Simulate "process exits while a frame is on screen": the cursor is
+        # hidden and there's no clear_progress_bar before exit. The atexit
+        # handler must emit a show.
+        console.show_progress_bar(5, 10)
+        self.assertTrue(console._cursor_hidden)
+        # Don't reuse the show_progress_bar's stderr capture; the handler
+        # should emit a new show-cursor escape.
+        self.stderr.truncate(0); self.stderr.seek(0)
+        console._restore_cursor_at_exit()
+        self.assertEqual(self.stderr.getvalue(), '\x1b[?25h')
+
+    def test_atexit_handler_is_noop_when_cursor_not_hidden(self):
+        # Common case: build finishes cleanly, clear_progress_bar already ran,
+        # nothing left to do. atexit must not emit a spurious show.
+        self.assertFalse(console._cursor_hidden)
+        console._restore_cursor_at_exit()
+        self.assertEqual(self.stderr.getvalue(), '')
+
+
+class ConcurrencyTest(_ConsoleStateMixin, unittest.TestCase):
+    """The lock around the clear-then-write pair must keep concurrent
+    progress refreshes and messages from interleaving inside a single
+    frame's bytes."""
+
+    def test_messages_never_split_a_progress_frame(self):
+        # Run many progress redraws and many message prints in parallel.
+        # With the lock, every frame ('\r[' ... '\033[K') must be a
+        # contiguous, uninterrupted byte range — no message text in the
+        # middle.
+        with patch.object(console, '_PROGRESS_REFRESH_INTERVAL', 0):
+            def producer_progress():
+                for i in range(200):
+                    # Force a distinct value so dedup doesn't drop it.
+                    console.show_progress_bar(i % 99, 100)
+
+            def producer_messages():
+                for i in range(200):
+                    console._do_print(f'msg-{i}', file=sys.stderr)
+
+            t1 = threading.Thread(target=producer_progress)
+            t2 = threading.Thread(target=producer_messages)
+            t1.start(); t2.start(); t1.join(); t2.join()
+
+        out = self.stderr.getvalue()
+        # Walk the byte stream looking for frame starts. '\r[' marks a frame
+        # (note: '\r\033[K' from a clear doesn't match — '\r' is followed by
+        # '\033', not '['). Between '\r[' and the next '\033[K' there must
+        # be no newline, otherwise a message leaked into the frame.
+        i = 0
+        frames_seen = 0
+        while True:
+            start = out.find('\r[', i)
+            if start < 0:
+                break
+            end = out.find('\x1b[K', start)
+            self.assertGreater(end, start,
+                               'every frame must end with \\033[K')
+            self.assertNotIn(
+                '\n', out[start:end],
+                f'message text leaked into frame: {out[start:end]!r}')
+            frames_seen += 1
+            i = end + 1
+        self.assertGreater(frames_seen, 0,
+                           'producer_progress should have emitted frames')
+
+
+class LogFileLifecycleTest(_ConsoleStateMixin, unittest.TestCase):
+    """``set_log_file`` releases any previously held fd and registers the
+    new one with ``atexit`` so its tail is flushed on abnormal exit."""
+
+    def test_re_setting_closes_previous_log(self):
+        # We patch atexit so we don't leak handlers into the rest of the
+        # test process. The functional behavior we care about here is just
+        # the close-the-old-fd path.
+        with tempfile.TemporaryDirectory() as td, \
+                patch('blade.console.atexit'):
+            console.set_log_file(os.path.join(td, 'a.log'))
+            first = console._log
+            console.set_log_file(os.path.join(td, 'b.log'))
+            second = console._log
+            self.assertTrue(first.closed,
+                            'previous log fd must be released on re-set')
+            self.assertFalse(second.closed)
+            second.close()  # leave the fixture in a clean state
+
+    def test_atexit_registers_a_closer_for_the_log(self):
+        # We patch atexit.register to capture the callable rather than
+        # actually register it for interpreter shutdown.
+        with tempfile.TemporaryDirectory() as td, \
+                patch('blade.console.atexit') as mock_atexit:
+            console.set_log_file(os.path.join(td, 'a.log'))
+            mock_atexit.register.assert_called_once()
+            registered = mock_atexit.register.call_args[0][0]
+            self.assertFalse(console._log.closed)
+            registered()
+            self.assertTrue(
+                console._log.closed,
+                'the atexit callable must close the current log file')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR cleans up a number of long-standing rough edges in `blade.console`'s
single-line progress bar and adds the first unit tests for the module.

### Bug fixes

- **Residue when shorter frame overwrites longer.** Every frame now ends with
  `\033[K` (clear-to-EOL), so going from `99/100 99%` → `1/100 1%` no longer
  leaves a stray `9%` tail on screen.
- **Locking.** A `threading.Lock` is now held across "clear progress bar" + "write
  message" so a concurrent progress refresh can't slip in between and split the
  message. Retires the existing `# TODO(chen3feng): Add lock`.
- **100% sometimes invisible.** If a build raced from <100% to 100% inside the
  200 ms throttle window, the final frame was dropped and users were left
  looking at a 50% bar. The 100% frame is now force-painted.
- **`total = 0` crashed.** Guarded.
- **`set_log_file` leaked the previous fd** and never flushed on abnormal exit.
  Now closes the previous log and registers `atexit.register(_log.close)`.

### Refactor

- **Split `_cursor_control` from `_color_enabled`.** They were the same flag,
  which made progress drawing accidentally depend on the color setting.
- **Progress writes to stderr.** Matches the convention used by `make`, `ninja`,
  `cargo`, `bazel`. `blade build > out.txt` no longer dumps escape codes into
  the file.
- **No progress in non-tty mode.** Used to fall back to `\n`-terminated lines
  appended to the log; now just no-ops.
- Dropped the unused `subprocess` import and replaced `subprocess.STD_OUTPUT_HANDLE`
  with the literal `-11` plus comment (that constant is only exposed on Windows).

### Features

- **Adaptive bar width.** Uses `shutil.get_terminal_size`, bounded by
  `[_MIN_PROGRESS_BAR_WIDTH=10, _MAX_PROGRESS_BAR_WIDTH=60]`, with one column
  of right-edge margin to avoid auto-wrap (which would break `\r` redraw).
- **Hide cursor while progress bar is on screen.** Emits `\033[?25l` on the
  first frame, `\033[?25h` before any non-progress output, and on `atexit` to
  cover `Ctrl+C` / uncaught exceptions. The blinking block at the end of the
  bar is gone.

### Tests

New `src/tests/unit/console_test.py` with **24 unit tests** covering:

- frame format (leading `\r`, trailing `\033[K`, residue clearing);
- throttling, dedup, and 100% force-paint;
- terminal-width clamping and the "line strictly fits within `cols`" invariant
  (which actually caught a +1 margin bug in the production code during review);
- `_do_print` clears the progress bar before writing;
- lock prevents messages from being interleaved into a frame's bytes;
- cursor hide/show lifecycle and the atexit restore hook;
- `set_log_file` close-on-re-set and atexit registration.

## Test plan

- [x] `PYTHONPATH=src python3 -m unittest discover -s src/tests/unit -p '*_test.py'`
      — full unit suite passes (219 tests, +24 new).
- [x] Manual smoke: ran a multi-action `blade build` in iTerm2; the progress bar
      sits at the bottom, the cursor is hidden during the build, errors scroll
      up cleanly, the cursor returns on completion and on `Ctrl+C`.
- [ ] Reviewer please double-check on Windows (VTP-enabled terminal): the
      `_console_support_cursor_control` path was tested via mocks but not on a
      real Windows console.