### PR TITLE
feat(dsl): add blade.getenv() for opt-in env-driven config (config phase only)

### DIFF
--- a/doc/en/develop/dsl_api.md
+++ b/doc/en/develop/dsl_api.md
@@ -64,12 +64,23 @@ BUILD load. It exposes:
   - `blade.cc_toolchain` — a read-only proxy over the active toolchain
     (`obj_suffix`, `lib_prefix`, `tool('cxx')`, ...). Lets a BUILD file
     parameterize names by toolchain without importing internal classes.
+- **Config-phase-only handles**:
+  - `blade.getenv(name, default=None)` — read an environment variable
+    from `BLADE_ROOT`. The only sanctioned env-access channel; calling it
+    from a BUILD file raises a `console.fatal` pointing at the resolved
+    toolchain (`blade.cc_toolchain.tool('cc')`) or `blade.config` as the
+    BUILD-phase equivalent. Keeping env reads at the config layer puts all
+    env dependencies in one auditable file and lets BUILD files stay
+    hermetic.
 
 A subset of these attributes are marked `_BUILD_ONLY_ATTRS`: accessing
 them from inside `BLADE_ROOT` (config phase) raises a clear error pointing
 out that "the toolchain doesn't exist yet — pass a lambda if you need a
 deferred value." This is one of the friction-reducing diagnostics that
-saves a lot of confused bug reports.
+saves a lot of confused bug reports. `getenv` enforces the symmetric rule
+inside the method body (`if not self._config_phase: console.fatal(...)`),
+since the BUILD-only attribute path is `__getattr__`-based and methods on
+`_BladeModule` don't go through it.
 
 ## 3. Sandbox
 

--- a/doc/en/dsl.md
+++ b/doc/en/dsl.md
@@ -47,6 +47,12 @@ These attributes are only available during BUILD file loading. Accessing them du
 - `current_source_dir` property: The directory where the current BUILD file is located (relative to the root directory of the workspace)
 - `current_target_dir` property: The output directory where the current BUILD file is located corresponds to (relative to the root directory of the workspace)
 
