### PR TITLE
feat(test): add --test-timeout-multiplier CLI flag

### DIFF
--- a/doc/en/command_line.md
+++ b/doc/en/command_line.md
@@ -99,6 +99,7 @@ Different subcommands support different options. Run `blade <subcommand> --help`
 - `-k`, `--keep-going` - Continue execution after non-fatal errors
 - `-j N`, `--jobs=N` - Parallel build jobs (Blade defaults to automatic parallelization)
 - `-t N`, `--test-jobs=N` - Parallel test execution for multi-CPU systems
+- `--test-timeout-multiplier=FACTOR` - Scale every per-test wall timeout by `FACTOR` for the current run (default `1.0`). Use on slower-than-baseline machines (e.g. shared CI runners) where the `global_config.test_timeout` configured for normal hardware is too tight. Affects only the current run; not stored in config. Example: `blade test --test-timeout-multiplier=3 ...`
 - `--verbose` - Display complete command output for each executed command
 - `-h`, `--help` - Display help information
 - `--color=yes/no/auto` - Enable/disable colored output

--- a/doc/zh_CN/command_line.md
+++ b/doc/zh_CN/command_line.md
@@ -99,6 +99,7 @@ $ blade dump --all-tags ...
 - `-k`、`--keep-going` —— 遇到非致命错误时继续执行
 - `-j N`、`--jobs=N` —— 并行构建任务数（默认自动并行）
 - `-t N`、`--test-jobs=N` —— 并行测试任务数，适用于多 CPU 机器
+- `--test-timeout-multiplier=FACTOR` —— 将每个测试的 wall timeout 按 `FACTOR` 放缩（默认 `1.0`）。用于在比基线机器慢的机器（如共享 CI runner）上跑测试，避免按"正常硬件"配置的 `global_config.test_timeout` 太紧导致 false-timeout。仅影响当前 run，不写入配置文件。例：`blade test --test-timeout-multiplier=3 ...`
 - `--verbose` —— 显示每条命令的完整命令行
 - `-h`、`--help` —— 显示帮助信息
 - `--color=yes/no/auto` —— 启用或禁用彩色输出

--- a/src/blade/command_line.py
+++ b/src/blade/command_line.py
@@ -356,6 +356,14 @@ class CommandLineParser:
             help='Show tests which are slower than specified seconds')
 
         parser.add_argument(
+            '--test-timeout-multiplier', type=float, metavar='FACTOR', default=1.0,
+            dest='test_timeout_multiplier',
+            help=('Multiply every per-test wall timeout by FACTOR. Default 1.0. '
+                  'Use on slower-than-baseline machines (e.g. shared CI runners) '
+                  'where the per-test timeout configured for normal hardware is '
+                  'too tight. Affects only the current run; not stored in config.'))
+
+        parser.add_argument(
             '--no-build', action='store_true',
             dest='no_build', default=False,
             help='Run tests directly without build')

--- a/src/blade/test_runner.py
+++ b/src/blade/test_runner.py
@@ -461,7 +461,11 @@ class TestRunner(binary_runner.BinaryRunner):
 
         console.notice('%d tests to run' % len(tests_run_list))
         console.flush()
-        scheduler = TestScheduler(tests_run_list, self.__test_jobs_num)
+        scheduler = TestScheduler(
+            tests_run_list,
+            self.__test_jobs_num,
+            test_timeout_multiplier=self.options.test_timeout_multiplier,
+        )
         try:
             scheduler.schedule_jobs()
         except KeyboardInterrupt:

--- a/src/blade/test_scheduler.py
+++ b/src/blade/test_scheduler.py
@@ -131,10 +131,18 @@ class WorkerThread(threading.Thread):
 class TestScheduler:
     """Schedule specified tests to be ran in multiple test threads"""
 
-    def __init__(self, tests_list, num_jobs):
-        """init method."""
+    def __init__(self, tests_list, num_jobs, test_timeout_multiplier=1.0):
+        """init method.
+
+        ``test_timeout_multiplier`` scales every per-test wall timeout for
+        the current run. Drives the ``--test-timeout-multiplier`` CLI flag
+        for adapting to slow CI machines without committing the slowdown
+        into config. A multiplier of 0 or non-positive ``test_timeout``
+        (the documented "unlimited" sentinel) stays unlimited.
+        """
         self.tests_list = tests_list
         self.num_jobs = num_jobs
