### PR TITLE
fix(cc): nm classification -- treat uppercase V/W as defined, not ambient

### DIFF
--- a/src/blade/builtin_tools.py
+++ b/src/blade/builtin_tools.py
@@ -202,10 +202,13 @@ def _nm_extract_externals(archive):
 
     Runs `nm -P -g <archive>` once. -P selects POSIX format
     (`name type [value [size]]`), -g restricts to external symbols. Type
-    letter encodes section: uppercase = external, U = undefined, w/v =
-    weak/vague undefined (treated as ambient). Intra-archive resolved
-    symbols (defined by some member, used by another) are caller's
-    responsibility to subtract.
+    letter encodes section: uppercase = defined external, U = undefined,
+    w/v = weak undefined (treated as ambient -- linker allowed to leave
+    them unresolved). The uppercase weak-defined variants (V/W) are real
+    definitions emitted with vague linkage -- typically template static
+    data (e.g. fmt's ``basic_data<void>::left_padding_shifts``) -- and
+    must be counted as defined, or downstream cc_libraries that pull
+    them in transitively will fail the undefined-symbol check.
     """
     try:
         out = subprocess.check_output(['nm', '-P', '-g', archive], stderr=subprocess.STDOUT)
@@ -234,9 +237,11 @@ def _nm_extract_externals(archive):
             continue
         if ty == 'U':
             undefined.add(name)
-        elif ty in ('w', 'v', 'V'):
-            # Weak / vague undefined — by ld semantics these may remain
-            # unresolved at link time without error. Treat as ambient.
+        elif ty in ('w', 'v'):
+            # Lowercase = weak UNDEFINED -- linker is allowed to leave
+            # them unresolved (resolved to 0 at runtime). Treat as ambient.
+            # Note: uppercase 'V' / 'W' are weak DEFINED and fall through
+            # to the next branch.
             continue
         elif ty.isupper():
             # Any other uppercase letter: defined external symbol.


### PR DESCRIPTION
## Summary

`_nm_extract_externals` was skipping uppercase `V` (weak object) along with lowercase `v`/`w` (weak undefined). Per GNU nm semantics:

| nm type | meaning |
|---|---|
| `V` / `W` (uppercase) | weak **defined** symbol |
| `v` / `w` (lowercase) | weak **undefined** reference |

Treating uppercase `V` as ambient meant template-instantiated static data emitted by libfmt (e.g. `fmt::v7::detail::basic_data<void>::left_padding_shifts`) was missing from libfmt.a's defined set. Any downstream cc_library that transitively pulled the symbol in (e.g. via `flare/base/internal/logging.h` includes) tripped `cc_check_undefined` on Linux even when the actual link succeeded.

## How this surfaced

flare's blade Ubuntu CI:

```
Blade(error): cc_check_undefined: flare/base/internal:logging has 1 undefined symbol(s) not covered by declared deps:
Blade(error):   _ZN3fmt2v76detail10basic_dataIvE19left_padding_shiftsE
Blade(error): cc_check_undefined: flare/rpc/binlog:packet_desc has 1 undefined symbol(s) not covered by declared deps:
Blade(error):   _ZN3fmt2v76detail10basic_dataIvE19left_padding_shiftsE
Blade(error): cc_check_undefined: flare/rpc/load_balancer:consistent_hash has 1 undefined symbol(s) not covered by declared deps:
Blade(error):   _ZN3fmt2v76detail10basic_dataIvE19left_padding_shiftsE
```

`logging` already declared `//thirdparty/fmt:fmt` as a dep — the symbol IS provided by libfmt. The bug was in blade's classification.

`./blade build --generate-dynamic flare/base/internal:logging` succeeds (link works), confirming this was a false positive from the check tool.

## Why macOS doesn't reproduce

BSD nm reports the same template static symbol as `S` (uppercase = section object in small data) instead of `V`. `S` correctly fell through to `ty.isupper()` and was added to defined. The bug is GNU-nm-specific.

## Test plan

- [x] 49/49 unit tests still pass locally
- [ ] flare master CI on Linux re-runs cleanly after bumping blade.zip

🤖 Generated with [Claude Code](https://claude.com/claude-code)