### PR TITLE
refactor(console): replace string + index verbosity with IntEnum

### DIFF
--- a/src/blade/console.py
+++ b/src/blade/console.py
@@ -15,6 +15,7 @@ This is the util module which provides command functions.
 
 import atexit
 import datetime
+import enum
 import os
 import shutil
 import sys
@@ -170,20 +171,33 @@ def log(msg):
 ##############################################################################
 
 
-# Output verbosity control, valid values:
-# verbose: verbose mode, show more details
-# normal: normal mode, show infos, warnings and errors
-# quiet: quiet mode, only show warnings and errors
-_VERBOSITIES = ('quiet', 'normal', 'verbose')
+class Verbosity(enum.IntEnum):
+    """Output verbosity, ordered low to high.
 
-_verbosity = 'normal'
+    - QUIET: only show warnings and errors
+    - NORMAL: show infos, warnings and errors
+    - VERBOSE: show more details
+    """
+    QUIET = 0
+    NORMAL = 1
+    VERBOSE = 2
+
+
+_verbosity = Verbosity.NORMAL
+
+
+def _to_verbosity(value):
+    """Coerce a Verbosity or a case-insensitive name to a Verbosity."""
+    if isinstance(value, Verbosity):
+        return value
+    return Verbosity[value.upper()]
 
 
 def set_verbosity(value):
-    """Set the global verbosity."""
+    """Set the global verbosity. Accepts a Verbosity or a string name
+    ('quiet' / 'normal' / 'verbose', case-insensitive)."""
     global _verbosity
-    assert value in _VERBOSITIES
-    _verbosity = value
+    _verbosity = _to_verbosity(value)
 
 
 def get_verbosity():
@@ -191,20 +205,20 @@ def get_verbosity():
 
 
 def verbosity_compare(lhs, rhs):
-    """Return -1, 0, 1 according to their order"""
-    a = _VERBOSITIES.index(lhs)
-    b = _VERBOSITIES.index(rhs)
+    """Return -1, 0, 1 according to their order."""
+    a = _to_verbosity(lhs)
+    b = _to_verbosity(rhs)
     return (a > b) - (a < b)
 
 
 def verbosity_le(expected):
-    """Current verbosity less than or equal to expected"""
-    return verbosity_compare(_verbosity, expected) <= 0
+    """Current verbosity less than or equal to expected."""
+    return _verbosity <= _to_verbosity(expected)
 
 
 def verbosity_ge(expected):
-    """Current verbosity greater than or equal to expected"""
-    return verbosity_compare(_verbosity, expected) >= 0
+    """Current verbosity greater than or equal to expected."""
+    return _verbosity >= _to_verbosity(expected)
 
 
 ##############################################################################

--- a/src/tests/unit/console_test.py
+++ b/src/tests/unit/console_test.py
@@ -371,5 +371,67 @@ class LogFileLifecycleTest(_ConsoleStateMixin, unittest.TestCase):
                 'the atexit callable must close the current log file')
 
 