+### Config-phase-only Attributes
+
+These attributes are only callable during `BLADE_ROOT` config parsing. Calling them from a BUILD file will abort with an error:
+
+- `getenv(name, default=None)` function: Read an environment variable. See [`blade.getenv`](#bladegetenv) below.
+
 ---
 
 ### `blade.config` Submodule
@@ -87,6 +93,40 @@ Get some information about the current [workspace](workspace.md), including:
 
 - `root_dir` property: Returns the directory of the current root workspace
 - `build_dir` property: Returns the name of the build subdirectory under the workspace, such as `build64_release`
+
+### `blade.getenv`
+
+> **Phase:** `BLADE_ROOT` config only. Calling from a BUILD file aborts with an error.
+
+Read an environment variable from the configuration phase. This is the sanctioned channel for env-driven configuration -- blade does not implicitly read environment variables anywhere else.
+
+```python
+def getenv(name: str, default: str | None = None) -> str | None
+```
+
+**Typical use:** select a toolchain via a CI matrix without committing the matrix shape into BLADE_ROOT.
+
+```python
+# BLADE_ROOT
+cc_toolchain_config(
+    name = 'default',
+    kind = 'gcc',
+    cc = blade.getenv('CC', 'gcc'),
+    cxx = blade.getenv('CXX', 'g++'),
+)
+```
+
+Then a CI workflow's `CC=gcc-10 CXX=g++-10 ./blade build ...` selects the right toolchain. Any string-valued config field can be sourced this way.
+
+**Why config-only?** Restricting env access to the global config layer keeps all env dependencies in one auditable file (BLADE_ROOT) and lets BUILD files stay hermetic -- the same source tree produces the same artifacts at the same target regardless of env. If a BUILD-phase rule needs the env-derived value (e.g. `foreign_cc_library` passing CC/CXX to a Makefile), read it from the resolved toolchain or config instead:
+
+```python
+# BUILD or *.bld file
+cc = blade.cc_toolchain.tool('cc')   # already folded from env at config time
+cxx = blade.cc_toolchain.tool('cxx')
+```
+
+**Limitation:** `blade.getenv()` returns the env value at the moment `BLADE_ROOT` loads. Changing the env between two runs of the same workspace does not by itself invalidate per-target build caches -- if you rely on env-driven config for incremental correctness, list the variable names in `global_config.test_related_envs` or otherwise include them in your configuration fingerprint.
 
 ### `blade.cc_toolchain` Object
 

--- a/doc/zh_CN/develop/dsl_api.md
+++ b/doc/zh_CN/develop/dsl_api.md
@@ -56,10 +56,19 @@ BUILD 文件是一段在严格受控命名空间里跑的 Python 脚本。命名
   - `blade.cc_toolchain`：活动工具链的只读代理（`obj_suffix`、
     `lib_prefix`、`tool('cxx')`、…）。让 BUILD 能按工具链参数化文件名，
     不必导入内部类。
+- **仅配置期可用的句柄**：
+  - `blade.getenv(name, default=None)` —— 在 `BLADE_ROOT` 中读取环境变量。
+    全 blade 唯一被授权的 env 访问入口；BUILD 文件调用会以 `console.fatal`
+    终止并指向 BUILD 期等价物（`blade.cc_toolchain.tool('cc')` 或
+    `blade.config`）。把 env 读取收敛到配置层，所有 env 依赖集中在一个
+    可审计文件里，BUILD 文件保持 hermetic。
 
 其中一部分属性被标为 `_BUILD_ONLY_ATTRS`：在 `BLADE_ROOT`（配置阶段）里
 读它们会触发清晰报错，提示"此时工具链还不存在，若想延后求值请传一个
-lambda"。这是减少用户困惑的诊断之一。
+lambda"。这是减少用户困惑的诊断之一。对称地，`getenv` 在方法体内自己做
+`if not self._config_phase: console.fatal(...)`——`_BUILD_ONLY_ATTRS`
+那套基于 `__getattr__`，对 `_BladeModule` 上的方法不起作用，所以放在方法
+里手判。
 
 ## 3. 沙箱
 

--- a/doc/zh_CN/dsl.md
+++ b/doc/zh_CN/dsl.md
@@ -48,6 +48,12 @@
 - `current_source_dir` 属性：当前 BUILD 文件所在的目录（相对于 workspace 根目录）
 - `current_target_dir` 属性：当前 BUILD 文件对应的构建输出目录（相对于 workspace 根目录）
 
+### 仅配置阶段可用的属性
+
+以下属性仅在 `BLADE_ROOT` 配置阶段可调用，在 BUILD 文件中调用会报错：
+
+- `getenv(name, default=None)` 函数：读取环境变量。详见下文 [`blade.getenv`](#bladegetenv)。
+
 ---
 
 ### `blade.config` 子模块
@@ -88,6 +94,40 @@
 
 - `root_dir` 属性：返回当前根工作空间的目录
 - `build_dir` 属性：返回工作空间下的 build 子目录名，比如 `build64_release`
+
+### `blade.getenv`
+
+> **可用阶段：** 仅 `BLADE_ROOT` 配置阶段。在 BUILD 文件中调用会报错并终止构建。
+
+在配置阶段读取一个环境变量。这是 blade 中**唯一**允许显式读环境变量的入口——blade 在其它任何位置都不会隐式读取 `CC`、`CXX` 等环境变量。
+
+```python
+def getenv(name: str, default: str | None = None) -> str | None
+```
+
+**典型用法**：通过 CI matrix 选择 toolchain，不需要把 matrix 的形状写进 BLADE_ROOT。
+
+```python
+# BLADE_ROOT
+cc_toolchain_config(
+    name = 'default',
+    kind = 'gcc',
+    cc = blade.getenv('CC', 'gcc'),
+    cxx = blade.getenv('CXX', 'g++'),
+)
+```
+
+之后 CI 工作流的 `CC=gcc-10 CXX=g++-10 ./blade build ...` 即可选中对应版本。任何接受字符串的配置字段都可以这样写。
+
+**为什么只在配置阶段？** 把 env 访问收敛到全局配置层，所有 env 依赖都集中在一个可审计的文件（BLADE_ROOT）里，BUILD 文件保持 hermetic——相同源码在相同 target 下产物不随 env 变化。如果 BUILD 阶段需要 env 衍生的值（比如 `foreign_cc_library` 要把 CC/CXX 传给 Makefile），从已解析的 toolchain 或 config 读：
+
+```python
+# BUILD 或 *.bld 文件
+cc = blade.cc_toolchain.tool('cc')   # 配置阶段已经吸收了 env
+cxx = blade.cc_toolchain.tool('cxx')
+```
+
+**限制：** `blade.getenv()` 返回的是加载 `BLADE_ROOT` 那一刻的 env 值。两次 run 之间改变 env 本身不会触发增量缓存失效——若依赖 env 驱动的配置做增量正确性判定，需要把相关变量名加到 `global_config.test_related_envs`，或以其它方式纳入配置指纹。
 
 ### `blade.cc_toolchain` 对象
 

--- a/src/blade/dsl_api.py
+++ b/src/blade/dsl_api.py
@@ -209,6 +209,51 @@ class _BladeModule(types.ModuleType):
         """Return ``True`` if the build type is ``'debug'``."""
         return self.build_type == 'debug'
 
+    def getenv(self, name: str, default: str | None = None) -> str | None:
+        """Read an environment variable. **BLADE_ROOT (config phase) only.**
+
+        Blade does not implicitly read environment variables; this is the
+        sanctioned channel for projects that want env-driven configuration.
+        Typical use is selecting a toolchain via the CI matrix without
+        committing the matrix shape into BLADE_ROOT::
+
+            cc_toolchain_config(
+                name = 'default',
+                kind = 'gcc',
+                cc = blade.getenv('CC', 'gcc'),
+                cxx = blade.getenv('CXX', 'g++'),
+            )
+
+        Any field that accepts a string can be sourced this way -- not just
+        the toolchain. Reading env vars stays explicit and traceable: the
+        BLADE_ROOT itself shows exactly which env vars influence the build.
+
+        BUILD files cannot call this method. Env access is restricted to the
+        config phase so that all env dependencies live in one auditable file
+        (BLADE_ROOT) and BUILD files stay hermetic. If BUILD-phase code needs
+        the env-derived value -- e.g. ``foreign_cc_library`` passing CC/CXX to
+        a Makefile -- read it from the resolved toolchain instead:
+
+            cc = blade.cc_toolchain.tool('cc')   # already env-folded at config
+
+        Note: this returns the env value at the moment BLADE_ROOT is loaded.
+        Changing the env between runs does not by itself invalidate cached
+        per-target builds; if you rely on env-driven config for incremental
+        correctness, list the relevant variable names in
+        ``global_config.test_related_envs`` or include the value in your
+        configuration fingerprint another way.
+        """
+        if not self._config_phase:
+            console.fatal(
+                'blade.getenv() is only available during BLADE_ROOT config '
+                'phase. To use env-derived values in BUILD files, fold them '
+                'into config at the BLADE_ROOT level (e.g. via '
+                'cc_toolchain_config(cc=blade.getenv(...))) and read the '
+                'resolved value from blade.cc_toolchain or blade.config in '
+                'BUILD.'
+            )
+        return os.environ.get(name, default)
+
 
 def _safe_blade_module(config_phase: bool = True):
     """Make the safe blade module."""

--- a/src/test/blade_main_test.py
+++ b/src/test/blade_main_test.py
@@ -18,6 +18,7 @@ from cc_binary_test import TestCcBinary
 from cc_library_test import TestCcLibrary
 from cc_plugin_test import TestCcPlugin
 from cc_test_test import TestCcTest
+from dsl_api_test import GetenvTest
 from dump_test import TestDump
 from extension_test import TestExtension
 from gen_rule_test import TestGenRule
@@ -44,6 +45,7 @@ def _main():
         unittest.defaultTestLoader.loadTestsFromTestCase(TestCcBinary),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestCcPlugin),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestCcTest),
