### PR TITLE
fix(cc): nm classification -- treat lowercase 'u' as defined (GNU unique global)

### DIFF
--- a/src/blade/builtin_tools.py
+++ b/src/blade/builtin_tools.py
@@ -238,15 +238,23 @@ def _nm_extract_externals(archive):
         if ty == 'U':
             undefined.add(name)
         elif ty in ('w', 'v'):
-            # Lowercase = weak UNDEFINED -- linker is allowed to leave
-            # them unresolved (resolved to 0 at runtime). Treat as ambient.
-            # Note: uppercase 'V' / 'W' are weak DEFINED and fall through
-            # to the next branch.
+            # Lowercase 'w'/'v' = weak UNDEFINED -- linker is allowed to
+            # leave them unresolved (resolved to 0 at runtime). Treat as
+            # ambient. Note: uppercase 'V' / 'W' are weak DEFINED and fall
+            # through to the isupper() / 'u' branches below.
             continue
+        elif ty == 'u':
+            # GNU extension: lowercase 'u' = unique global symbol. Despite
+            # being lowercase (which usually means local in nm), 'u' is the
+            # asymmetric counterpart of 'U' (undefined) -- it is GLOBAL and
+            # DEFINED, used by C++ to guarantee one instance of template
+            # static data across TUs. fmt's basic_data<void> members
+            # (left_padding_shifts etc.) are emitted as 'u' on gcc/Linux.
+            defined.add(name)
         elif ty.isupper():
             # Any other uppercase letter: defined external symbol.
             defined.add(name)
-        # lowercase letters are local, ignore.
+        # Remaining lowercase letters are local, ignore.
     return undefined, defined
 
 

--- a/src/tests/unit/cc_check_undefined_test.py
+++ b/src/tests/unit/cc_check_undefined_test.py
@@ -145,16 +145,23 @@ class NmExtractTest(unittest.TestCase):
     """Test the per-archive nm output parser used at check time."""
 
     def test_parse_undefined_and_defined(self):
-        fake_nm_output = (b'__ZTV1A T 100 0\n'
-                          b'foo T 200 0\n'
-                          b'bar U 0 0\n'
-                          b'_local t 300 0\n'   # lowercase = local, ignore
-                          b'weak_sym w 0 0\n'    # weak undefined, ignore
-                          b'baz D 400 0\n')
+        fake_nm_output = (
+            b'__ZTV1A T 100 0\n'
+            b'foo T 200 0\n'
+            b'bar U 0 0\n'
+            b'_local t 300 0\n'   # lowercase t = local, ignore
+            b'weak_undef_sym w 0 0\n'   # lowercase w = weak undefined, ignore
+            b'weak_undef_obj v 0 0\n'   # lowercase v = weak undefined, ignore
+            b'weak_def_sym W 500 0\n'   # uppercase W = weak defined, KEEP
+            b'weak_def_obj V 600 0\n'   # uppercase V = weak defined, KEEP
+            b'unique_global u 700 5\n'  # lowercase u = GNU unique global, KEEP
+            b'baz D 400 0\n')
         with mock.patch.object(subprocess, 'check_output', return_value=fake_nm_output):
             undef, defd = builtin_tools._nm_extract_externals('/fake/lib.a')
         self.assertEqual(undef, {'bar'})
-        self.assertEqual(defd, {'__ZTV1A', 'foo', 'baz'})
+        self.assertEqual(defd, {'__ZTV1A', 'foo', 'baz',
+                                'weak_def_sym', 'weak_def_obj',
+                                'unique_global'})
 
     def test_archive_header_lines_skipped(self):
         fake = (b'lib.a[foo.o]:\n'


### PR DESCRIPTION
## Summary

Follow-up to #1239 (V/W fix). GNU nm uses an asymmetric convention for 'U' / 'u':

| nm type | meaning |
|---|---|
| `U` (uppercase) | undefined |
| `u` (lowercase) | **GNU extension — unique global symbol** (defined) |

The lowercase `u` is **defined and global** (used by C++ to guarantee one instance of template static data across TUs), even though every other lowercase letter in nm output means "local, ignore". `_nm_extract_externals`'s default `lowercase = local` branch silently dropped `u` symbols on the floor.

## How this surfaced

Verified on Ubuntu 24.04 with fmt 7.1.3 built via the same cmake invocation flare uses:

```
$ nm -P -g libfmt.a | grep padding_shifts
_ZN3fmt2v76detail10basic_dataIvE19left_padding_shiftsE  u  0  5
_ZN3fmt2v76detail10basic_dataIvE20right_padding_shiftsE u  0  5
```

40 symbols in libfmt.a have type `u` (mostly `basic_data<void>::*`). They all silently vanished from `libfmt.a.syms`'s `#D` set. Any downstream `cc_library` transitively pulling fmt failed `cc_check_undefined` with:

```
Blade(error): cc_check_undefined: flare/base/internal:logging has 1 undefined symbol(s):
Blade(error):   _ZN3fmt2v76detail10basic_dataIvE19left_padding_shiftsE
```

`./blade build --generate-dynamic flare/base/internal:logging` succeeds (link works fine on macOS because BSD nm reports the same symbol as 'S', and on Linux because ld resolves the 'u' symbol normally). The check tool was the only consumer that mishandled it.

## Why #1239 didn't catch it

#1239 fixed `V` (uppercase weak object) being skipped along with `v`/`w`. The new asymmetry it introduced (V/v split) is the same kind as U/u, but `u` was already broken in the original code -- not introduced by #1239, just exposed by it once V got out of the way.

## Test plan

- [x] Extended `NmExtractTest.test_parse_undefined_and_defined` with explicit cases for V / W / v / w / u
- [x] 49/49 local unit tests pass
- [ ] flare master CI on Linux green after blade.zip bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)