+class VerbosityTest(unittest.TestCase):
+    """The verbosity ladder used to be a tuple + ``.index()`` lookup; it's now an
+    ``IntEnum``. Pin down: the ordering, that the public API still accepts string
+    names (the CLI parses ``--verbose`` / ``--quiet`` into raw strings), and that
+    the comparison helpers behave under every (string, enum) input pairing.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self._saved_verbosity = console._verbosity
+
+    def tearDown(self):
+        console._verbosity = self._saved_verbosity
+        super().tearDown()
+
+    def test_enum_order_is_quiet_normal_verbose(self):
+        # The semantics of verbosity_le / verbosity_ge depend on this ordering.
+        self.assertLess(console.Verbosity.QUIET, console.Verbosity.NORMAL)
+        self.assertLess(console.Verbosity.NORMAL, console.Verbosity.VERBOSE)
+
+    def test_set_verbosity_accepts_string_name(self):
+        # CLI gives us a raw string; we must accept it.
+        console.set_verbosity('quiet')
+        self.assertEqual(console.get_verbosity(), console.Verbosity.QUIET)
+        console.set_verbosity('NORMAL')         # case-insensitive
+        self.assertEqual(console.get_verbosity(), console.Verbosity.NORMAL)
+
+    def test_set_verbosity_accepts_enum_directly(self):
+        # Internal callers can skip the string round-trip.
+        console.set_verbosity(console.Verbosity.VERBOSE)
+        self.assertEqual(console.get_verbosity(), console.Verbosity.VERBOSE)
+
+    def test_set_verbosity_rejects_unknown_name(self):
+        # Bad input fails loud, not silent. The exact exception type is less
+        # important than the fact that something is raised.
+        with self.assertRaises((KeyError, ValueError)):
+            console.set_verbosity('shouting')
+
+    def test_verbosity_le_and_ge(self):
+        console.set_verbosity('normal')
+        self.assertTrue(console.verbosity_le('normal'))
+        self.assertTrue(console.verbosity_le('verbose'))   # normal <= verbose
+        self.assertFalse(console.verbosity_le('quiet'))    # normal > quiet
+        self.assertTrue(console.verbosity_ge('normal'))
+        self.assertTrue(console.verbosity_ge('quiet'))     # normal >= quiet
+        self.assertFalse(console.verbosity_ge('verbose'))  # normal < verbose
+
+    def test_verbosity_compare_returns_minus_one_zero_one(self):
+        # The signature predates the refactor; preserve it so callers like
+        # ninja_runner.py keep working.
+        self.assertEqual(console.verbosity_compare('quiet', 'verbose'), -1)
+        self.assertEqual(console.verbosity_compare('normal', 'normal'), 0)
+        self.assertEqual(console.verbosity_compare('verbose', 'quiet'), 1)
+
+    def test_compare_accepts_mixed_string_and_enum(self):
+        # The coercion layer must handle either form on either side.
+        self.assertEqual(
+            console.verbosity_compare('quiet', console.Verbosity.VERBOSE), -1)
+        self.assertEqual(
+            console.verbosity_compare(console.Verbosity.VERBOSE, 'quiet'), 1)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to #1218. The verbosity ladder in \`blade.console\` was a tuple of strings plus \`_VERBOSITIES.index()\` lookups for ordering — a classic "stringly-typed enum" pattern. Replace with a proper \`IntEnum\` so comparisons collapse to plain \`<=\` / \`>=\` on integer-backed members, and the \`assert\`-based name validation in \`set_verbosity\` becomes a clear dict-style lookup.

### What changed

\`\`\`python
# Before
_VERBOSITIES = ('quiet', 'normal', 'verbose')
_verbosity = 'normal'

def verbosity_compare(lhs, rhs):
    a = _VERBOSITIES.index(lhs)
    b = _VERBOSITIES.index(rhs)
    return (a > b) - (a < b)

def verbosity_le(expected):
    return verbosity_compare(_verbosity, expected) <= 0
\`\`\`

\`\`\`python
# After
class Verbosity(enum.IntEnum):
    QUIET = 0
    NORMAL = 1
    VERBOSE = 2

_verbosity = Verbosity.NORMAL

def verbosity_le(expected):
    return _verbosity <= _to_verbosity(expected)
\`\`\`

### Backward compatibility

The public API still accepts the same string names. The CLI continues to parse \`--verbose\` / \`--quiet\` into raw strings in [\`command_line.py\`](src/blade/command_line.py#L390-L395), and existing callers in [\`ninja_runner.py\`](src/blade/ninja_runner.py#L27) and [\`test_scheduler.py\`](src/blade/test_scheduler.py#L166) keep passing string literals — they all keep working unchanged.

\`get_verbosity()\` now returns a \`Verbosity\` enum rather than a string, but \`grep\` shows no current caller uses the return value, so this is safe to ship.

### Bonus

Case-insensitive lookup (\`set_verbosity('NORMAL')\` now works) and a clean \`ValueError\`/\`KeyError\` on unknown names — previously \`assert value in _VERBOSITIES\` could be disabled by \`python -O\`.

## Test plan

- [x] \`PYTHONPATH=src python3 -m unittest discover -s src/tests/unit -p '*_test.py'\` — full unit suite passes (226 tests, +7 new).
- [x] Added \`VerbosityTest\` with 7 cases covering enum ordering, string + enum mixing in every comparison helper, case-insensitive name lookup, and explicit failure on unknown names.
- [x] Grepped all callers (\`main.py\`, \`ninja_runner.py\`, \`test_scheduler.py\`, \`workspace.py\`) to confirm none of them depend on the old string-typed return of \`get_verbosity()\` or on \`AssertionError\` specifically.