### PR TITLE
perf(toolchain): cache get_cc_target_arch (52x faster BUILD load)

### DIFF
--- a/src/blade/toolchain.py
+++ b/src/blade/toolchain.py
@@ -186,13 +186,18 @@ class ToolChain:
     @property
     def target_arch(self) -> str:
         """Target CPU architecture, e.g. ``'x86_64'`` or ``'aarch64'``."""
+        cached = getattr(self, '_cached_target_arch', None)
+        if cached is not None:
+            return cached
         import re
         triple = self.get_cc_target_arch()
+        result = ''
         if triple:
             m = re.match(r'^([^-]+)', triple)
             if m:
-                return BuildArchitecture.get_canonical_architecture(m.group(1)) or m.group(1)
-        return ''
+                result = BuildArchitecture.get_canonical_architecture(m.group(1)) or m.group(1)
+        self._cached_target_arch = result
+        return result
 
     def tool(self, key):
         """Return tool path for *key*, or ``None`` if not available.
@@ -240,15 +245,24 @@ class ToolChain:
             return 'gcc'
         return 'unknown'
 
-    @staticmethod
-    def get_cc_target_arch():
-        """Get the cc target architecture (auto-detect from system compiler)."""
+    _cc_target_arch_cache = None
+
+    @classmethod
+    def get_cc_target_arch(cls):
+        """Get the cc target architecture (auto-detect from system compiler).
+
+        The result is cached at the class level — ``gcc -dumpmachine`` is
+        invariant for the lifetime of the process and forking the compiler
+        per call was the dominant cost during BUILD-file loading.
+        """
+        if cls._cc_target_arch_cache is not None:
+            return cls._cc_target_arch_cache
         import shutil
         cc = shutil.which('gcc') or 'gcc'
         returncode, stdout, stderr = run_command([cc, '-dumpmachine'])
-        if returncode == 0:
-            return stdout.strip()
-        return ''
+        result = stdout.strip() if returncode == 0 else ''
+        cls._cc_target_arch_cache = result
+        return result
 
     def get_cc_commands(self):
         return self.cc, self.cxx, self.ld


### PR DESCRIPTION
## Summary

`ToolChain.target_arch` is a DSL property that BUILD files commonly check (e.g. for arch-conditional deps). Each access forked `gcc -dumpmachine`, so in a realistic workspace BUILD-file loading spawned the compiler hundreds of times.

## Measurement

Flare workspace, single target, `--stop-after load --profiling` on macOS arm64:

| | Before | After |
|---|---:|---:|
| Total load time | 13.221s | 0.254s |
| `subprocess.run` calls | 481 | 3 |
| `target_arch` / `get_cc_target_arch` calls | 478 / 478 | 478 / 1 |

That's a **52× speedup** for the load phase.

Top of the cumulative profile before:
```
12.922   0.019 config.get_section
12.908   0.001 config._resolve_value
12.887   0.027 dsl_api.target_arch
12.883   0.027 toolchain.target_arch
12.840   0.027 toolchain.get_cc_target_arch
12.769   0.027 util.run_command
12.754   0.027 subprocess.run
11.696   0.012 select.poll
```

## Change

- `get_cc_target_arch` becomes a `@classmethod` with a class-level cache. `gcc -dumpmachine` is invariant for the process lifetime.
- `target_arch` caches the regex-derived canonical arch per-instance after the first call.

Both still recompute exactly once per process, so no observable behavior change.

## Test plan

- [x] Existing unit tests still pass (`python3 -m unittest src.tests.unit.cc_library_config_test`)
- [x] Verified the 52× speedup on a real Flare workspace
- [ ] Check CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)