### PR TITLE
feat(resource_library): MSVC /INCLUDE: directive for index symbols

### DIFF
--- a/src/blade/builtin_tools.py
+++ b/src/blade/builtin_tools.py
@@ -1083,10 +1083,31 @@ def _generate_resource_index(targets, sources, name, path):
                 }};
                 BLADE_RESOURCE_KEEP
                 const unsigned {0}_len = {1};''').format(index_name, len(sources)))
+        # MSVC analogue of GCC's `retain` -- and strictly stronger, because it
+        # also forces static-archive pull-in. The `#pragma comment(linker,
+        # "/INCLUDE:foo")` directive is embedded into every consumer .obj that
+        # includes this header; the linker then requires `foo` to be defined,
+        # so an unreferenced archive member that defines it gets pulled in.
+        # `retain` on GCC operates after archive selection, so the GCC fallback
+        # for that case is still `link_all_symbols = True`.
+        #
+        # Symbol decoration: C symbols carry a leading underscore on x86
+        # (`__cdecl`); x86_64 / arm64 keep the bare name. The x86 branch is
+        # rarely used these days but is essentially free to retain.
         h.write(textwrap.dedent('''\
                 // Resource index
                 extern const struct BladeResourceEntry {0}[];
                 extern const unsigned {0}_len;
+
+                #ifdef _MSC_VER
+                #  ifdef _M_IX86
+                #    pragma comment(linker, "/INCLUDE:_{0}")
+                #    pragma comment(linker, "/INCLUDE:_{0}_len")
+                #  else
+                #    pragma comment(linker, "/INCLUDE:{0}")
+                #    pragma comment(linker, "/INCLUDE:{0}_len")
+                #  endif
+                #endif
 
                 #ifdef __cplusplus
                 }}  // extern "C"


### PR DESCRIPTION
## Summary

Follow-up to #1249.

GCC's `retain` only protects against post-link `--gc-sections`. MSVC's analogue — `#pragma comment(linker, "/INCLUDE:foo")` embedded from a consumer .obj — is **strictly stronger**: it also drives static-archive member selection, pulling in unreferenced archive members that satisfy the symbol. So the resource_library symbols become fully protected on Windows in a way `retain` alone can't manage on GCC.

## What the generated `.h` looks like now

```c
extern const struct BladeResourceEntry RESOURCE_INDEX_web[];
extern const unsigned RESOURCE_INDEX_web_len;

#ifdef _MSC_VER
#  ifdef _M_IX86
#    pragma comment(linker, "/INCLUDE:_RESOURCE_INDEX_web")
#    pragma comment(linker, "/INCLUDE:_RESOURCE_INDEX_web_len")
#  else
#    pragma comment(linker, "/INCLUDE:RESOURCE_INDEX_web")
#    pragma comment(linker, "/INCLUDE:RESOURCE_INDEX_web_len")
#  endif
#endif
```

## Why in the header (not in the `.c`)

The MSVC linker reads directives from .obj files **after** archive selection. If the pragma lives in the resource_library's own `.c`, and that `.c` is archived into a static lib that no consumer references, the linker never reads the directive — Catch-22.

Putting the pragma in the header means every consumer TU that `#include`s it embeds the directive in its own .obj. Those .objs are part of the link set by definition (consumer code), so the linker processes the directive, requires the symbol to be defined, and pulls in whichever archive member defines it.

The linker dedups identical `/INCLUDE:` directives across .obj files, so the per-TU cost is zero at runtime and tiny at link time.

## Symbol decoration

C symbols carry a leading underscore on x86 (`__cdecl`); x86_64 / arm64 use the bare name. Both branches emitted behind `_M_IX86`. x86 is essentially obsolete on modern Windows but keeping the branch is free.

## Doesn't touch per-file byte arrays

The index struct holds `RESOURCE_<file>` pointers as initializer fields. Once the index survives, the linker sees those references and keeps the byte arrays alive transitively. Only the index itself needs explicit retention — same principle as the GCC side of #1249.

## Test plan

- [x] Generator unit-tested by direct invocation; emitted `.h` contains the expected `#pragma` block.
- [x] Apple Clang still compiles cleanly (silently ignores `_MSC_VER` branch).
- [ ] Windows CI (Unit + smoke) confirms no regression.
- [ ] Manual MSVC validation against a small Windows blade build would be nice eventually — out of my reach here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)