### PR TITLE
docs(cc): two more missing-dep resolution cases (dead include + facade re-export); demote system_symbols log to debug

### DIFF
--- a/doc/en/build_rules/cc.md
+++ b/doc/en/build_rules/cc.md
@@ -233,13 +233,46 @@ Blade can detect two kind of missing dependencies:
 
   The header files are included in `srcs` or `hdrs` through the `#include` directive, but the library
   to which they belong is not declared in `deps`, or these header files are not declared in any `hdrs`
-  of `cc_library` at all. Problems and solution:
+  of `cc_library` at all.
 
-  - The library to which the header file belongs is not declared in the `deps` of this target, just follow the instruction to fix it
-  - The header file is a private header file of the library to which it belongs, and direct use is prohibited
-  - The header file should be the public header file of this target, it should be declared in its `hdr`
-  - The header file should be the target's private header file, it should be declared in its `src`
-  - The header file should be a public header file of other libraries, but there is no declaration, just declare it in the corresponding library `hdr`
+  Before mechanically following the "add this dep" suggestion, pause and ask which of the patterns
+  below actually applies — the mechanical fix is right in case (1), but in cases (6) and (7) it
+  either bloats the dep graph for nothing or runs straight into a visibility error on the next build.
+
+  Problems and solutions:
+
+  1. The library to which the header file belongs is not declared in the `deps` of this target, just follow the instruction to fix it.
+  2. The header file is a private header file of the library to which it belongs, and direct use is prohibited. **Exception:** see case (7).
+  3. The header file should be the public header file of this target, it should be declared in its `hdrs`.
+  4. The header file should be the target's private header file, it should be declared in its `srcs`.
+  5. The header file should be a public header file of other libraries, but there is no declaration, just declare it in the corresponding library's `hdrs`.
+  6. **The `#include` is unnecessary; just delete it.** Blade's missing-dep check is content-blind — it only sees that you `#include`-d a header. If your source doesn't actually use any name from that header (the include was copy-pasted, became dead after a refactor, or the type you thought you needed turns out to be re-exported through a header you already include), the right fix is to remove the `#include` line, not to add a dep. A quick check: grep your source for the types / functions defined in the suspicious header; if nothing matches, the include is dead.
+  7. **Legitimate "facade" re-export across a visibility boundary.** When an umbrella target's own public header re-`#include`s a sub-library's header so the umbrella's consumers can use those types, blade will report a Missing-dep notice on the umbrella because the sub-library is locked down via `visibility`. The umbrella IS a legitimate consumer — it's the canonical re-exporter — but case (2)'s "private, direct use prohibited" rule is overly absolute here. Treat the umbrella like a C++ `friend`: add it to the sub-library's `visibility` list (a narrow, named widening) and declare the sub-library in the umbrella's `deps`. Both the visibility entry and the dep declaration should mention the re-export so the relationship is self-documenting.
+
+     ```python
+     # In the inner sub-library:
+     cc_library(
+         name = 'http_filter',
+         hdrs = 'http_filter.h',
+         ...,
+         # `friend`-style allow-list: only the two umbrella facades may
+         # depend on us directly; everyone else must go through them.
+         visibility = ['//flare/rpc:http', '//flare/rpc:rpc'],
+     )
+
+     # In the umbrella whose public `hdrs` re-export the sub-library:
+     cc_library(
+         name = 'rpc',
+         hdrs = ['http_filter.h', ...],  # re-includes inner header
+         deps = [
+             ...,
+             '//flare/rpc/protocol/http:http_filter',  # we re-export it
+         ],
+         visibility = 'PUBLIC',
+     )
+     ```
+
+     If the umbrella consumes the sub-library only for its public surface (not as a re-export through the umbrella's own hdrs), and `unused_deps` flags the dep, that's actually the [Header re-export auto-exemption](#check-unused-dependencies) case in the other direction — declare the sub-library's header in the umbrella's `hdrs` and the unused-deps check stops complaining without any visibility widening.
 
 - `Missing indirect dependency`
 

--- a/doc/zh_CN/build_rules/cc.md
+++ b/doc/zh_CN/build_rules/cc.md
@@ -210,13 +210,44 @@ Blade 能检查到两种缺失情况：
 - `Missing dependency` 直接依赖缺失
 
   在 `srcs` 或者 `hdrs` 里的文件通过 `#include` 指令包含了头文件，但是其所属的库没有在 `deps` 里声明，
-  或者这些头文件根本没有在任何 `cc_library` 的 `hdrs` 里声明。具体原因及解决方法：
+  或者这些头文件根本没有在任何 `cc_library` 的 `hdrs` 里声明。
 
-  - 该头文件所属的库没有在本目标的 `deps` 里声明，按提示修复即可
-  - 该头文件是所属的库的私有头文件，禁止直接使用
-  - 该头文件应当是本目标的公有头文件，在其 `hdrs` 里声明即可
-  - 该头文件应当是本目标的私有头文件，在其 `srcs` 里声明即可
-  - 该头文件应当是其他库的公有头文件，但是没有声明，在相应库的 `hdrs` 里声明即可
+  在机械地按提示「加这个 dep」之前，先停一步，对照下面几条确认你属于哪种情形——只有情形 1 适合直接照办；情形 6 是多余的 include 应该直接删；情形 7 在下次构建会撞到 visibility 错误，需要走 `friend`-式扩 visibility。
+
+  具体原因及解决方法：
+
+  1. 该头文件所属的库没有在本目标的 `deps` 里声明，按提示修复即可。
+  2. 该头文件是所属的库的私有头文件，禁止直接使用。**例外见情形 7。**
+  3. 该头文件应当是本目标的公有头文件，在其 `hdrs` 里声明即可。
+  4. 该头文件应当是本目标的私有头文件，在其 `srcs` 里声明即可。
+  5. 该头文件应当是其他库的公有头文件，但是没有声明，在相应库的 `hdrs` 里声明即可。
+  6. **这个 `#include` 本身是多余的，直接删掉就行。** Blade 的 missing-dep 检查不看你的代码内容，只看你 `#include` 了什么。如果你的源文件并没有真的用到那个头里定义的任何名字（include 是早年复制粘贴留下的、重构后变成 dead code、或者你以为需要的类型其实通过你已经 include 的另一个头传递性可达），正确解法是**删掉这一行 `#include`**，而不是加一个 dep。快速判断：在源文件里 grep 一下可疑头里定义的类型/函数名；如果一个都没匹配到，include 就是死的。
+  7. **跨越 visibility 边界的合法 "facade" 再导出场景。** 当一个 umbrella 目标的公共头通过 `#include` 把内层私库的头导出，使得 umbrella 的消费者能用到那些类型时，blade 会对 umbrella 报 missing-dep——因为内层私库的 `visibility` 把 umbrella 锁在外面。但 umbrella 本来就是合法消费者——它是这些类型的规范再导出点——情形 (2) 那条「私头禁止直接用」太绝对，没给这种合法 facade 留口子。把 umbrella 当成 C++ 的 `friend`：在内层私库的 `visibility` 列表里把它加进去（一个窄而具名的开放），然后在 umbrella 的 `deps` 里声明该私库。visibility 行和 deps 行都附上注释说明再导出关系，让意图自文档。
+
+     ```python
+     # 内层私库：
+     cc_library(
+         name = 'http_filter',
+         hdrs = 'http_filter.h',
+         ...,
+         # `friend` 式白名单：只允许下面两个 umbrella facade 直接依赖；
+         # 其它消费者必须走 facade。
+         visibility = ['//flare/rpc:http', '//flare/rpc:rpc'],
+     )
+
+     # 在公共头里再导出该私库的 umbrella：
+     cc_library(
+         name = 'rpc',
+         hdrs = ['http_filter.h', ...],  # 透传 include 内层头
+         deps = [
+             ...,
+             '//flare/rpc/protocol/http:http_filter',  # 我们再导出
+         ],
+         visibility = 'PUBLIC',
+     )
+     ```
+
+     如果 umbrella 只是「消费者」（用了内层库的公共接口，但**不**通过自己的 hdrs 再导出），并且 `unused_deps` 报了这个 dep，那其实是反方向的 [Header re-export 自动豁免](#检查未使用的依赖) 场景——把内层私库的头列入 umbrella 自己的 `hdrs` 即可，无需放开 visibility。
 
 - `Missing indirect dependency` 间接依赖缺失
 

--- a/src/blade/build_manager.py
+++ b/src/blade/build_manager.py
@@ -61,8 +61,8 @@ def _log_system_symbol_resolution(alias, cache):
                     n += 1
     except OSError:
         pass
-    console.info('system_symbols: %s -> %s (%d symbols from %s)'
-                 % (alias, cache, n, src))
+    console.debug('system_symbols: %s -> %s (%d symbols from %s)'
+                  % (alias, cache, n, src))
 
 
 # Start of fingerprint line in each per-target ninja file


### PR DESCRIPTION
## Summary

Adds two case studies to the **Fix missing dependencies errors caused by \`hdrs\`** section in \`doc/{en,zh_CN}/build_rules/cc.md\`. The existing 5-bullet list assumed the \`#include\` itself was legitimate; following its advice for either of the two new patterns lands the user in trouble. Both came up while cleaning up the dep graph of Tencent/flare.

| New case | What blade sees | Existing 5-bullet advice | The actual right fix |
|---|---|---|---|
| **6. The \`#include\` is unnecessary** | \"You included \`X.h\` but didn't declare \`:x\`\" | (1) add \`:x\` to deps | Delete the \`#include\` line — your source doesn't use any name from \`X.h\`; the include was copy-paste / refactor leftover. Adding the dep just bloats the graph. |
| **7. Legitimate facade re-export across a visibility boundary** | \"You included \`internal/foo.h\` from \`:foo\` (visibility-restricted)\" | (2) private header, direct use prohibited | The umbrella IS the canonical re-exporter and is a legitimate consumer. Widen the sub-library's \`visibility\` narrowly to allow the umbrella (C++ \`friend\`-style), declare the dep on the umbrella's side, annotate both ends. |

Both en/ and zh_CN/ get the same 7-item list with the worked example for case 7 mirroring the [flare fix](https://github.com/Tencent/flare/pull/159).

Also includes a tag-along: demote the \"system_symbols: <alias> -> <cache>\" resolution log from \`info\` to \`debug\`. It's identical across rebuilds and only useful when diagnosing alias resolution; 5 lines per build on macOS clutters the default console.

## Test plan

- [x] Markdown lints clean
- [x] Cross-links resolve (case 7 references the Header re-export auto-exemption section)
- [x] zh_CN mirrors en

🤖 Generated with [Claude Code](https://claude.com/claude-code)