### PR TITLE
fix(cc): use cp -L for prebuilt .so copies to dereference symlinks (#730)

### DIFF
--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -347,7 +347,14 @@ class _NinjaFileHeaderGenerator:
         if os.name == 'nt':
             copy_cmd = 'cmd /c copy /y ${in} ${out} > nul'
         else:
-            copy_cmd = 'cp -f ${in} ${out}'
+            # -L dereferences symbolic-link sources so a prebuilt
+            # `libfoo.so -> libfoo.so.2.2` resolves to a real file in the
+            # build dir rather than a dangling symlink. Both GNU and BSD
+            # cp default to following symlinks in single-file copy mode,
+            # but issue #730 reported a build-1.1.2-era environment that
+            # behaved otherwise; -L makes the intent explicit and
+            # platform-independent.
+            copy_cmd = 'cp -fL ${in} ${out}'
         self.generate_rule(name='copy',
                            command=copy_cmd,
                            description='COPY ${in} ${out}')


### PR DESCRIPTION
## Summary

Closes #730. The 2020 report described a prebuilt \`libgflags.so -> libgflags.so.2.2\` symlink being copied as-is into \`build64_release/\`, leaving a dangling reference because the versioned target wasn't in the destination dir.

## Status check

The bug is hard to reproduce on a modern environment:

- **macOS BSD cp**: defaults to dereferencing symlinks in single-file mode (confirmed via a manual repro — a fresh prebuilt setup with \`libdummy.dylib -> libdummy.dylib.2.2\` produces a real file under build_dir, not a symlink)
- **GNU coreutils cp**: documented default is to follow symlinks for single-file copy

So the 2020 report was likely against an older cp variant, a custom shell alias, or a non-standard environment. Either way, the defensive fix is tiny.

## Change

Add \`-L\` (POSIX "follow symbolic links") to the file-copy rule in \`backend.py\`. One-line code change:

\`\`\`diff
- copy_cmd = 'cp -f \${in} \${out}'
+ copy_cmd = 'cp -fL \${in} \${out}'
\`\`\`

Zero behavior change on hosts where the bug was already invisible (vast majority); defensive on the rest.

Runtime soname handling is unaffected — \`binary_runner._prepare_shared_libraries\` already creates the \`<soname> -> <real path>\` symlink in the runfiles dir so dyld/ld.so can find a copy named after the soname.

## Test plan

- [ ] CI green on Linux, macOS, Windows (Windows path uses \`cmd /c copy\` which already follows symlinks)
- [ ] All existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)