### PR TITLE
feat(toolchain): auto-detect default_linked_libs via cc -### output

### DIFF
--- a/doc/en/build_rules/cc.md
+++ b/doc/en/build_rules/cc.md
@@ -140,13 +140,13 @@ Attributes:
 
   Setting `generate_dynamic = True` forces the shared library to be generated unconditionally.
 
-- `check_undefined`: bool = True
+- `check_undefined`: bool = True **(EXPERIMENTAL)**
 
-  Whether Blade statically validates — at archive time, before any link — that the target's declared `deps` cover every undefined symbol the library references. If a symbol is left unresolved, the check fails with an error pointing at the missing dep, instead of waiting for a final link to fail (often hundreds of targets later) with an opaque linker error.
+  Whether Blade statically validates — at archive time, before any link — that the target's declared `deps` cover every undefined symbol the library references. If a symbol is left unresolved, the check reports a diagnostic pointing at the missing dep, instead of waiting for a final link to fail (often hundreds of targets later) with an opaque linker error.
 
-  The check uses `nm` on the target's just-built static archive and each transitive `cc_library` dep's archive, plus pre-generated symbol caches for every `#alias` system library (so e.g. consumers of `pow()` are required to actually declare `'#m'`). It runs even when `generate_dynamic = True` — it is faster than the link itself and catches the same misses earlier, per-library, with feedback that points at the specific dep instead of at the final binary.
+  The check uses `nm` (or `dumpbin` on MSVC) on the target's just-built static archive and each transitive `cc_library` dep's archive, plus pre-generated symbol caches for every `#alias` system library (so e.g. consumers of `pow()` are required to actually declare `'#m'`). It runs even when `generate_dynamic = True` — it is faster than the link itself and catches the same misses earlier, per-library, with feedback that points at the specific dep instead of at the final binary.
 