+        self.test_timeout_multiplier = test_timeout_multiplier
 
         self.job_queue = queue.Queue(0)
         self.exclusive_job_queue = queue.Queue(0)
@@ -150,6 +158,17 @@ class TestScheduler:
     def _get_workers_num(self):
         """get the number of thread workers."""
         return min(self.job_queue.qsize(), self.num_jobs)
+
+    def _effective_timeout(self, base_timeout):
+        """Apply the run-time multiplier to a per-target timeout.
+
+        ``base_timeout`` of 0 or any non-positive value means *unlimited*
+        (the documented sentinel of ``global_config.test_timeout``) and
+        stays unlimited regardless of the multiplier.
+        """
+        if not base_timeout or base_timeout <= 0:
+            return base_timeout
+        return base_timeout * self.test_timeout_multiplier
 
     def _get_result(self, returncode):
         """translate result from returncode."""
@@ -182,7 +201,7 @@ class TestScheduler:
         shell = target.attr.get('run_in_shell', False)
         if shell:
             cmd = subprocess.list2cmdline(cmd)
-        timeout = target.attr.get('test_timeout')
+        timeout = self._effective_timeout(target.attr.get('test_timeout'))
         self._show_progress(cmd)
         log_path = os.path.join(run_dir, 'blade-test.log')
         console.info(f'Live output of //{test_name} -> {log_path}')
@@ -216,7 +235,7 @@ class TestScheduler:
         shell = target.attr.get('run_in_shell', False)
         if shell:
             cmd = subprocess.list2cmdline(cmd)
-        timeout = target.attr.get('test_timeout')
+        timeout = self._effective_timeout(target.attr.get('test_timeout'))
         self._show_progress(cmd)
         p = subprocess.Popen(cmd, env=test_env, cwd=run_dir, close_fds=True, shell=shell)
         job_thread.set_job_data(p, test_name, timeout)

--- a/src/test/blade_main_test.py
+++ b/src/test/blade_main_test.py
@@ -20,6 +20,7 @@ from cc_plugin_test import TestCcPlugin
 from cc_test_test import TestCcTest
 from dsl_api_test import GetenvTest
 from dump_test import TestDump
+from test_scheduler_test import EffectiveTimeoutTest
 from extension_test import TestExtension
 from gen_rule_test import TestGenRule
 from hdr_dep_check_test import TestHdrDepCheck
@@ -45,6 +46,7 @@ def _main():
         unittest.defaultTestLoader.loadTestsFromTestCase(TestCcBinary),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestCcPlugin),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestCcTest),
+        unittest.defaultTestLoader.loadTestsFromTestCase(EffectiveTimeoutTest),
         unittest.defaultTestLoader.loadTestsFromTestCase(GetenvTest),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestDump),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestExtension),