+        unittest.defaultTestLoader.loadTestsFromTestCase(GetenvTest),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestDump),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestExtension),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestGenRule),

--- a/src/test/dsl_api_test.py
+++ b/src/test/dsl_api_test.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Author: chen3feng <chen3feng@gmail.com>
+
+"""Tests for the safe blade DSL API exposed to BLADE_ROOT / BUILD files."""
+
+import os
+import unittest
+
+import blade_test  # noqa: F401  -- registers run() and adds blade to sys.path
+from blade import console
+from blade import dsl_api
+
+
+class GetenvTest(unittest.TestCase):
+    """blade.getenv: env-var lookup for env-driven config (config phase only)."""
+
+    def setUp(self):
+        self.blade = dsl_api.new_blade_module_for_config()
+        self._saved_env = os.environ.copy()
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._saved_env)
+
+    def testReturnsValueWhenSet(self):
+        os.environ['BLADE_TEST_GETENV'] = 'gcc-10'
+        self.assertEqual(self.blade.getenv('BLADE_TEST_GETENV'), 'gcc-10')
+
+    def testReturnsDefaultWhenUnset(self):
+        os.environ.pop('BLADE_TEST_GETENV', None)
+        self.assertEqual(self.blade.getenv('BLADE_TEST_GETENV', 'gcc'), 'gcc')
+
+    def testReturnsNoneWhenUnsetWithoutDefault(self):
+        os.environ.pop('BLADE_TEST_GETENV', None)
+        self.assertIsNone(self.blade.getenv('BLADE_TEST_GETENV'))
+
+    def testEmptyStringIsAValue(self):
+        # An explicit empty value should win over the default --
+        # matches os.environ.get semantics, which the user already knows.
+        os.environ['BLADE_TEST_GETENV'] = ''
+        self.assertEqual(self.blade.getenv('BLADE_TEST_GETENV', 'fallback'), '')
+
+    def testFailsInBuildPhase(self):
+        # _safe_blade_module(config_phase=False) gives the BUILD-phase shape
+        # without requiring full workspace init.
+        build_blade = dsl_api._safe_blade_module(config_phase=False)
+        with self.assertRaises(SystemExit):
+            build_blade.getenv('PATH')
+
+
+if __name__ == '__main__':
+    blade_test.run(GetenvTest)