-  Skipped automatically when the toolchain is MSVC (`link.exe` already rejects undefined externals via LNK2019, and MSVC's `.obj` `DEFAULTLIB` directives resolve symbols outside the source-visible graph in ways the nm model can't represent).
+  The check ships enabled by default, but while it is still experimental its findings default to `warning` severity (see [`cc_library_config.check_undefined_severity`](../config.md#cc_library_config)) — the build keeps going so any edge cases surface as diagnostics rather than CI failures. Flip the severity to `error` once it's clean on your codebase.
 
   See [Static undefined-symbol check](#static-undefined-symbol-check) for the bigger picture; per-invocation overrides are `--cc-check-undefined` / `--no-cc-check-undefined`; the global default is [`cc_library_config.check_undefined`](../config.md#cc_library_config).
 

--- a/doc/en/config.md
+++ b/doc/en/config.md
@@ -331,21 +331,32 @@ C/C++ library configuration
 
   Whether to generate a dynamic library in addition to the static library.
 
-- `check_undefined` : bool = True
+- `check_undefined` : bool = True **(EXPERIMENTAL)**
 
   Project-wide default for the [static undefined-symbol check](build_rules/cc.md#static-undefined-symbol-check).
   When True (default), every `cc_library`'s undefined symbols are statically validated against
   its declared `deps` immediately after the archive is built — moving "missing dep" failures
-  earlier in the build, with errors that point at the broken library instead of at the final
-  binary.
+  earlier in the build, with diagnostics that point at the broken library instead of at the
+  final binary.
+
+  The check ships on by default but, while still experimental, its findings default to
+  `warning` severity (see `check_undefined_severity` below): the build keeps going so any
+  edge cases we haven't seen surface as diagnostics rather than CI failures. Flip the severity
+  to `error` once the check is clean on your codebase.
 
   Override per-invocation with `--cc-check-undefined` / `--no-cc-check-undefined`.
   Override per-target with `check_undefined = False` on `cc_library` (lowest setting wins —
   a per-target `False` cannot be re-enabled from CLI or config).
 
-  Skipped automatically on the MSVC toolchain (`link.exe` LNK2019 already rejects undefined
-  externals, and `.obj` DEFAULTLIB directives resolve symbols in ways the nm model can't
-  represent).
+- `check_undefined_severity` : str = `'warning'`
+
+  Severity of an unresolved-symbol finding:
+  - `'warning'` (default, experimental setting) — log the finding via `console.warning` and
+    let the build continue.
+  - `'error'` — fail the build on any finding (the eventual non-experimental default).
+
+  This setting is project-global; per-target behavior is still controlled by
+  `check_undefined` / `allow_undefined`.
 
 - `allow_undefined` : list = []
 

--- a/doc/zh_CN/build_rules/cc.md
+++ b/doc/zh_CN/build_rules/cc.md
@@ -132,13 +132,13 @@ cc_library(
 
   设为 `generate_dynamic = True` 则强制无条件生成动态库。
 
-- `check_undefined`: bool = True
+- `check_undefined`: bool = True **（实验性）**
 
-  是否在归档完成、最终链接之前**静态校验**：本库声明的 `deps` 是否覆盖了它引用的全部未定义符号。如果有未定义符号缺乏来源，立即报错并指出具体的缺失依赖；否则一直等到最终二进制链接才会爆出（往往滞后到几百个目标之后），错误消息只指向二进制名而非有问题的库本身。
+  是否在归档完成、最终链接之前**静态校验**：本库声明的 `deps` 是否覆盖了它引用的全部未定义符号。如果有未定义符号缺乏来源，立即给出诊断并指出具体的缺失依赖；否则一直等到最终二进制链接才会爆出（往往滞后到几百个目标之后），错误消息只指向二进制名而非有问题的库本身。
 
-  检查方式：对本目标新生成的 `.a` 跑 `nm -u`，对每个传递的 `cc_library` 依赖归档跑 `nm --defined-only`，再加上每个 `#alias` 系统库（如 `#m`、`#pthread`、`#dl`）的预生成符号缓存（消费者用了 `pow()` 就必须显式声明 `'#m'`）。即便 `generate_dynamic = True`，本检查也仍然执行——它比最终链接更快、并能更早、按库粒度指出问题。
+  检查方式：对本目标新生成的 `.a` 跑 `nm -u`（MSVC 下用 `dumpbin`），对每个传递的 `cc_library` 依赖归档跑 `nm --defined-only`（同样 MSVC 下用 `dumpbin`），再加上每个 `#alias` 系统库（如 `#m`、`#pthread`、`#dl`）的预生成符号缓存（消费者用了 `pow()` 就必须显式声明 `'#m'`）。即便 `generate_dynamic = True`，本检查也仍然执行——它比最终链接更快、并能更早、按库粒度指出问题。
 
-  在 MSVC 工具链下自动跳过（`link.exe` 已经通过 LNK2019 拒绝未定义外部符号；而且 MSVC 的 `.obj` `DEFAULTLIB` 指令解析符号的方式我们的 nm 模型无法表达）。
+  本检查默认启用，但目前仍属实验阶段，其诊断默认以 `warning` 级别输出（见 [`cc_library_config.check_undefined_severity`](../config.md#cc_library_config)）——构建照常继续，未覆盖到的边缘情况以告警形式出现，而不会直接打断 CI。在你的代码库上稳定通过后，可将级别切换为 `error`。
 
   详见 [静态未定义符号检查](#static-undefined-symbol-check)；本次调用级覆盖：`--cc-check-undefined` / `--no-cc-check-undefined`；全局默认：[`cc_library_config.check_undefined`](../config.md#cc_library_config)。
 

--- a/doc/zh_CN/config.md
+++ b/doc/zh_CN/config.md
@@ -341,18 +341,27 @@ Blade 支持构建多目标平台的产物，例如在 x64 Linux 下，可以通
 
 除了生成静态库之外，是否同时生成动态库。
 
-#### `check_undefined`：bool = True
+#### `check_undefined`：bool = True **（实验性）**
 
 **[静态未定义符号检查](build_rules/cc.md#static-undefined-symbol-check)的项目级默认开关。**
 
-默认开启时，每个 `cc_library` 在归档完成后立即对其未定义符号进行静态校验，确认其声明的 `deps` 是否真的覆盖了所有用到的符号——把「缺依赖」的失败时机左移、按库报错，而不是堆到最终二进制链接才爆出。
+默认开启时，每个 `cc_library` 在归档完成后立即对其未定义符号进行静态校验，确认其声明的 `deps` 是否真的覆盖了所有用到的符号——把「缺依赖」的失败时机左移、按库给出诊断信息，而不是堆到最终二进制链接才爆出。
+
+检查默认启用，但目前仍属实验阶段，其诊断默认以 **warning** 级别输出（见下方 `check_undefined_severity`）：构建继续进行，未覆盖到的边缘情况以告警形式出现，而非直接打断 CI。在本检查在你的代码库稳定通过后，可将级别切换为 `error`。
 
 覆盖优先级：
 
 - 单次调用：`--cc-check-undefined` / `--no-cc-check-undefined`。
 - 单目标：在 `cc_library` 上设 `check_undefined = False`。**最低值胜出**——单目标 `False` 不能被 CLI 或配置重新开启。
 
-MSVC 工具链下自动跳过（`link.exe` 的 LNK2019 已经拒绝未定义外部符号；并且 `.obj` 的 DEFAULTLIB 指令解析方式 nm 模型无法表达）。
+#### `check_undefined_severity`：str = `'warning'`
+
+**未解析符号诊断的级别。**
+
+- `'warning'`（默认，实验阶段值）—— 通过 `console.warning` 输出诊断，构建继续。
+- `'error'` —— 任何未解析符号都判定构建失败（脱离实验阶段后的默认目标）。
+
+本配置作用于项目全局；单目标层面的开关仍由 `check_undefined` / `allow_undefined` 控制。
 
 #### `allow_undefined`：list = []
 

--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -722,9 +722,13 @@ class _NinjaFileHeaderGenerator:
         # ``.a`` archives and re-ran ``nm`` on every dep for every target's
         # check, making the total cost O(targets × deps) and scaling badly
         # on diamond-shaped dep graphs.
+        # On MSVC the archives are COFF .lib files and nm is unavailable, so the
+        # emit-syms tool reads symbols with dumpbin instead; pass its path.
+        syms_args = '${out} ${in}'
+        if self.build_toolchain.cc_is('msvc'):
+            syms_args += ' --dumpbin="%s"' % self.build_toolchain.dumpbin
         self.generate_rule(name='ccsyms',
-                           command=self._builtin_command(
-                               'cc_emit_syms', '${out} ${in}'),
+                           command=self._builtin_command('cc_emit_syms', syms_args),
                            description='CC SYMS ${in}')
         # Single batch rule: ``${in}`` is the manifest JSON (built by
         # BuildManager after all cc_libraries have generated), ``${out}``

--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -737,9 +737,15 @@ class _NinjaFileHeaderGenerator:
         # batch emitter registers (each .syms is also an explicit input
         # there, so ninja still re-runs the batch when any archive's
         # symbol set changes).
+        # Severity is project-global, baked into the rule command at generate
+        # time so a config flip triggers a normal ninja regen (the build.ninja
+        # text changes -> ninja reloads). 'warning' (default while the check is
+        # experimental) logs findings but doesn't fail the build; 'error' fails.
+        severity = config.get_item('cc_library_config', 'check_undefined_severity')
+        batch_args = '${out} ${in} --severity=%s' % severity
         self.generate_rule(name='ccchkund_batch',
                            command=self._builtin_command(
-                               'cc_check_undefined_batch', '${out} ${in}'),
+                               'cc_check_undefined_batch', batch_args),
                            description='CC CHECK UNDEFINED [batch]')
 
     def _generate_cc_ar_rules(self):

--- a/src/blade/builtin_tools.py
+++ b/src/blade/builtin_tools.py
@@ -197,8 +197,53 @@ def _check_undefined_compile_baseline():
     return [_re.compile(p) for p in _CHECK_UNDEFINED_RESIDUAL_BASELINE]
 
 
-def _nm_extract_externals(archive):
+def _dumpbin_extract_externals(dumpbin, archive):
+    """Return (undefined, defined) external symbol sets for an MSVC ``.lib``.
+
+    The MSVC analog of ``nm -P -g``. ``dumpbin /symbols`` prints one row per
+    COFF symbol; the storage-class column reads ``External`` for externals and
+    the section column is ``UNDEF`` for undefined references, anything else
+    (``SECTn``, ``ABS``) for definitions. The raw (decorated) symbol name is the
+    token right after ``|`` -- the trailing ``(demangled)`` comment is dropped,
+    so names match what ``dumpbin /linkermember`` reports for the system libs.
+    """
+    try:
+        out = subprocess.check_output([dumpbin, '/nologo', '/symbols', archive],
+                                      stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        console.warning('dumpbin failed on %s (%s); treating as no symbols' % (archive, e))
+        return set(), set()
+    except OSError:  # FileNotFoundError ⊂ OSError
+        console.error('cc_check_undefined: dumpbin not found')
+        return set(), set()
+
+    undefined, defined = set(), set()
+    text = out.decode('utf-8', errors='replace')
+    for raw in text.splitlines():
+        if '|' not in raw:
+            continue
+        left, _, right = raw.partition('|')
+        cols = left.split()
+        # External symbol rows end the COFF columns with the storage class
+        # 'External'; e.g. "008 00000000 UNDEF notype () External | name".
+        if not cols or cols[-1] != 'External':
+            continue
+        name = right.strip().split(None, 1)[0] if right.strip() else ''
+        if not name:
+            continue
+        section = cols[2] if len(cols) >= 3 else ''
+        if section == 'UNDEF':
+            undefined.add(name)
+        else:
+            defined.add(name)
+    return undefined, defined
+
+
+def _nm_extract_externals(archive, dumpbin=None):
     """Return (undefined_external, defined_external) sets for an archive.
+
+    With ``dumpbin`` set (MSVC), defer to :func:`_dumpbin_extract_externals`
+    since ``nm`` is unavailable and the inputs are COFF ``.lib`` archives.
 
     Runs `nm -P -g <archive>` once. -P selects POSIX format
     (`name type [value [size]]`), -g restricts to external symbols. Type
@@ -210,6 +255,8 @@ def _nm_extract_externals(archive):
     must be counted as defined, or downstream cc_libraries that pull
     them in transitively will fail the undefined-symbol check.
     """
+    if dumpbin:
+        return _dumpbin_extract_externals(dumpbin, archive)
     try:
         out = subprocess.check_output(['nm', '-P', '-g', archive], stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
@@ -319,11 +366,14 @@ def _read_archive_syms(path):
     return undefined, defined
 
 
-def generate_cc_emit_syms(args, **_opts):
+def generate_cc_emit_syms(args, dumpbin=None, **_opts):
     """Run ``nm`` on a static archive once and emit its symbol-set cache.
 
     Args:
         args: ``[<output.syms>, <input.a>]``
+        dumpbin: path to ``dumpbin.exe`` (passed as ``--dumpbin=<path>`` by the
+            ``ccsyms`` rule on MSVC); when set, symbols are read with dumpbin
+            instead of ``nm`` (the archives are COFF ``.lib`` files).
 
     Writes ``output.syms`` with two sections: ``#U`` (undefined externals)
     and ``#D`` (defined externals). This collapses what the check tool used
@@ -334,7 +384,7 @@ def generate_cc_emit_syms(args, **_opts):
     out_path = args[0]
     archive = args[1]
     _declare_outputs(out_path)
-    undef, defd = _nm_extract_externals(archive)
+    undef, defd = _nm_extract_externals(archive, dumpbin=dumpbin)
     tmp = out_path + '.tmp'
     os.makedirs(os.path.dirname(tmp), exist_ok=True)
     with open(tmp, 'w', encoding='utf-8') as f:

--- a/src/blade/builtin_tools.py
+++ b/src/blade/builtin_tools.py
@@ -476,7 +476,7 @@ def generate_cc_check_undefined(args, **opts):
     return None
 
 
-def generate_cc_check_undefined_batch(args, **_opts):
+def generate_cc_check_undefined_batch(args, severity='error', **_opts):
     """Project-wide variant of :func:`generate_cc_check_undefined`.
 
     Runs the static undefined-symbol check for every cc_library in the
@@ -492,15 +492,16 @@ def generate_cc_check_undefined_batch(args, **_opts):
 
     Args:
         args: ``[<batch_stamp>, <manifest.json>]``
+        severity: ``'warning'`` (project default while the check is
+            experimental) logs findings via console.warning and still
+            writes the stamp so the build keeps going. ``'error'`` fails
+            the build on any finding. Anything else falls back to
+            ``'error'`` (defensive: an unknown severity is closer to "be
+            strict" than "be silent").
 
-    The manifest is a JSON array of per-target spec dicts written by
-    BuildManager at generate time:
-        {"target_label": str, "target_syms": str, "dep_syms": [str],
-         "sys_caches": [str], "allow_file": str}
-
-    Exits non-zero (and writes nothing) if any spec fails. The stamp
-    file is written only on full success, so a later incremental
-    invocation can short-circuit if no inputs changed.
+    On severity=``'error'``, exits non-zero (and writes nothing) when any
+    spec fails. The stamp is always written on the warning path so a
+    later incremental invocation can short-circuit if no inputs changed.
     """
     import json as _json  # pylint: disable=import-outside-toplevel
     import re as _re  # pylint: disable=import-outside-toplevel
@@ -542,6 +543,10 @@ def generate_cc_check_undefined_batch(args, **_opts):
         allow_cache[path] = compiled
         return compiled
 
+    # `severity` is the project-global diagnostic level. We resolve it once to
+    # the matching console.{warning,error} bound method so the per-target loop
+    # below doesn't keep re-branching.
+    log = console.warning if severity == 'warning' else console.error
     failed = 0
     for spec in specs:
         target_label = spec['target_label']
@@ -564,19 +569,20 @@ def generate_cc_check_undefined_batch(args, **_opts):
                           if not any(p.fullmatch(s) for p in compiled)}
         if unresolved:
             failed += 1
-            console.error('cc_check_undefined: %s has %d undefined symbol(s) not covered '
-                          'by declared deps:' % (target_label, len(unresolved)))
+            log('cc_check_undefined: %s has %d undefined symbol(s) not covered '
+                'by declared deps:' % (target_label, len(unresolved)))
             for s in sorted(unresolved)[:50]:
-                console.error('  %s' % s)
+                log('  %s' % s)
             if len(unresolved) > 50:
-                console.error('  ... and %d more' % (len(unresolved) - 50))
+                log('  ... and %d more' % (len(unresolved) - 50))
 
     if failed:
-        console.error('cc_check_undefined: %d target(s) failed; add the providing '
-                      'cc_library (or #syslib) to deps, or whitelist with '
-                      'allow_undefined=[regex] / cc_library_config.allow_undefined.'
-                      % failed)
-        return 1
+        log('cc_check_undefined: %d target(s) failed; add the providing '
+            'cc_library (or #syslib) to deps, or whitelist with '
+            'allow_undefined=[regex] / cc_library_config.allow_undefined.'
+            % failed)
+        if severity != 'warning':
+            return 1
 
     os.makedirs(os.path.dirname(stamp_file), exist_ok=True)
     with open(stamp_file, 'w', encoding='utf-8') as f:

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -968,15 +968,14 @@ class CcTarget(Target):
         and writes ``<archive>.syms``. The downstream ``ccchkund`` rule reads
         the cache instead of re-running nm.
 
-        Skipped on MSVC, where the static check is already skipped (link.exe
-        handles undefined externals natively); the cache would be unused.
+        On MSVC the archive is a COFF ``.lib`` and the rule reads symbols with
+        ``dumpbin`` instead of ``nm`` (wired in the backend); the ``.syms``
+        format is identical, so the rest of the check is platform-agnostic.
 
         Idempotent across multiple call sites: re-registering the same
         STATIC_LIB_SYMS_LABEL on a target is a no-op.
         """
         tc = self.blade.get_build_toolchain()
-        if tc.cc_is('msvc'):
-            return None
         if self._get_target_file(tc.STATIC_LIB_SYMS_LABEL):
             return self._get_target_file(tc.STATIC_LIB_SYMS_LABEL)
         syms = archive + '.syms'
@@ -987,13 +986,13 @@ class CcTarget(Target):
     def _generate_check_undefined(self, static_lib, inclusion_check_result):
         """Emit the dep-completeness check rule for this cc_library.
 
-        Skipped when:
-          * check_undefined is False (per target / CLI / config), or
-          * the toolchain is MSVC -- link.exe already rejects undefined
-            externals (LNK2019), and Microsoft's lib.exe / .obj DEFAULTLIB
-            directives resolve standard C/C++ symbols outside the source-
-            visible ``-l<name>`` graph, which our nm-based model can't
-            represent without significant Windows-specific work.
+        Skipped when check_undefined is False (per target / CLI / config).
+
+        Works on MSVC too: symbols are read with ``dumpbin`` (``nm`` analog),
+        and the ``.obj`` ``/DEFAULTLIB`` directives that pull the CRT outside
+        the source-visible ``-l<name>`` graph are covered by the toolchain's
+        auto-detected ``default_linked_libs`` baseline (msvcrt / ucrt /
+        vcruntime / oldnames), so standard C/C++ symbols don't false-positive.
 
         Keeps running when generate_dynamic is True as an early, cheaper
         cross-check -- the dynamic link's `-Wl,--no-undefined` is the final
@@ -1020,8 +1019,6 @@ class CcTarget(Target):
         if not self.attr.get('check_undefined', True):
             return None
         tc = self.blade.get_build_toolchain()
-        if tc.cc_is('msvc'):
-            return None
         # `allow_undefined=True` is the legacy "this library has unresolved
         # symbols by design (the consumer provides them at final link)"
         # signal. It already disables -Wl,--no-undefined at link time; the

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -129,10 +129,18 @@ _CONFIG_TEMPLATE = {
         'hdrs_missing_suppress': set(),
         # Validate that a cc_library's declared deps cover every undefined
         # symbol it references, without requiring a shared-library link.
-        # See issue #1225.
+        # See issue #1225. EXPERIMENTAL -- the check ships on by default but at
+        # `warning` severity so that any false-positives we haven't seen yet
+        # surface as diagnostics without blocking builds. Flip severity to
+        # `error` once you've confirmed the check is clean on your codebase.
         'check_undefined': True,
-        'check_undefined__help__': 'Whether to statically validate that declared deps '
-            'cover every undefined symbol referenced by each cc_library. Default True.',
+        'check_undefined__help__': 'EXPERIMENTAL. Whether to statically validate that '
+            'declared deps cover every undefined symbol referenced by each cc_library. '
+            'Default True; pair with check_undefined_severity to control the diagnostic.',
+        'check_undefined_severity': 'warning',
+        'check_undefined_severity__help__': 'Severity of an unresolved-symbol finding: '
+            '"warning" (default) logs a warning and lets the build continue; "error" fails '
+            'the build. Default is "warning" while the check is experimental.',
         # Global allowlist of symbols permitted to remain undefined. Each entry
         # is a Python regex matched with re.fullmatch against the mangled name
         # (what `nm -u` prints). System symbols (libc, libstdc++, weak refs)

--- a/src/blade/system_symbols.py
+++ b/src/blade/system_symbols.py
@@ -209,8 +209,18 @@ def resolve_lib_paths(toolchain, alias):
     Symbols like ``__stack_chk_fail`` live ONLY in the ``_nonshared.a``;
     we must enumerate every member to get a complete baseline.
 
+    If ``alias`` is an absolute path that already points at a real
+    library file, skip resolution and return ``[alias]`` -- this lets
+    callers feed direct-path entries from the toolchain's auto-detected
+    default-linked-libs list (e.g. macOS clang's compiler-rt archive)
+    through the same code path as alias-based entries.
+
     Empty list if the alias can't be resolved.
     """
+    # Direct-path fast path: an entry that's already an absolute path to
+    # an existing file (.a / .dylib / .so) is consumed verbatim.
+    if os.path.isabs(alias) and os.path.isfile(alias):
+        return [os.path.realpath(alias)]
     cc = toolchain.cc
     for candidate in _candidate_filenames(toolchain, alias):
         try:
@@ -483,12 +493,17 @@ def ensure_cache(toolchain, alias, cache_dir):
     bundles libc.so.6 + libc_nonshared.a), union symbols from all of them;
     cache validity is keyed on the first file's (mtime, size) which is
     sufficient because the bundled members upgrade together.
+
+    ``alias`` may be either a short blade-style name (``c``, ``stdc++``,
+    ``System``) or an absolute path to a library file (e.g. macOS clang's
+    compiler-rt archive, picked up via auto-detected default_linked_libs).
+    The cache filename is derived to avoid path separators in either case.
     """
     sources = resolve_lib_paths(toolchain, alias)
     if not sources:
         return None
     primary = sources[0]
-    cache_file = os.path.join(cache_dir, '%s.syms' % alias)
+    cache_file = os.path.join(cache_dir, '%s.syms' % _cache_filename_for(alias))
     if _is_cache_valid(cache_file, alias, primary):
         return cache_file
     symbols = set()
@@ -496,6 +511,23 @@ def ensure_cache(toolchain, alias, cache_dir):
         symbols |= _nm_defined_externals(src)
     _write_cache(cache_file, alias, primary, symbols)
     return cache_file
+
+
+def _cache_filename_for(alias):
+    """Derive a flat, path-separator-free cache file stem for ``alias``.
+
+    For a short alias (``c``, ``stdc++``, ``System``) return it verbatim.
+    For an absolute path (``/path/to/libclang_rt.osx.a``) use the file's
+    basename plus a short hash of the full path so two different paths
+    with the same basename don't collide (e.g. cross-compile sysroots
+    that ship multiple libgcc.a's under different prefixes).
+    """
+    if not os.path.isabs(alias):
+        return alias
+    import hashlib  # noqa: PLC0415  cold path
+    basename = os.path.basename(alias)
+    short_hash = hashlib.sha1(alias.encode('utf-8')).hexdigest()[:8]
+    return '%s_%s' % (basename, short_hash)
 
 
 def read_symbols(cache_file):

--- a/src/blade/system_symbols.py
+++ b/src/blade/system_symbols.py
@@ -218,9 +218,18 @@ def resolve_lib_paths(toolchain, alias):
     Empty list if the alias can't be resolved.
     """
     # Direct-path fast path: an entry that's already an absolute path to
-    # an existing file (.a / .dylib / .so) is consumed verbatim.
+    # an existing file (.a / .dylib / .so / .lib) is consumed verbatim.
     if os.path.isabs(alias) and os.path.isfile(alias):
         return [os.path.realpath(alias)]
+    # MSVC: cl.exe has no `-print-file-name`; search the toolchain's library
+    # directories (the equivalent of the LIB env var) for `<alias>.lib`.
+    if toolchain.cc_is('msvc'):
+        for libdir in toolchain.get_system_lib_paths():
+            for candidate in _candidate_filenames(toolchain, alias):
+                path = os.path.join(libdir, candidate)
+                if os.path.isfile(path):
+                    return [os.path.realpath(path)]
+        return []
     cc = toolchain.cc
     for candidate in _candidate_filenames(toolchain, alias):
         try:
@@ -259,8 +268,53 @@ def resolve_lib_paths(toolchain, alias):
     return []
 
 
-def _nm_defined_externals(lib_path):
+def _is_hexoffset(token):
+    """True if ``token`` is a hexadecimal archive offset (dumpbin column)."""
+    try:
+        int(token, 16)
+        return True
+    except ValueError:
+        return False
+
+
+def _dumpbin_defined_symbols(dumpbin, lib_path):
+    """Defined external symbols of an MSVC ``.lib`` via ``dumpbin /linkermember``.
+
+    The first linker member is the archive's symbol index -- exactly the set of
+    names the lib can satisfy at link time (for an import lib, both the ``foo``
+    and ``__imp_foo`` forms). After the ``<N> public symbols`` line each row is
+    ``<hex-offset> <symbol>``; we take the symbol token.
+
+    Empty set on any failure (dumpbin missing, bad lib) -- the caller then
+    treats the lib as contributing no baseline symbols.
+    """
+    try:
+        out = subprocess.check_output(
+            [dumpbin, '/nologo', '/linkermember:1', lib_path],
+            stderr=subprocess.DEVNULL, encoding='utf-8', errors='replace')
+    except (subprocess.CalledProcessError, OSError):  # FileNotFoundError ⊂ OSError
+        return set()
+    symbols = set()
+    started = False
+    for raw in out.splitlines():
+        line = raw.strip()
+        if not started:
+            # The symbol listing begins right after the "<N> public symbols" row.
+            if line.endswith('public symbols'):
+                started = True
+            continue
+        parts = line.split(None, 1)
+        if len(parts) == 2 and _is_hexoffset(parts[0]):
+            symbols.add(parts[1].strip())
+    return symbols
+
+
+def _nm_defined_externals(lib_path, toolchain=None):
     """Return the set of externally-defined symbol names in ``lib_path``.
+
+    On MSVC (``toolchain.cc_is('msvc')``) the libraries are COFF ``.lib``
+    archives and ``nm`` is unavailable, so we read the defined externals with
+    ``dumpbin /linkermember`` instead.
 
     Portable across GNU binutils nm and Apple's nm:
       * GNU nm: ``-D`` (dynamic table), ``--defined-only``, ``--extern-only``
@@ -285,6 +339,8 @@ def _nm_defined_externals(lib_path):
     so for ``.tbd`` inputs we go straight to the text parser, which
     sees the symbols of every embedded document.
     """
+    if toolchain is not None and toolchain.cc_is('msvc'):
+        return _dumpbin_defined_symbols(toolchain.dumpbin, lib_path)
     if lib_path.endswith('.tbd'):
         # Skip nm: Apple's nm only enumerates the first YAML document.
         return _tbd_extract_symbols(lib_path)
@@ -508,7 +564,7 @@ def ensure_cache(toolchain, alias, cache_dir):
         return cache_file
     symbols = set()
     for src in sources:
-        symbols |= _nm_defined_externals(src)
+        symbols |= _nm_defined_externals(src, toolchain)
     _write_cache(cache_file, alias, primary, symbols)
     return cache_file
 

--- a/src/blade/toolchain.py
+++ b/src/blade/toolchain.py
@@ -1187,26 +1187,91 @@ def _detect_default_linked_libs(cxx: str) -> 'tuple[str, ...]':
         except ValueError:
             # Malformed quoting -- skip this line.
             continue
+        skip_next = False
         for tok in tokens:
-            if not tok.startswith('-l') or len(tok) <= 2:
+            if skip_next:
+                # Argument of a previous flag (e.g. the path that follows
+                # ``-lto_library``); not a library entry.
+                skip_next = False
                 continue
-            # ``-l:libfoo.so.1`` is GNU ld's literal-name form (resolves
-            # to a specific filename rather than a library alias). Skip:
-            # we can't represent it as a blade ``#alias``.
-            if tok[2] == ':':
+            if tok in _DASH_L_FLAGS_WITH_PATH_ARG:
+                skip_next = True
                 continue
-            name = tok[2:]
-            if name in _NON_LIB_DASH_L_FLAGS:
+            entry = _classify_link_token(tok)
+            if entry is None or entry in seen:
                 continue
-            if name in seen:
-                continue
-            seen.add(name)
-            libs.append(name)
+            seen.add(entry)
+            libs.append(entry)
         if libs:
             # First link line with `-l` tokens wins; subsequent lines
             # would be informational (e.g. echoed copy of the command).
             break
     return tuple(libs)
+
+
+# Link-line flags that consume a following path argument. The path
+# itself must be skipped, otherwise alias-or-direct-path classification
+# would mis-pick it as a default-linked library entry.
+#
+#   -lto_library <plugin.dylib>   : Apple Clang LTO plugin (macOS)
+#   -plugin <liblto_plugin.so>    : GCC's LTO plugin loader (Linux)
+#   -dynamic-linker <ld.so>       : ELF interpreter (Linux ld; ends in .so.N)
+#   -rpath <dir>                  : runtime search path (some flavors take .so)
+#   -rpath-link <dir>             : link-time search path
+#   -T <linker_script>            : GNU ld linker script
+#   -syslibroot <sdk>             : Apple ld64 sysroot
+#   -isysroot <sdk>               : compiler driver sysroot
+#   -o <output>                   : output file
+_DASH_L_FLAGS_WITH_PATH_ARG = frozenset({
+    '-lto_library',
+    '-plugin',
+    '-dynamic-linker',
+    '-rpath',
+    '-rpath-link',
+    '-T',
+    '-syslibroot',
+    '-isysroot',
+    '-o',
+})
+
+
+def _classify_link_token(tok: str) -> 'str | None':
+    """Classify a single link-command token and return the entry to add
+    to ``default_linked_libs``, or ``None`` to skip.
+
+    Two shapes are interesting:
+
+    * ``-l<alias>`` --- a blade-style library alias. We strip the ``-l``
+      and return the alias unchanged. Filter known non-library flags
+      (``-lto_library``) and skip the ``-l:literal-filename`` form
+      (GNU ld extension we can't represent as a blade alias).
+    * Absolute path to a ``.a`` / ``.dylib`` / ``.so`` (or versioned
+      ``.so.N``) --- compiler runtime archives like macOS's
+      ``libclang_rt.osx.a`` arrive this way; their symbols need to land
+      in the baseline too. Return the path verbatim; callers distinguish
+      absolute-path entries from aliases by the leading ``/``.
+
+    Everything else (flags, output paths, the user's compiled .o)
+    returns ``None``.
+    """
+    if tok.startswith('-l') and len(tok) > 2:
+        # ``-l:libfoo.so.1`` is GNU ld's literal-name form; skip.
+        if tok[2] == ':':
+            return None
+        name = tok[2:]
+        if name in _NON_LIB_DASH_L_FLAGS:
+            return None
+        return name
+    # Absolute paths only -- relative paths in the link line are the
+    # user's compiled .o (e.g. ``/tmp/cc<hash>.o``); but we want absolute
+    # toolchain-installed archives, which always come as full paths.
+    if (tok.startswith('/')
+            and (tok.endswith('.a') or tok.endswith('.dylib') or '.so' in tok)
+            # Exclude the user's compiled .o (cleanups), startup object
+            # files, and other non-library outputs from the link line.
+            and not tok.endswith('.o')):
+        return tok
+    return None
 
 
 _CC_TOOLCHAIN_KINDS = {'gcc', 'clang', 'msvc', 'mingw', 'cygwin'}

--- a/src/blade/toolchain.py
+++ b/src/blade/toolchain.py
@@ -509,11 +509,41 @@ class MsvcToolChain(ToolChain):
 
     @property
     def default_linked_libs(self) -> 'tuple[str, ...]':
-        """MSVC implicitly links the UCRT + VC runtime + Win32 base libs.
+        """Library aliases MSVC links implicitly into every binary.
 
-        The exact set depends on the runtime selection (/MD vs /MT vs the
-        debug variants); we list the union so the baseline covers all four
-        configurations. lib.exe / link.exe resolves these via LIB env var
+        Union of:
+          * a hardcoded baseline (UCRT + VC runtime + Win32 base libs), so the
+            ``check_undefined`` baseline never regresses even when detection
+            fails
+          * what the compiler itself reports via ``/DEFAULTLIB`` directives
+            (read back with ``dumpbin /directives``), which captures the CRT
+            variant actually selected (``/MD`` -> ``msvcrt``, ``/MT`` ->
+            ``libcmt``, debug -> ``*d``) plus ``oldnames``
+
+        Per-instance cached: detection compiles a tiny TU (~100 ms) and the
+        answer is invariant for the toolchain. Mirrors
+        ``GccToolChain.default_linked_libs``; this is the MSVC analog of the
+        ``-###`` link-line parse (cl.exe accepts neither ``-###`` nor ``-l``).
+        """
+        cached = getattr(self, '_cached_default_linked_libs', None)
+        if cached is not None:
+            return cached
+        hardcoded = self._hardcoded_default_linked_libs()
+        detected = _detect_default_linked_libs_msvc(self.cc)
+        # Union, preserving hardcoded order and appending novel extras.
+        seen = set(hardcoded)
+        extras = tuple(lib for lib in detected if lib not in seen)
+        result = hardcoded + extras
+        self._cached_default_linked_libs = result
+        return result
+
+    def _hardcoded_default_linked_libs(self) -> 'tuple[str, ...]':
+        """Baseline when ``/DEFAULTLIB`` detection yields nothing.
+
+        MSVC implicitly links the UCRT + VC runtime + Win32 base libs. The
+        exact CRT depends on the runtime selection (/MD vs /MT vs the debug
+        variants); we list the union so the baseline covers all four
+        configurations. lib.exe / link.exe resolves these via the LIB env var
         plus their own search paths.
         """
         return ('msvcrt', 'vcruntime', 'ucrt', 'kernel32')
@@ -1272,6 +1302,100 @@ def _classify_link_token(tok: str) -> 'str | None':
             and not tok.endswith('.o')):
         return tok
     return None
+
+
+def _detect_default_linked_libs_msvc(cc: str) -> 'tuple[str, ...]':
+    """Auto-detect MSVC default-linked libraries from compiler directives.
+
+    The MSVC analog of ``-###`` link-line parsing: the CRT headers (and the
+    compiler itself) inject ``#pragma comment(lib, ...)`` directives into every
+    object file, naming the runtime libraries link.exe pulls implicitly -- the
+    CRT variant the runtime flag selected (``/MD`` -> ``MSVCRT``, ``/MT`` ->
+    ``LIBCMT``, debug -> ``*D``) plus ``OLDNAMES``. We compile a trivial
+    translation unit and read those ``/DEFAULTLIB`` directives back with
+    ``dumpbin /directives``.
+
+    ``cc`` is the path to ``cl.exe``; ``dumpbin.exe`` is expected alongside it,
+    falling back to PATH. A bare ``int main(){}`` carries the CRT directives
+    without needing any INCLUDE/LIB environment, so this stays fast and
+    self-contained. We compile with ``/MD`` to match blade's default MSVC
+    runtime (``cc.cppflags`` in the builtin config); since the result is unioned
+    with the hardcoded baseline, the exact variant is not critical.
+
+    Returns an empty tuple on any failure (cl/dumpbin missing, compile error,
+    no directives) -- the caller falls back to the hardcoded baseline, so there
+    is no regression risk.
+    """
+    import shutil               # noqa: PLC0415  pulled lazily; cold path
+    import subprocess           # noqa: PLC0415
+    import tempfile             # noqa: PLC0415
+
+    dumpbin = os.path.join(os.path.dirname(cc), 'dumpbin.exe')
+    if not os.path.isfile(dumpbin):
+        found = shutil.which('dumpbin')
+        if not found:
+            return ()
+        dumpbin = found
+
+    tmpdir = tempfile.mkdtemp(prefix='blade_msvc_libs_')
+    try:
+        src = os.path.join(tmpdir, 'probe.cpp')
+        obj = os.path.join(tmpdir, 'probe.obj')
+        with open(src, 'w') as f:
+            f.write('int main() { return 0; }\n')
+        try:
+            proc = subprocess.run(
+                [cc, '/nologo', '/c', '/MD', src, '/Fo' + obj],
+                capture_output=True, text=True, timeout=30, check=False,
+                cwd=tmpdir)
+        except (OSError, subprocess.TimeoutExpired):
+            return ()
+        if proc.returncode != 0 or not os.path.isfile(obj):
+            return ()
+        try:
+            dump = subprocess.run(
+                [dumpbin, '/nologo', '/directives', obj],
+                capture_output=True, text=True, timeout=30, check=False)
+        except (OSError, subprocess.TimeoutExpired):
+            return ()
+        output = dump.stdout or ''
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    libs: list[str] = []
+    seen: set[str] = set()
+    for raw_line in output.splitlines():
+        entry = _classify_msvc_directive(raw_line)
+        if entry is None or entry in seen:
+            continue
+        seen.add(entry)
+        libs.append(entry)
+    return tuple(libs)
+
+
+def _classify_msvc_directive(line: str) -> 'str | None':
+    """Extract the library alias from a ``dumpbin /directives`` line.
+
+    Lines of interest carry a linker directive ``/DEFAULTLIB:MSVCRT`` or
+    ``/DEFAULTLIB:"libname.lib"`` (drivers vary on quoting and on the ``.lib``
+    suffix). Returns the normalized blade alias (lowercased, quotes and the
+    ``.lib`` suffix stripped) or ``None`` for any other line (the ``Linker
+    Directives`` banner, ``/FAILIFMISMATCH``, ``/merge``, blanks, ...).
+    """
+    text = line.strip()
+    marker = '/DEFAULTLIB:'
+    idx = text.upper().find(marker)
+    if idx == -1:
+        return None
+    value = text[idx + len(marker):].strip()
+    parts = value.split()
+    value = parts[0] if parts else ''
+    value = value.strip('"').strip()
+    if not value:
+        return None
+    if value.lower().endswith('.lib'):
+        value = value[:-4]
+    return value.lower() or None
 
 
 _CC_TOOLCHAIN_KINDS = {'gcc', 'clang', 'msvc', 'mingw', 'cygwin'}

--- a/src/blade/toolchain.py
+++ b/src/blade/toolchain.py
@@ -529,7 +529,8 @@ class MsvcToolChain(ToolChain):
         if cached is not None:
             return cached
         hardcoded = self._hardcoded_default_linked_libs()
-        detected = _detect_default_linked_libs_msvc(self.cc)
+        detected = _detect_default_linked_libs_msvc(
+            self.cc, self.get_system_include_paths())
         # Union, preserving hardcoded order and appending novel extras.
         seen = set(hardcoded)
         extras = tuple(lib for lib in detected if lib not in seen)
@@ -545,8 +546,18 @@ class MsvcToolChain(ToolChain):
         variants); we list the union so the baseline covers all four
         configurations. lib.exe / link.exe resolves these via the LIB env var
         plus their own search paths.
+
+        The C++ standard library is included via both its import lib
+        (``msvcprt``, the /MD variant the compiler selects with
+        ``/DEFAULTLIB:msvcprt`` whenever a C++ STL header is used) and the
+        static lib (``libcpmt``). Both are needed: ``msvcprt`` exports most
+        ``std::`` symbols, but a handful of data globals -- ``std::cerr``, the
+        locale facet ``id`` static members -- are referenced by their *plain*
+        name (defined inline in the headers) and only ``libcpmt`` carries that
+        form (``msvcprt`` has only the ``__imp_`` import stub). Together they
+        make the whole C++ stdlib surface ambient, as it is for any C++ binary.
         """
-        return ('msvcrt', 'vcruntime', 'ucrt', 'kernel32')
+        return ('msvcrt', 'msvcprt', 'libcpmt', 'vcruntime', 'ucrt', 'kernel32')
 
     def __init__(self, target_arch='auto', msvc_version='auto'):
         super().__init__()
@@ -824,6 +835,17 @@ class MsvcToolChain(ToolChain):
                 return first_path
 
         return tool  # Let it fail with a clear error later
+
+    @property
+    def dumpbin(self) -> str:
+        """Path to ``dumpbin.exe`` -- MSVC's object/library inspector.
+
+        Used by the cc ``check_undefined`` static check as the MSVC analog of
+        ``nm``: ``dumpbin /linkermember`` enumerates an import lib's defined
+        externals and ``dumpbin /symbols`` separates a static lib's undefined
+        from defined externals. Resolved alongside cl / lib / link.
+        """
+        return self._get_msvc_command('dumpbin')
 
     def get_resource_compiler(self):
         """Return path to Windows Resource Compiler (``rc.exe``).
@@ -1304,23 +1326,28 @@ def _classify_link_token(tok: str) -> 'str | None':
     return None
 
 
-def _detect_default_linked_libs_msvc(cc: str) -> 'tuple[str, ...]':
+def _detect_default_linked_libs_msvc(
+        cc: str, include_paths=None) -> 'tuple[str, ...]':
     """Auto-detect MSVC default-linked libraries from compiler directives.
 
-    The MSVC analog of ``-###`` link-line parsing: the CRT headers (and the
-    compiler itself) inject ``#pragma comment(lib, ...)`` directives into every
-    object file, naming the runtime libraries link.exe pulls implicitly -- the
-    CRT variant the runtime flag selected (``/MD`` -> ``MSVCRT``, ``/MT`` ->
-    ``LIBCMT``, debug -> ``*D``) plus ``OLDNAMES``. We compile a trivial
+    The MSVC analog of ``-###`` link-line parsing: the CRT and STL headers (and
+    the compiler itself) inject ``#pragma comment(lib, ...)`` directives into
+    every object file, naming the runtime libraries link.exe pulls implicitly --
+    the CRT variant the runtime flag selected (``/MD`` -> ``MSVCRT``, ``/MT`` ->
+    ``LIBCMT``, debug -> ``*D``), the matching C++ standard library
+    (``MSVCPRT`` / ``LIBCPMT``), and ``OLDNAMES``. We compile a small
     translation unit and read those ``/DEFAULTLIB`` directives back with
     ``dumpbin /directives``.
 
     ``cc`` is the path to ``cl.exe``; ``dumpbin.exe`` is expected alongside it,
-    falling back to PATH. A bare ``int main(){}`` carries the CRT directives
-    without needing any INCLUDE/LIB environment, so this stays fast and
-    self-contained. We compile with ``/MD`` to match blade's default MSVC
-    runtime (``cc.cppflags`` in the builtin config); since the result is unioned
-    with the hardcoded baseline, the exact variant is not critical.
+    falling back to PATH. ``include_paths`` (the toolchain's system include
+    dirs) is needed because the probe ``#include``s a C++ STL header so the
+    compiler injects the C++ standard library's ``/DEFAULTLIB`` -- that lib
+    (``msvcprt``) defines ``std::`` symbols (``_Xlength_error``, the locale
+    facets, iostream globals) that a bare ``int main(){}`` never references. We
+    compile with ``/MD`` to match blade's default MSVC runtime (``cc.cppflags``
+    in the builtin config); since the result is unioned with the hardcoded
+    baseline, the exact variant is not critical.
 
     Returns an empty tuple on any failure (cl/dumpbin missing, compile error,
     no directives) -- the caller falls back to the hardcoded baseline, so there
@@ -1337,17 +1364,26 @@ def _detect_default_linked_libs_msvc(cc: str) -> 'tuple[str, ...]':
             return ()
         dumpbin = found
 
+    # INCLUDE lets the probe pull STL headers (for the C++ stdlib DEFAULTLIB).
+    env = os.environ.copy()
+    if include_paths:
+        env['INCLUDE'] = os.pathsep.join(include_paths)
+
     tmpdir = tempfile.mkdtemp(prefix='blade_msvc_libs_')
     try:
         src = os.path.join(tmpdir, 'probe.cpp')
         obj = os.path.join(tmpdir, 'probe.obj')
         with open(src, 'w') as f:
-            f.write('int main() { return 0; }\n')
+            # <string> pulls the throw helpers, <iostream> the locale/stream
+            # globals -- together they trigger /DEFAULTLIB:msvcprt.
+            f.write('#include <string>\n#include <iostream>\n'
+                    'int main() { std::string s; std::cout << s; '
+                    'return (int)s.size(); }\n')
         try:
             proc = subprocess.run(
                 [cc, '/nologo', '/c', '/MD', src, '/Fo' + obj],
                 capture_output=True, text=True, timeout=30, check=False,
-                cwd=tmpdir)
+                cwd=tmpdir, env=env)
         except (OSError, subprocess.TimeoutExpired):
             return ()
         if proc.returncode != 0 or not os.path.isfile(obj):

--- a/src/blade/toolchain.py
+++ b/src/blade/toolchain.py
@@ -1220,7 +1220,7 @@ def _detect_default_linked_libs(cxx: str) -> 'tuple[str, ...]':
         try:
             os.unlink(tmp_out)
         except OSError:
-            pass
+            pass  # best-effort cleanup; the temp file may already be gone
 
     libs: list[str] = []
     seen: set[str] = set()

--- a/src/blade/toolchain.py
+++ b/src/blade/toolchain.py
@@ -430,31 +430,53 @@ class GccToolChain(ToolChain):
 
     @property
     def default_linked_libs(self) -> 'tuple[str, ...]':
-        """GCC/Clang drivers always pull in libc + the C++ runtime + libgcc-or-
-        compiler-rt helpers + the platform's program-startup objects. macOS
-        bundles libc/libm/libpthread/libdl/libsystem_* into ``libSystem`` and
-        uses ``libc++`` as the C++ runtime; Linux distros expose them
-        individually.
+        """Library aliases the C/C++ driver links implicitly.
 
-        We don't list ``libpthread``/``libm``/``libdl``/``librt`` for Linux:
-        on glibc those are linked only when explicitly requested
-        (``-lpthread`` etc.), which blade already models via ``#pthread`` /
-        ``#m`` / ``#dl`` deps. Including them in the implicit baseline would
-        hide missing ``#xxx`` deps the check is meant to catch.
+        Result is the **union** of:
+          * a hardcoded per-platform minimum (libc / libstdc++ / libgcc_s
+            etc.), so existing workspaces never regress on baseline coverage
+          * what the driver itself reports via ``-###`` parsing, which adds
+            things specific to the host's toolchain (e.g. ``c++`` /
+            ``c++abi`` on macOS, ``stdc++`` on Linux, vendor-specific
+            runtime libs, items introduced by ``-stdlib=libc++`` /
+            cross-compiler / wrapper setups)
+
+        Caching is per-instance: ``-###`` is ~100 ms and the answer is
+        invariant for the toolchain.
+
+        The hardcoded set takes priority on ordering (predictable for
+        link-order-sensitive consumers); auto-detected extras are
+        appended.
+        """
+        cached = getattr(self, '_cached_default_linked_libs', None)
+        if cached is not None:
+            return cached
+        hardcoded = self._hardcoded_default_linked_libs()
+        detected = _detect_default_linked_libs(self.cxx)
+        # Union, preserving hardcoded order and appending novel extras.
+        seen = set(hardcoded)
+        extras = tuple(lib for lib in detected if lib not in seen)
+        result = hardcoded + extras
+        self._cached_default_linked_libs = result
+        return result
+
+    def _hardcoded_default_linked_libs(self) -> 'tuple[str, ...]':
+        """Last-resort defaults when ``-###`` parsing yields nothing.
+
+        We don't list ``libpthread`` / ``libm`` / ``libdl`` / ``librt``
+        for Linux: on glibc those are linked only when explicitly
+        requested (``-lpthread`` etc.), which blade already models via
+        ``#pthread`` / ``#m`` / ``#dl`` deps. Including them in the
+        implicit baseline would hide missing ``#xxx`` deps the check is
+        meant to catch.
 
         For C-only targets the ``stdc++`` / ``c++`` entries contribute
         nothing harmful (they're a no-op for pure C undefined refs).
         """
         if self._target == 'darwin':
-            # libSystem is the unified Apple libc. libc++ for C++ runtime.
-            # libc++abi is usually re-exported through libc++ but we list it
-            # separately to handle ABI symbols (typeinfo, vtables) that may
-            # live there directly.
             return ('System', 'c++', 'c++abi')
         if self._target == 'windows':
-            # GCC on Windows (MinGW): msvcrt is the C runtime.
             return ('msvcrt', 'stdc++', 'gcc_s')
-        # Linux / other ELF: libgcc_s for unwinder + helpers, libc, libstdc++.
         return ('c', 'gcc_s', 'stdc++')
 
 
@@ -1093,6 +1115,99 @@ class MsvcToolChain(ToolChain):
 # ------------------------------------------------------------------
 # Toolchain kind / target helpers
 # ------------------------------------------------------------------
+
+# `-l<name>` tokens that appear on a GCC/Clang link command line but
+# are NOT library names. ld treats these as flags whose syntax happens
+# to start with `-l`. Filter them out of the auto-detected default-
+# linked-libs set.
+_NON_LIB_DASH_L_FLAGS = frozenset({
+    'to_library',   # -lto_library <path>  : selects the LTO plugin (clang on macOS)
+})
+
+
+def _detect_default_linked_libs(cxx: str) -> 'tuple[str, ...]':
+    """Auto-detect default-linked libraries by parsing the driver's link command.
+
+    Runs ``<cxx> -### -x c++ /dev/null -o <tmp>`` -- ``-###`` prints the
+    full command set the driver would execute without running anything,
+    so it's fast and side-effect-free. The link invocation appears as
+    a separate line containing the linker executable (``ld``, ``ld64``,
+    ``ld.lld``, ``lld``, or ``collect2``); we tokenize it (respecting
+    the driver's argument quoting), pull every ``-l<name>``, and filter
+    known non-library flags.
+
+    Returns an empty tuple when:
+      * the driver doesn't accept ``-###`` (very old / non-standard CC)
+      * no link line could be identified
+      * the link line has no ``-l<name>`` tokens
+    -- caller is expected to fall back to a hardcoded per-platform set.
+    """
+    import shlex                # noqa: PLC0415  pulled lazily; cold path
+    import subprocess           # noqa: PLC0415
+    import tempfile             # noqa: PLC0415
+
+    # tempfile path is needed because some drivers refuse to write to
+    # /dev/null when the architecture's linker insists on creating a
+    # mach-o/ELF header structure.
+    with tempfile.NamedTemporaryFile(suffix='.out', delete=False) as f:
+        tmp_out = f.name
+    try:
+        try:
+            proc = subprocess.run(
+                [cxx, '-###', '-x', 'c++', '/dev/null', '-o', tmp_out],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return ()
+        # `-###` writes to stderr on both GCC and Clang.
+        output = proc.stderr or proc.stdout
+    finally:
+        try:
+            os.unlink(tmp_out)
+        except OSError:
+            pass
+
+    libs: list[str] = []
+    seen: set[str] = set()
+    # Linker executable markers, ordered roughly by likelihood:
+    #  * ``ld``      : Apple ld64 / classic GNU ld
+    #  * ``collect2``: GCC's link wrapper that calls the real ld
+    #  * ``lld`` /``ld.lld``: LLVM lld
+    #  * ``ld64``   : explicit ld64 invocations (some toolchains)
+    linker_markers = ('/ld ', '/ld"', '/collect2 ', '/collect2"',
+                      '/ld.lld', '/lld ', '/lld"', '/ld64')
+    for raw_line in output.splitlines():
+        if not any(marker in raw_line for marker in linker_markers):
+            continue
+        try:
+            tokens = shlex.split(raw_line, posix=True)
+        except ValueError:
+            # Malformed quoting -- skip this line.
+            continue
+        for tok in tokens:
+            if not tok.startswith('-l') or len(tok) <= 2:
+                continue
+            # ``-l:libfoo.so.1`` is GNU ld's literal-name form (resolves
+            # to a specific filename rather than a library alias). Skip:
+            # we can't represent it as a blade ``#alias``.
+            if tok[2] == ':':
+                continue
+            name = tok[2:]
+            if name in _NON_LIB_DASH_L_FLAGS:
+                continue
+            if name in seen:
+                continue
+            seen.add(name)
+            libs.append(name)
+        if libs:
+            # First link line with `-l` tokens wins; subsequent lines
+            # would be informational (e.g. echoed copy of the command).
+            break
+    return tuple(libs)
+
 
 _CC_TOOLCHAIN_KINDS = {'gcc', 'clang', 'msvc', 'mingw', 'cygwin'}
 

--- a/src/tests/unit/cc_check_undefined_msvc_test.py
+++ b/src/tests/unit/cc_check_undefined_msvc_test.py
@@ -20,7 +20,7 @@ import os
 import subprocess
 import sys
 import unittest
-from unittest import mock
+import unittest.mock as mock
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
@@ -138,8 +138,11 @@ class DumpbinExtractExternalsTest(unittest.TestCase):
         self.assertEqual(undef, {'?helper@@YAHXZ'})
 
     def test_dumpbin_missing_returns_empty(self):
+        # Patch console.error so the expected "dumpbin not found" diagnostic
+        # doesn't print as noise during the test run.
         with mock.patch.object(subprocess, 'check_output',
-                               side_effect=FileNotFoundError(2, 'no dumpbin')):
+                               side_effect=FileNotFoundError(2, 'no dumpbin')), \
+             mock.patch.object(builtin_tools.console, 'error'):
             self.assertEqual(
                 builtin_tools._dumpbin_extract_externals('dumpbin', 'a.lib'),
                 (set(), set()))

--- a/src/tests/unit/cc_check_undefined_msvc_test.py
+++ b/src/tests/unit/cc_check_undefined_msvc_test.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for the MSVC side of the cc check_undefined static check.
+
+On MSVC the archives are COFF ``.lib`` files and ``nm`` is unavailable, so
+symbols are read with ``dumpbin``:
+
+  * system import libs -> ``dumpbin /linkermember`` gives the defined externals
+    (system_symbols._dumpbin_defined_symbols),
+  * a target's own ``.lib`` -> ``dumpbin /symbols`` separates undefined from
+    defined externals (builtin_tools._dumpbin_extract_externals).
+
+These tests feed canned dumpbin output (so they run on any platform) and pin
+the parsers, plus the MSVC dispatch in resolve_lib_paths / _nm_* wrappers.
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import builtin_tools  # noqa: E402
+from blade import system_symbols  # noqa: E402
+
+
+# A realistic `dumpbin /linkermember:1` dump of an import lib: header rows, the
+# "<N> public symbols" line, a blank line, then "<hex-offset> <symbol>" rows.
+_LINKERMEMBER_OUT = """\
+Microsoft (R) COFF/PE Dumper
+
+Dump of file kernel32.lib
+
+File Type: LIBRARY
+
+Archive member name at 8: /
+         uid
+         gid
+       0 mode
+   128B4 size
+    2795 public symbols
+
+    251F2 __IMPORT_DESCRIPTOR_KERNEL32
+    25956 AddConsoleAliasA
+    25956 __imp_AddConsoleAliasA
+    25A32 AddDllDirectory
+"""
+
+# A realistic `dumpbin /symbols` dump of a static lib with one undefined ref,
+# two definitions, plus non-external noise that must be ignored.
+_SYMBOLS_OUT = """\
+Microsoft (R) COFF/PE Dumper
+
+Dump of file a.lib
+
+COFF SYMBOL TABLE
+000 00000000 SECT1  notype       Static       | .text
+007 00000000 SECT1  notype       Label        | $LN3
+008 00000000 UNDEF  notype ()    External     | ?helper@@YAHXZ (int __cdecl helper(void))
+009 00000000 SECT3  notype ()    External     | ?use@@YAHXZ (int __cdecl use(void))
+00A 00000020 SECT3  notype ()    External     | ?defined_here@@YAHXZ (int __cdecl defined_here(void))
+"""
+
+
+class IsHexOffsetTest(unittest.TestCase):
+    def test_accepts_hex(self):
+        self.assertTrue(system_symbols._is_hexoffset('251F2'))
+        self.assertTrue(system_symbols._is_hexoffset('0'))
+
+    def test_rejects_non_hex(self):
+        self.assertFalse(system_symbols._is_hexoffset('public'))
+        self.assertFalse(system_symbols._is_hexoffset('__imp_foo'))
+        self.assertFalse(system_symbols._is_hexoffset(''))
+
+
+class DumpbinDefinedSymbolsTest(unittest.TestCase):
+    """system_symbols._dumpbin_defined_symbols parses /linkermember output."""
+
+    def _run(self, text):
+        with mock.patch.object(subprocess, 'check_output', return_value=text):
+            return system_symbols._dumpbin_defined_symbols('dumpbin', 'kernel32.lib')
+
+    def test_collects_symbols_after_public_symbols_line(self):
+        self.assertEqual(
+            self._run(_LINKERMEMBER_OUT),
+            {'__IMPORT_DESCRIPTOR_KERNEL32', 'AddConsoleAliasA',
+             '__imp_AddConsoleAliasA', 'AddDllDirectory'})
+
+    def test_header_rows_before_marker_are_ignored(self):
+        # 'size', 'mode', etc. (hex-prefixed header rows) precede the marker and
+        # must not leak in.
+        syms = self._run(_LINKERMEMBER_OUT)
+        self.assertNotIn('size', syms)
+        self.assertNotIn('mode', syms)
+
+    def test_dumpbin_failure_returns_empty(self):
+        with mock.patch.object(subprocess, 'check_output',
+                               side_effect=FileNotFoundError(2, 'no dumpbin')):
+            self.assertEqual(
+                system_symbols._dumpbin_defined_symbols('dumpbin', 'x.lib'), set())
+
+    def test_called_process_error_returns_empty(self):
+        with mock.patch.object(subprocess, 'check_output',
+                               side_effect=subprocess.CalledProcessError(1, 'dumpbin')):
+            self.assertEqual(
+                system_symbols._dumpbin_defined_symbols('dumpbin', 'x.lib'), set())
+
+
+class DumpbinExtractExternalsTest(unittest.TestCase):
+    """builtin_tools._dumpbin_extract_externals parses /symbols output into
+    (undefined, defined)."""
+
+    def _run(self, text):
+        with mock.patch.object(subprocess, 'check_output',
+                               return_value=text.encode('utf-8')):
+            return builtin_tools._dumpbin_extract_externals('dumpbin', 'a.lib')
+
+    def test_splits_undefined_and_defined(self):
+        undef, defd = self._run(_SYMBOLS_OUT)
+        self.assertEqual(undef, {'?helper@@YAHXZ'})
+        self.assertEqual(defd, {'?use@@YAHXZ', '?defined_here@@YAHXZ'})
+
+    def test_static_and_label_rows_ignored(self):
+        # '.text' (Static) and '$LN3' (Label) are not External -> dropped.
+        undef, defd = self._run(_SYMBOLS_OUT)
+        self.assertNotIn('.text', undef | defd)
+        self.assertNotIn('$LN3', undef | defd)
+
+    def test_demangled_comment_dropped(self):
+        # The "(int __cdecl helper(void))" comment after the name must not be
+        # part of the symbol.
+        undef, _ = self._run(_SYMBOLS_OUT)
+        self.assertEqual(undef, {'?helper@@YAHXZ'})
+
+    def test_dumpbin_missing_returns_empty(self):
+        with mock.patch.object(subprocess, 'check_output',
+                               side_effect=FileNotFoundError(2, 'no dumpbin')):
+            self.assertEqual(
+                builtin_tools._dumpbin_extract_externals('dumpbin', 'a.lib'),
+                (set(), set()))
+
+
+class _FakeMsvcToolchain:
+    """Minimal toolchain stub for the MSVC dispatch tests."""
+    cc = 'cl.exe'
+    dumpbin = 'dumpbin.exe'
+    target_os = 'windows'
+
+    def __init__(self, lib_paths):
+        self._lib_paths = lib_paths
+
+    def cc_is(self, vendor):
+        return vendor == 'msvc'
+
+    def get_system_lib_paths(self):
+        return self._lib_paths
+
+
+class ResolveLibPathsMsvcTest(unittest.TestCase):
+    """resolve_lib_paths searches the toolchain's lib dirs for <alias>.lib on
+    MSVC (cl has no -print-file-name)."""
+
+    def test_finds_lib_in_search_paths(self):
+        tc = _FakeMsvcToolchain([r'C:\sdk\lib', r'C:\msvc\lib'])
+        hit = os.path.join(r'C:\msvc\lib', 'oldnames.lib')
+        with mock.patch('os.path.isfile', side_effect=lambda p: p == hit), \
+             mock.patch('os.path.realpath', side_effect=lambda p: p):
+            self.assertEqual(system_symbols.resolve_lib_paths(tc, 'oldnames'), [hit])
+
+    def test_unresolved_returns_empty(self):
+        tc = _FakeMsvcToolchain([r'C:\sdk\lib'])
+        with mock.patch('os.path.isfile', return_value=False):
+            self.assertEqual(system_symbols.resolve_lib_paths(tc, 'nope'), [])
+
+    def test_nm_defined_externals_dispatches_to_dumpbin(self):
+        tc = _FakeMsvcToolchain([])
+        with mock.patch.object(system_symbols, '_dumpbin_defined_symbols',
+                               return_value={'printf'}) as m:
+            out = system_symbols._nm_defined_externals(r'C:\x\msvcrt.lib', tc)
+        self.assertEqual(out, {'printf'})
+        m.assert_called_once_with('dumpbin.exe', r'C:\x\msvcrt.lib')
+
+
+class NmExtractExternalsDispatchTest(unittest.TestCase):
+    """builtin_tools._nm_extract_externals routes to dumpbin when given one."""
+
+    def test_dumpbin_path_routes_to_dumpbin(self):
+        with mock.patch.object(builtin_tools, '_dumpbin_extract_externals',
+                               return_value=({'u'}, {'d'})) as m:
+            out = builtin_tools._nm_extract_externals('a.lib', dumpbin='dumpbin.exe')
+        self.assertEqual(out, ({'u'}, {'d'}))
+        m.assert_called_once_with('dumpbin.exe', 'a.lib')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/unit/cc_check_undefined_test.py
+++ b/src/tests/unit/cc_check_undefined_test.py
@@ -551,5 +551,109 @@ class CheckUndefinedDiffTest(unittest.TestCase):
         self.assertEqual(rc, 1)
 
 
+# ----------------------------------------------------------------------------
+# Batch tool severity behavior (experimental warning default)
+# ----------------------------------------------------------------------------
+
+
+class CheckUndefinedBatchSeverityTest(unittest.TestCase):
+    """Pin the project-global severity contract of
+    ``generate_cc_check_undefined_batch``:
+
+      * ``severity='warning'`` (the experimental default): findings emit via
+        ``console.warning``, no failure, stamp is written.
+      * ``severity='error'``: findings emit via ``console.error``, return is 1,
+        no stamp.
+    """
+
+    def _run(self, severity, missing_symbol='_real_missing'):
+        """Drive the batch tool with one synthetic spec that has an
+        unresolved symbol; return (rc, stamp_exists, warnings, errors).
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            target_syms = os.path.join(tmp, 'target.syms')
+            with open(target_syms, 'w', encoding='utf-8') as f:
+                f.write('# blade archive-symbols cache v1\n#U\n')
+                f.write(missing_symbol + '\n#D\n')
+            allow_file = os.path.join(tmp, 'allow')
+            with open(allow_file, 'w', encoding='utf-8') as f:
+                pass
+            manifest = os.path.join(tmp, 'manifest.json')
+            import json as _json
+            with open(manifest, 'w', encoding='utf-8') as f:
+                _json.dump([{
+                    'target_label': 'foo:bar',
+                    'target_syms': target_syms,
+                    'dep_syms': [],
+                    'sys_caches': [],
+                    'allow_file': allow_file,
+                }], f)
+            stamp = os.path.join(tmp, 'stamp')
+            warnings, errors = [], []
+            with mock.patch.object(builtin_tools.console, 'warning',
+                                   side_effect=warnings.append), \
+                 mock.patch.object(builtin_tools.console, 'error',
+                                   side_effect=errors.append):
+                rc = builtin_tools.generate_cc_check_undefined_batch(
+                    [stamp, manifest], severity=severity)
+            return rc, os.path.exists(stamp), warnings, errors
+
+    def test_warning_severity_logs_and_continues(self):
+        rc, stamp_exists, warnings, errors = self._run('warning')
+        self.assertIsNone(rc)
+        self.assertTrue(stamp_exists, 'stamp must be written on warning path')
+        self.assertEqual(errors, [], 'no errors on warning path')
+        # At minimum: the per-target header, the one symbol, and the summary.
+        self.assertTrue(any('foo:bar' in w for w in warnings))
+        self.assertTrue(any('_real_missing' in w for w in warnings))
+
+    def test_error_severity_fails_and_skips_stamp(self):
+        rc, stamp_exists, warnings, errors = self._run('error')
+        self.assertEqual(rc, 1)
+        self.assertFalse(stamp_exists, 'stamp must NOT be written on error path')
+        self.assertEqual(warnings, [], 'no warnings on error path')
+        self.assertTrue(any('foo:bar' in e for e in errors))
+
+    def test_clean_run_writes_stamp_at_either_severity(self):
+        """No unresolved symbols -> stamp written, no diagnostics, return is
+        None. Severity is irrelevant when there's nothing to report."""
+        for severity in ('warning', 'error'):
+            with self.subTest(severity=severity), \
+                 tempfile.TemporaryDirectory() as tmp:
+                target_syms = os.path.join(tmp, 'target.syms')
+                with open(target_syms, 'w', encoding='utf-8') as f:
+                    f.write('# blade archive-symbols cache v1\n#U\n#D\n')
+                allow_file = os.path.join(tmp, 'allow')
+                with open(allow_file, 'w', encoding='utf-8') as f:
+                    pass
+                manifest = os.path.join(tmp, 'manifest.json')
+                import json as _json
+                with open(manifest, 'w', encoding='utf-8') as f:
+                    _json.dump([{
+                        'target_label': 'foo:bar',
+                        'target_syms': target_syms,
+                        'dep_syms': [], 'sys_caches': [],
+                        'allow_file': allow_file,
+                    }], f)
+                stamp = os.path.join(tmp, 'stamp')
+                rc = builtin_tools.generate_cc_check_undefined_batch(
+                    [stamp, manifest], severity=severity)
+                self.assertIsNone(rc)
+                self.assertTrue(os.path.exists(stamp))
+
+
+class CheckUndefinedSeverityConfigTest(unittest.TestCase):
+    """Template default + help text for the new severity config option."""
+
+    def setUp(self):
+        self._template = config._CONFIG_TEMPLATE['cc_library_config']
+
+    def test_severity_defaults_to_warning(self):
+        self.assertEqual(self._template['check_undefined_severity'], 'warning')
+
+    def test_help_text_marks_experimental(self):
+        self.assertIn('EXPERIMENTAL', self._template['check_undefined__help__'])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/tests/unit/detect_default_linked_libs_test.py
+++ b/src/tests/unit/detect_default_linked_libs_test.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Unit tests for _detect_default_linked_libs (PR #1233 follow-up).
+
+"""Tests for the ``-### -x c++`` driver-output parser that supplements
+``GccToolChain.default_linked_libs`` with toolchain-specific entries
+the hardcoded list might miss.
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import toolchain  # noqa: E402
+from blade.toolchain import _detect_default_linked_libs  # noqa: E402
+
+
+def _fake_run(stderr_text):
+    """Build a ``subprocess.run`` replacement that returns the given stderr."""
+    def runner(*args, **kwargs):
+        m = mock.Mock()
+        m.stderr = stderr_text
+        m.stdout = ''
+        m.returncode = 0
+        return m
+    return runner
+
+
+class DetectDefaultLinkedLibsTest(unittest.TestCase):
+    """Cover the parser's handling of real driver output shapes."""
+
+    def _run_with(self, stderr_text):
+        """Invoke the detector with a patched subprocess.run."""
+        with mock.patch.object(subprocess, 'run',
+                               side_effect=_fake_run(stderr_text)):
+            return _detect_default_linked_libs('cxx-stub')
+
+    # ---- macOS clang shape ----
+
+    def test_macos_clang_link_line(self):
+        """Apple Clang quotes each argument; the linker is ``ld`` from
+        the Xcode toolchain. ``-lto_library`` is a flag (selects the LTO
+        plugin), not a library."""
+        stderr = (
+            ' "/Applications/Xcode.app/Contents/Developer/Toolchains/'
+            'XcodeDefault.xctoolchain/usr/bin/clang" "-cc1" ...\n'
+            ' "/Applications/Xcode.app/Contents/Developer/Toolchains/'
+            'XcodeDefault.xctoolchain/usr/bin/ld" "-demangle" '
+            '"-lto_library" "/Applications/.../libLTO.dylib" '
+            '"-dynamic" "-arch" "arm64" "-o" "/tmp/out" "-lc++" '
+            '"-lSystem"\n'
+        )
+        self.assertEqual(self._run_with(stderr), ('c++', 'System'))
+
+    def test_macos_lto_library_filtered(self):
+        """``-lto_library`` must not leak in as a library name."""
+        stderr = ' "/usr/bin/ld" "-lto_library" "/path/libLTO.dylib" "-lSystem"\n'
+        self.assertEqual(self._run_with(stderr), ('System',))
+
+    # ---- Linux GCC shape ----
+
+    def test_linux_gcc_collect2_line(self):
+        """GCC drivers invoke ``collect2`` (the link wrapper) with
+        unquoted args. -lgcc appears twice (GCC's standard link-group
+        convention); dedupe but preserve first-seen order."""
+        stderr = (
+            ' /usr/libexec/gcc/x86_64-linux-gnu/13/cc1plus ...\n'
+            ' /usr/libexec/gcc/x86_64-linux-gnu/13/collect2 -plugin '
+            '/usr/libexec/.../liblto_plugin.so --eh-frame-hdr '
+            '-m elf_x86_64 -dynamic-linker /lib64/ld-linux-x86-64.so.2 '
+            '/tmp/cc.o -lstdc++ -lm -lgcc_s -lgcc -lc -lgcc_s -lgcc\n'
+        )
+        self.assertEqual(self._run_with(stderr),
+                         ('stdc++', 'm', 'gcc_s', 'gcc', 'c'))
+
+    def test_linux_lld_link_line(self):
+        """LLVM's lld is also detected (some setups use ``ld.lld``)."""
+        stderr = ' /usr/bin/ld.lld -o /tmp/out /tmp/cc.o -lc++ -lc\n'
+        self.assertEqual(self._run_with(stderr), ('c++', 'c'))
+
+    # ---- Special / edge cases ----
+
+    def test_literal_filename_l_form_skipped(self):
+        """GNU ld's ``-l:libfoo.so.1`` resolves to a specific filename
+        rather than a library alias; we can't represent it as a blade
+        ``#alias`` so we skip it."""
+        stderr = ' /usr/bin/ld -o /tmp/out -lc -l:libgcc_s.so.1\n'
+        self.assertEqual(self._run_with(stderr), ('c',))
+
+    def test_only_first_link_line_consumed(self):
+        """Some drivers echo the command multiple times (e.g. a banner
+        followed by the actual invocation). Take only the first link
+        line that contains ``-l<name>`` tokens; ignore the rest."""
+        stderr = (
+            ' /usr/bin/ld -lFIRST -lSYS\n'
+            ' /usr/bin/ld -lSECOND -lSYS\n'
+        )
+        self.assertEqual(self._run_with(stderr), ('FIRST', 'SYS'))
+
+    def test_non_link_line_with_dash_l_substring_ignored(self):
+        """Compiler-frontend lines often contain things like
+        ``-disable-llvm-verifier`` -- the ``-l`` substring inside an
+        identifier must not be misread as a library flag."""
+        stderr = (
+            ' /usr/bin/cc1 "-disable-llvm-verifier" "-mllvm" '
+            '"-enable-linkonceodr-outlining"\n'
+        )
+        # No linker marker -> nothing extracted.
+        self.assertEqual(self._run_with(stderr), ())
+
+    def test_dash_l_alone_skipped(self):
+        """A bare ``-l`` (no name) is malformed; ignore."""
+        stderr = ' /usr/bin/ld -l -lSystem\n'
+        self.assertEqual(self._run_with(stderr), ('System',))
+
+    # ---- Failure modes ----
+
+    def test_compiler_not_found_returns_empty(self):
+        """If the driver isn't on PATH, the parser must not raise."""
+        def boom(*args, **kwargs):
+            raise FileNotFoundError(2, 'not found', args[0][0])
+        with mock.patch.object(subprocess, 'run', side_effect=boom):
+            self.assertEqual(_detect_default_linked_libs('no-such-cxx'), ())
+
+    def test_timeout_returns_empty(self):
+        """A hung driver must not block blade indefinitely."""
+        def slow(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd='cxx', timeout=15)
+        with mock.patch.object(subprocess, 'run', side_effect=slow):
+            self.assertEqual(_detect_default_linked_libs('cxx'), ())
+
+    def test_no_link_line_returns_empty(self):
+        """Driver output that contains no recognizable linker invocation
+        (e.g. a syntax-error compile that never reached link) yields ()."""
+        stderr = ' /usr/bin/cc1 "-cc1" "-E" "/dev/null"\n'
+        self.assertEqual(self._run_with(stderr), ())
+
+    def test_malformed_quoting_skipped(self):
+        """A line that fails ``shlex.split`` (mismatched quotes) is
+        skipped rather than crashing the detector."""
+        stderr = (
+            ' /usr/bin/ld "unclosed -lBAD\n'
+            ' /usr/bin/ld -lGOOD\n'
+        )
+        # Mismatched quote on the first line -> skipped; the second
+        # well-formed line provides the answer.
+        self.assertEqual(self._run_with(stderr), ('GOOD',))
+
+
+class GccToolChainDefaultLinkedLibsTest(unittest.TestCase):
+    """Pin the union semantic: hardcoded as the floor, auto-detect as the
+    supplement; novel extras appended after the hardcoded set."""
+
+    def _tc(self, target_os, cxx='cxx-stub'):
+        tc = toolchain.GccToolChain.__new__(toolchain.GccToolChain)
+        tc._target = target_os
+        tc.cxx = cxx
+        return tc
+
+    def test_union_no_extras(self):
+        """When auto-detect is a strict subset of hardcoded, the result
+        equals the hardcoded set (preserving its order)."""
+        tc = self._tc('darwin')
+        with mock.patch.object(toolchain, '_detect_default_linked_libs',
+                               return_value=('c++', 'System')):
+            self.assertEqual(tc.default_linked_libs,
+                             ('System', 'c++', 'c++abi'))
+
+    def test_union_with_extras(self):
+        """Anything auto-detect finds that hardcoded missed gets
+        appended after the hardcoded prefix."""
+        tc = self._tc('linux')
+        with mock.patch.object(toolchain, '_detect_default_linked_libs',
+                               return_value=('stdc++', 'm', 'gcc_s', 'gcc', 'c')):
+            self.assertEqual(tc.default_linked_libs,
+                             # hardcoded: c, gcc_s, stdc++
+                             # extras (new): m, gcc
+                             ('c', 'gcc_s', 'stdc++', 'm', 'gcc'))
+
+    def test_detection_empty_uses_hardcoded(self):
+        """When auto-detect fails (returns ()), the hardcoded baseline
+        alone is returned (the regression-safe path)."""
+        tc = self._tc('linux')
+        with mock.patch.object(toolchain, '_detect_default_linked_libs',
+                               return_value=()):
+            self.assertEqual(tc.default_linked_libs,
+                             ('c', 'gcc_s', 'stdc++'))
+
+    def test_result_cached_after_first_call(self):
+        """The detector is ~100 ms; a per-instance cache ensures we run
+        it at most once for the toolchain's lifetime."""
+        tc = self._tc('linux')
+        with mock.patch.object(toolchain, '_detect_default_linked_libs',
+                               return_value=('extra1',)) as m:
+            _ = tc.default_linked_libs
+            _ = tc.default_linked_libs
+            _ = tc.default_linked_libs
+            self.assertEqual(m.call_count, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/unit/detect_default_linked_libs_test.py
+++ b/src/tests/unit/detect_default_linked_libs_test.py
@@ -20,6 +20,8 @@ sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
 
 from blade import toolchain  # noqa: E402
 from blade.toolchain import _detect_default_linked_libs  # noqa: E402
+from blade.toolchain import _classify_msvc_directive  # noqa: E402
+from blade.toolchain import _detect_default_linked_libs_msvc  # noqa: E402
 
 
 def _fake_run(stderr_text):
@@ -245,6 +247,143 @@ class GccToolChainDefaultLinkedLibsTest(unittest.TestCase):
         with mock.patch.object(toolchain, '_detect_default_linked_libs',
                                return_value=('extra1',)) as m:
             _ = tc.default_linked_libs
+            _ = tc.default_linked_libs
+            _ = tc.default_linked_libs
+            self.assertEqual(m.call_count, 1)
+
+
+class ClassifyMsvcDirectiveTest(unittest.TestCase):
+    """The ``dumpbin /directives`` line classifier (MSVC analog of the
+    GCC ``-l`` token classifier). Pure function -- runs on any platform."""
+
+    def test_bare_defaultlib(self):
+        self.assertEqual(_classify_msvc_directive('   /DEFAULTLIB:MSVCRT'), 'msvcrt')
+
+    def test_quoted_with_lib_suffix(self):
+        """Some directives are quoted and carry the ``.lib`` suffix; strip both."""
+        self.assertEqual(_classify_msvc_directive('/DEFAULTLIB:"libcmt.lib"'), 'libcmt')
+
+    def test_oldnames(self):
+        self.assertEqual(_classify_msvc_directive('/DEFAULTLIB:OLDNAMES'), 'oldnames')
+
+    def test_banner_line_ignored(self):
+        self.assertIsNone(_classify_msvc_directive('   Linker Directives'))
+        self.assertIsNone(_classify_msvc_directive('   ------------------'))
+
+    def test_other_directives_ignored(self):
+        """``/FAILIFMISMATCH`` and ``/merge`` are linker directives but not
+        default libraries."""
+        self.assertIsNone(_classify_msvc_directive(
+            '/FAILIFMISMATCH:_MSC_VER=1900'))
+        self.assertIsNone(_classify_msvc_directive('  /merge:.foo=.bar'))
+
+    def test_blank_and_garbage(self):
+        self.assertIsNone(_classify_msvc_directive(''))
+        self.assertIsNone(_classify_msvc_directive('/DEFAULTLIB:'))
+        self.assertIsNone(_classify_msvc_directive('/DEFAULTLIB:""'))
+
+
+def _fake_msvc_run(compile_rc, directives_text):
+    """Build a ``subprocess.run`` replacement: first call is the cl compile,
+    second is ``dumpbin /directives``. (The ``/Fo`` object check is satisfied
+    by patching ``os.path.isfile`` in the caller, so no real file is needed.)"""
+    state = {'calls': 0}
+
+    def runner(argv, *args, **kwargs):
+        state['calls'] += 1
+        m = mock.Mock()
+        m.stderr = ''
+        if state['calls'] == 1:               # cl compile
+            m.returncode = compile_rc
+            m.stdout = ''
+        else:                                  # dumpbin /directives
+            m.returncode = 0
+            m.stdout = directives_text
+        return m
+    return runner
+
+
+class DetectDefaultLinkedLibsMsvcTest(unittest.TestCase):
+    """The end-to-end MSVC detector with cl/dumpbin mocked, so it runs on
+    any platform."""
+
+    _DIRECTIVES = (
+        '\n'
+        'Dump of file probe.obj\n\n'
+        '   Linker Directives\n'
+        '   -----------------\n'
+        '   /DEFAULTLIB:MSVCRT\n'
+        '   /DEFAULTLIB:OLDNAMES\n'
+        '   /FAILIFMISMATCH:_CRT_STDIO_ISO_WIDE_SPECIFIERS=0\n'
+    )
+
+    def _run(self, runner):
+        # Pretend dumpbin.exe sits next to cl.exe so resolution succeeds.
+        with mock.patch('os.path.isfile', return_value=True), \
+             mock.patch.object(subprocess, 'run', side_effect=runner):
+            return _detect_default_linked_libs_msvc(r'C:\msvc\bin\cl.exe')
+
+    def test_parses_defaultlib_directives(self):
+        """Pulls the CRT + oldnames out of the directive dump; ignores the
+        banner and ``/FAILIFMISMATCH``."""
+        self.assertEqual(
+            self._run(_fake_msvc_run(0, self._DIRECTIVES)),
+            ('msvcrt', 'oldnames'))
+
+    def test_compile_failure_returns_empty(self):
+        self.assertEqual(self._run(_fake_msvc_run(2, '')), ())
+
+    def test_no_directives_returns_empty(self):
+        self.assertEqual(
+            self._run(_fake_msvc_run(0, 'Dump of file probe.obj\n\nSummary\n')),
+            ())
+
+    def test_cl_not_found_returns_empty(self):
+        def boom(*args, **kwargs):
+            raise FileNotFoundError(2, 'not found')
+        self.assertEqual(self._run(boom), ())
+
+    def test_timeout_returns_empty(self):
+        def slow(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd='cl', timeout=30)
+        self.assertEqual(self._run(slow), ())
+
+    def test_dumpbin_missing_returns_empty(self):
+        """No dumpbin next to cl and none on PATH -> empty (no crash)."""
+        with mock.patch('os.path.isfile', return_value=False), \
+             mock.patch('shutil.which', return_value=None):
+            self.assertEqual(
+                _detect_default_linked_libs_msvc(r'C:\msvc\bin\cl.exe'), ())
+
+
+class MsvcToolChainDefaultLinkedLibsTest(unittest.TestCase):
+    """The union semantic on MSVC: hardcoded floor + detected extras."""
+
+    def _tc(self, cc='cl-stub'):
+        tc = toolchain.MsvcToolChain.__new__(toolchain.MsvcToolChain)
+        tc.cc = cc
+        return tc
+
+    def test_union_appends_oldnames(self):
+        """``oldnames`` (and any /MT ``libcmt``) is appended after the
+        hardcoded prefix; the already-present ``msvcrt`` is not duplicated."""
+        tc = self._tc()
+        with mock.patch.object(toolchain, '_detect_default_linked_libs_msvc',
+                               return_value=('msvcrt', 'oldnames')):
+            self.assertEqual(tc.default_linked_libs,
+                             ('msvcrt', 'vcruntime', 'ucrt', 'kernel32', 'oldnames'))
+
+    def test_detection_empty_uses_hardcoded(self):
+        tc = self._tc()
+        with mock.patch.object(toolchain, '_detect_default_linked_libs_msvc',
+                               return_value=()):
+            self.assertEqual(tc.default_linked_libs,
+                             ('msvcrt', 'vcruntime', 'ucrt', 'kernel32'))
+
+    def test_result_cached(self):
+        tc = self._tc()
+        with mock.patch.object(toolchain, '_detect_default_linked_libs_msvc',
+                               return_value=('oldnames',)) as m:
             _ = tc.default_linked_libs
             _ = tc.default_linked_libs
             self.assertEqual(m.call_count, 1)

--- a/src/tests/unit/detect_default_linked_libs_test.py
+++ b/src/tests/unit/detect_default_linked_libs_test.py
@@ -13,7 +13,7 @@ import os
 import subprocess
 import sys
 import unittest
-from unittest import mock
+import unittest.mock as mock
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))

--- a/src/tests/unit/detect_default_linked_libs_test.py
+++ b/src/tests/unit/detect_default_linked_libs_test.py
@@ -60,9 +60,54 @@ class DetectDefaultLinkedLibsTest(unittest.TestCase):
         self.assertEqual(self._run_with(stderr), ('c++', 'System'))
 
     def test_macos_lto_library_filtered(self):
-        """``-lto_library`` must not leak in as a library name."""
+        """``-lto_library`` must not leak in as a library name, AND its
+        following path argument must not be picked up as a direct-path
+        library entry."""
         stderr = ' "/usr/bin/ld" "-lto_library" "/path/libLTO.dylib" "-lSystem"\n'
         self.assertEqual(self._run_with(stderr), ('System',))
+
+    def test_macos_direct_path_compiler_rt(self):
+        """Apple Clang always links compiler-rt as a direct path, not via
+        ``-l``. Its symbols (compiler builtins, soft-float, atomics) need
+        to land in the baseline. The detector picks it up alongside the
+        ``-l`` aliases."""
+        stderr = (
+            ' "/usr/bin/ld" "-lto_library" "/path/libLTO.dylib" "-arch" '
+            '"arm64" "-o" "/tmp/out" "/tmp/cc.o" "-lc++" "-lSystem" '
+            '"/Applications/Xcode.app/.../libclang_rt.osx.a"\n'
+        )
+        self.assertEqual(
+            self._run_with(stderr),
+            ('c++', 'System',
+             '/Applications/Xcode.app/.../libclang_rt.osx.a'),
+        )
+
+    def test_linux_gcc_plugin_arg_skipped(self):
+        """GCC's link line contains ``-plugin /path/to/liblto_plugin.so``;
+        the path is a tool plugin, NOT a default-linked library. The
+        ``-plugin`` flag is in the skip-next-arg set so the plugin path
+        is consumed without being misclassified."""
+        stderr = (
+            ' /usr/libexec/.../collect2 -plugin '
+            '/usr/libexec/.../liblto_plugin.so -dynamic-linker '
+            '/lib/ld-linux.so.2 /tmp/cc.o -lstdc++ -lm -lc\n'
+        )
+        self.assertEqual(self._run_with(stderr), ('stdc++', 'm', 'c'))
+
+    def test_output_path_after_dash_o_skipped(self):
+        """``-o /tmp/output`` must not pick up ``/tmp/output`` as a
+        library entry (it doesn't end in a lib extension anyway, but
+        the explicit skip is defense in depth)."""
+        stderr = ' /usr/bin/ld -o /tmp/_blade_test.so -lc\n'
+        # /tmp/_blade_test.so contains '.so' but it's the -o argument.
+        self.assertEqual(self._run_with(stderr), ('c',))
+
+    def test_compiled_user_object_not_picked_up(self):
+        """The user's compiled .o (something like ``/tmp/cc<hash>.o``)
+        is on the link line as a positional input. It ends in ``.o``
+        so the direct-path filter excludes it."""
+        stderr = ' /usr/bin/ld /tmp/ccABCDE.o -lc\n'
+        self.assertEqual(self._run_with(stderr), ('c',))
 
     # ---- Linux GCC shape ----
 

--- a/src/tests/unit/detect_default_linked_libs_test.py
+++ b/src/tests/unit/detect_default_linked_libs_test.py
@@ -359,9 +359,18 @@ class DetectDefaultLinkedLibsMsvcTest(unittest.TestCase):
 class MsvcToolChainDefaultLinkedLibsTest(unittest.TestCase):
     """The union semantic on MSVC: hardcoded floor + detected extras."""
 
+    # The hardcoded MSVC floor: C runtime + C++ stdlib (import + static) +
+    # vcruntime + ucrt + kernel32.
+    _FLOOR = ('msvcrt', 'msvcprt', 'libcpmt', 'vcruntime', 'ucrt', 'kernel32')
+
     def _tc(self, cc='cl-stub'):
         tc = toolchain.MsvcToolChain.__new__(toolchain.MsvcToolChain)
         tc.cc = cc
+        # default_linked_libs passes the system include paths to the detector;
+        # stub the installation state so get_system_include_paths() returns [].
+        tc._msvc_path = None
+        tc._sdk_path = None
+        tc._sdk_ver = None
         return tc
 
     def test_union_appends_oldnames(self):
@@ -370,15 +379,13 @@ class MsvcToolChainDefaultLinkedLibsTest(unittest.TestCase):
         tc = self._tc()
         with mock.patch.object(toolchain, '_detect_default_linked_libs_msvc',
                                return_value=('msvcrt', 'oldnames')):
-            self.assertEqual(tc.default_linked_libs,
-                             ('msvcrt', 'vcruntime', 'ucrt', 'kernel32', 'oldnames'))
+            self.assertEqual(tc.default_linked_libs, self._FLOOR + ('oldnames',))
 
     def test_detection_empty_uses_hardcoded(self):
         tc = self._tc()
         with mock.patch.object(toolchain, '_detect_default_linked_libs_msvc',
                                return_value=()):
-            self.assertEqual(tc.default_linked_libs,
-                             ('msvcrt', 'vcruntime', 'ucrt', 'kernel32'))
+            self.assertEqual(tc.default_linked_libs, self._FLOOR)
 
     def test_result_cached(self):
         tc = self._tc()


### PR DESCRIPTION
## Summary

Follow-up to #1233. \`GccToolChain.default_linked_libs\` previously returned a hardcoded per-platform tuple (\`('c', 'gcc_s', 'stdc++')\` for Linux; \`('System', 'c++', 'c++abi')\` for macOS; etc.). That drifts on custom toolchains:

- \`-stdlib=libc++\` vs libstdc++
- vendor / version differences (Apple Clang vs upstream LLVM, GCC 11 vs GCC 14, MinGW-w64 variants)
- user cross-compilers
- ccache-style wrappers

## Change

New \`_detect_default_linked_libs(cxx)\` runs \`<cxx> -### -x c++ /dev/null -o <tmp>\` (\`-###\` prints commands without executing — fast, side-effect-free). Parses driver output:

1. Find link line by markers (\`ld\`, \`ld64\`, \`ld.lld\`, \`lld\`, \`collect2\`)
2. \`shlex.split\` (drivers vary in quoting)
3. Extract every \`-l<name>\`, skip \`-l:literal-filename\` (GNU ld extension)
4. Filter known non-library flags (currently just \`-lto_library\`, the LTO plugin arg on macOS clang)

\`default_linked_libs\` is now the **union** of hardcoded floor + auto-detected extras:
- Hardcoded ordering preserved (predictable for link-order-sensitive consumers)
- Auto-detected novel items appended
- Per-instance cached (detection is ~100ms, answer is invariant)

## Why union, not replacement

On macOS, auto-detect returns \`('c++', 'System')\` for clang++ — libc++abi isn't on the link line because libc++ re-exports it. But \`nm\` doesn't follow Mach-O re-exports, so dropping \`c++abi\` from the baseline would lose those symbols. Union keeps the hardcoded \`c++abi\` while letting auto-detect catch anything we missed (e.g. on a system with \`-stdlib=libc++\` and \`libunwind\` showing up in the link line).

Worst case: detection fails entirely (driver doesn't accept \`-###\`, link line missing, etc.) → empty tuple → hardcoded baseline alone → identical to current behavior. No regression risk.

## Test plan

- [x] 16 unit tests covering parser shapes (Apple Clang quoted args, GCC collect2, ld.lld), filter rules (\`-lto_library\`, \`-l:literal\`, substring guards), failure modes (FileNotFoundError, TimeoutExpired, malformed quoting), and the union semantic
- [x] All existing unit tests pass
- [x] Local clang/g++ on macOS produces correct sets (\`('c++', 'System')\` for C++ driver)
- [x] flare/base/... full build clean (39 actions including link + check_undefined; zero false positives)
- [ ] CI green on all Python versions + platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)