### PR TITLE
chore(cc): remove dead _get_as_flags helper (#833)

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -596,15 +596,6 @@ class CcTarget(Target):
 
         return cpp_flags, regular_incs, system_incs
 
-    def _get_as_flags(self):
-        """Return as flags according to the build architecture."""
-        options = self.blade.get_options()
-        if options.m:
-            as_flags = ['-g', '--' + options.m]
-            aspp_flags = ['-Wa,--' + options.m]
-            return as_flags, aspp_flags
-        return [], []
-
     def _export_incs_list(self):
         """Return ``(regular_incs, system_incs)`` collected from deps.
 


### PR DESCRIPTION
## Summary

Closes #833. The issue ("some dysfunctional features") flagged two items:

1. \`cc_plugin.prefix\` not used
2. \`_get_as_flags\` not called

**(1) was already fixed** in a prior PR — \`cc_plugin\`'s \`prefix\` and \`suffix\` are honored at codegen time (\`CcPlugin.generate\`, cc_targets.py:2442), with a deprecation warning for the historical \`name='foo.so'\` workaround.

**(2) is still dead.** \`_get_as_flags\` was defined to inject \`-g --m32/--m64\` (GNU as arch flags) for \`.s\`/\`.S\` sources when the user passes \`-m 32/64\` to blade, but nothing has ever called it — confirmed via \`grep -rn 'as_flags\\|_get_as'\` (no static call sites, no getattr/dynamic access). \`extra_asflags\` already covers the user-facing assembler-flags path. Five years with no consumer is sufficient evidence it isn't needed; users who want auto-injected assembler arch flags can put \`-Wa,--32\` in \`extra_asflags\` directly.

## Change

Single-file delete: 9 lines removed from cc_targets.py.

## Test plan

- [ ] All existing unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)