### PR DESCRIPTION
## Summary

Closes #1243.

Adds `blade.getenv(name, default=None)` to the DSL — the **only** sanctioned channel for env-driven configuration. Restricted to the **config phase** (`BLADE_ROOT` only); calling it from a BUILD file aborts with a fatal that points at the BUILD-phase equivalent (`blade.cc_toolchain.tool('cc')` / `blade.config`).

## Usage

```python
# BLADE_ROOT
cc_toolchain_config(
    name = 'default',
    kind = 'gcc',
    cc = blade.getenv('CC', 'gcc'),
    cxx = blade.getenv('CXX', 'g++'),
)
```

Then a CI matrix's `CC=gcc-10 CXX=g++-10 ./blade build ...` actually selects the toolchain. Any string-valued config field can be sourced the same way.

## Why config-phase only

The phase restriction is the substantive design choice — discussed in #1243 and chosen after looking at Bazel's model:

- **One auditable file for env deps.** Every env var the build reacts to lives in BLADE_ROOT. `grep getenv` over one file answers "what env vars influence this build?".
- **BUILD files stay hermetic.** Same source tree → same artifacts regardless of host env. Per-package env switches are usually a code smell.
- **Aligns with Bazel.** Bazel forbids env in BUILD; allows it only in `repository_ctx` (the analog of our config phase), and even there requires explicit `environ=[...]` declaration. `blade.getenv()` plays the same role as `repository_ctx.os.environ` — a single tightly-scoped channel.
- **BUILD-phase code that needs the value reads the resolved toolchain.** For example, `foreign_cc_library` passing CC/CXX to a Makefile gets the value from `blade.cc_toolchain.tool('cc')` — blade has already folded the env into the toolchain at config time.

## Files

- `src/blade/dsl_api.py` — adds `_BladeModule.getenv()` with `_config_phase` check
- `src/test/dsl_api_test.py` — 5 test cases (set / unset / default / empty-string is a value / BUILD-phase abort)
- `src/test/blade_main_test.py` — wires the new test into the main suite
- `doc/en/dsl.md` + `doc/zh_CN/dsl.md` — user-facing docs: new "Config-phase-only Attributes" subsection and a detailed `blade.getenv` section
- `doc/en/develop/dsl_api.md` — implementor notes mention the symmetric config-phase guard and why it's inside the method (methods on `_BladeModule` don't go through `__getattr__`)

## Known limitation (documented)

`blade.getenv()` returns the env value at `BLADE_ROOT` load. Changing env between two runs of the *same* workspace does not by itself invalidate per-target build caches. CI matrix use (one toolchain pick per fresh workspace) is unaffected. Listed in the docstring + dsl.md, with a pointer at `global_config.test_related_envs` for incremental-correctness needs. A follow-up can record consulted env vars and fold them into the configuration fingerprint automatically.

## Test plan

- [x] `python3 dsl_api_test.py` passes locally (5/5)
- [x] Wired into `blade_main_test.py`
- [x] Calling `blade.getenv()` from a BUILD context produces the diagnostic shown above and aborts

🤖 Generated with [Claude Code](https://claude.com/claude-code)