--- a/src/test/test_scheduler_test.py
+++ b/src/test/test_scheduler_test.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Author: chen3feng <chen3feng@gmail.com>
+
+"""Tests for ``test_scheduler.TestScheduler``."""
+
+import unittest
+
+import blade_test  # noqa: F401  -- adds src/blade to sys.path
+from blade.test_scheduler import TestScheduler
+
+
+class EffectiveTimeoutTest(unittest.TestCase):
+    """``_effective_timeout`` -- run-time multiplier applied to per-target timeout."""
+
+    def _scheduler(self, multiplier):
+        return TestScheduler(tests_list=[], num_jobs=1,
+                             test_timeout_multiplier=multiplier)
+
+    def testDefaultMultiplierIsIdentity(self):
+        s = self._scheduler(multiplier=1.0)
+        self.assertEqual(s._effective_timeout(60), 60)
+
+    def testMultiplierScales(self):
+        s = self._scheduler(multiplier=3.0)
+        self.assertEqual(s._effective_timeout(60), 180)
+
+    def testZeroBaseStaysUnlimited(self):
+        # 0 is the documented "unlimited" sentinel of global_config.test_timeout.
+        # No multiplier should ever turn unlimited into limited.
+        s = self._scheduler(multiplier=3.0)
+        self.assertEqual(s._effective_timeout(0), 0)
+
+    def testNegativeBaseStaysUnlimited(self):
+        # config docstring: "0 (default) or any non-positive value means unlimited"
+        s = self._scheduler(multiplier=2.0)
+        self.assertEqual(s._effective_timeout(-1), -1)
+
+    def testNoneBaseStaysNone(self):
+        # target.attr.get('test_timeout') can return None on targets that
+        # predate the attribute being set.
+        s = self._scheduler(multiplier=2.0)
+        self.assertIsNone(s._effective_timeout(None))
+
+    def testFractionalMultiplier(self):
+        s = self._scheduler(multiplier=0.5)
+        self.assertEqual(s._effective_timeout(60), 30)
+
+
+if __name__ == '__main__':
+    blade_test.run(EffectiveTimeoutTest)


### PR DESCRIPTION
## Summary

Implements v1 of #1242 (test timeout improvement). Adds a per-run multiplier exposed as a CLI flag:

```bash
blade test --test-timeout-multiplier=3 ...
```

Use case: `global_config.test_timeout` is a single value baked into project config, but a single number can't simultaneously fit a fast dev machine and a slow shared CI runner. Today, projects work around this by setting the timeout wide (e.g. flare's 600s) so the CI worst-case doesn't false-timeout — with the downside that a fast unit test that genuinely hangs takes 10+ minutes to fail. The multiplier lets each run dial the global timeout to the machine.

## Why CLI-only (no env var fallback, no config field)

The substantive design choice. Two principles:

1. **Environment access that changes build behaviour silently is anti-pattern.** This is the same line that `blade.getenv()` (#1244) established for env-driven config: env can influence the build, but only when something in the source explicitly opts in. A magic `BLADE_TEST_TIMEOUT_MULTIPLIER` env var would be a sneaky reverse of that.
2. **`global_config` describes project intrinsics, not environment adaptation.** "Our tests need at most N seconds on normal hardware" belongs in `BLADE_ROOT`. "This runner is 3× slower than normal" does not — it's a property of the runner, not the project, so it belongs at the CLI level.

CI workflows pass the flag explicitly. One greppable line in the yml:

```yaml
- name: Run tests
  run: blade test --test-timeout-multiplier=3 ...
```

## Behaviour

- Default `1.0` → identical to before, no breakage for existing projects.
- `0` or negative `global_config.test_timeout` (the documented "unlimited" sentinel) stays unlimited regardless of multiplier.
- Applied at job dispatch in `TestScheduler._effective_timeout()`; `target.attr['test_timeout']` itself is unchanged.

## What's not here (deferred)

- **v2 `test_size` buckets** (Bazel-style small/medium/large). Useful when test durations are bimodal; flare's distribution is single-peak so v1 alone is enough. Left in #1242.
- **v3 CPU time (`setrlimit(RLIMIT_CPU)`)**. More complex, platform-specific. Left in #1242.

## Files

- `src/blade/command_line.py` — adds `--test-timeout-multiplier` argparse option (default 1.0)
- `src/blade/test_runner.py` — passes `options.test_timeout_multiplier` into `TestScheduler` ctor
- `src/blade/test_scheduler.py` — `TestScheduler.__init__` accepts it; `_effective_timeout()` applies it at dispatch, preserving the unlimited sentinel
- `src/test/test_scheduler_test.py` — 6 unit tests (identity, scaling, zero/negative/None sentinel preservation, fractional multiplier)
- `src/test/blade_main_test.py` — wires the new test into the main suite
- `doc/en/command_line.md` + `doc/zh_CN/command_line.md` — user-facing docs

## Test plan

- [x] `python3 test_scheduler_test.py` passes locally (6/6)
- [x] `blade_main_test.py` imports correctly with the new test wired in
- [x] No behavioural change with default multiplier `1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)