### PR TITLE
fix(check_undefined): enumerate absolute-path libs from their known path

### DIFF
--- a/src/blade/build_manager.py
+++ b/src/blade/build_manager.py
@@ -228,6 +228,18 @@ class Blade:
                 if ':' in dep_key:
                     path, name = dep_key.split(':', 1)
                     if path == '#':
+                        # Absolute-path system libs (the synthetic
+                        # '#:abslib_<hash>' for an absolute lib path) carry their
+                        # real path in `libpath` and are enumerated eagerly at
+                        # registration (Target._add_system_library ->
+                        # ensure_external_lib_syms). Skip them here: their alias
+                        # is a hash that `cc -print-file-name` cannot resolve,
+                        # which would otherwise log a spurious "could not
+                        # resolve" warning.
+                        lib = self.__build_targets.get(dep_key)
+                        libpath = getattr(lib, 'libpath', None) if lib else None
+                        if libpath and os.path.isabs(libpath):
+                            continue
                         aliases.add(name)
 
         resolved = {}
@@ -251,6 +263,38 @@ class Blade:
         if it was not pre-generated (unknown alias or resolution failed)."""
         caches = getattr(self, '_system_symbol_caches', None) or {}
         return caches.get(alias)
+
+    def ensure_external_lib_syms(self, libpath):
+        """Generate (once) and return the ``.syms`` cache for an external,
+        absolute-path library -- e.g. an absolute lib passed via deps/linkflags
+        (the synthetic ``#:abslib_<hash>`` system library) or a proto/thrift
+        config lib. These cannot be located by ``cc -print-file-name`` (the
+        alias is a hash, not a lib name), but their path is already known, so we
+        enumerate directly from it. The result is cached on the SystemLibrary
+        object (see Target._add_system_library), so the check looks it up by
+        object rather than by the unresolvable alias name.
+
+        Returns None when check_undefined is disabled, the path is missing, or
+        enumeration fails."""
+        from blade import config  # pylint: disable=import-outside-toplevel
+        if not config.get_item('cc_library_config', 'check_undefined'):
+            return None
+        cache = getattr(self, '_external_lib_syms_cache', None)
+        if cache is None:
+            cache = self._external_lib_syms_cache = {}
+        if libpath in cache:
+            return cache[libpath]
+        from blade import system_symbols  # pylint: disable=import-outside-toplevel
+        cache_dir = os.path.join(self.get_build_dir(), '.cache', 'system-symbols')
+        result = None
+        try:
+            result = system_symbols.ensure_cache(
+                self.get_build_toolchain(), libpath, cache_dir)
+        except Exception as e:  # pylint: disable=broad-except
+            console.warning(
+                'system_symbols: failed to enumerate "%s": %s' % (libpath, e))
+        cache[libpath] = result
+        return result
 
     def get_default_linked_system_caches(self):
         """Return the list of cache file paths for the toolchain's default-

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1033,11 +1033,14 @@ class CcTarget(Target):
         for key in self.expanded_deps:
             dep = targets[key]
             if dep.path == '#':
-                # System library -- e.g. `#pthread`, `#m`. Its symbols come
-                # from the pre-generated cache; if the cache was never made
-                # (resolution failed) skip silently and let the per-target
-                # diagnostic surface any genuine miss.
-                cache = self.blade.get_system_symbol_cache(dep.name)
+                # System library -- e.g. `#pthread`, `#m`, or an absolute-path
+                # lib ('#:abslib_<hash>'). Absolute-path libs carry their cache
+                # on the SystemLibrary (enumerated from the known path); alias
+                # libs resolve theirs via the pre-generated cache map. If no
+                # cache exists (resolution failed) skip silently and let the
+                # per-target diagnostic surface any genuine miss.
+                cache = (getattr(dep, 'syms_cache', None)
+                         or self.blade.get_system_symbol_cache(dep.name))
                 if cache:
                     system_caches.append(cache)
                 continue

--- a/src/blade/target.py
+++ b/src/blade/target.py
@@ -416,6 +416,13 @@ class Target:
         if key not in self.target_database:
             libpath = name if os.path.isabs(name) else None
             lib = SystemLibrary(name, key=key, libpath=libpath)
+            # For an absolute-path lib (the synthetic '#:abslib_<hash>'), the
+            # check's symbol provider cannot be found via `cc -print-file-name`
+            # (the alias is a hash). The path is known here, so enumerate its
+            # symbols now and stash the cache on the SystemLibrary; the check
+            # reads `dep.syms_cache` instead of resolving the alias.
+            if libpath and os.path.exists(libpath):
+                lib.syms_cache = self.blade.ensure_external_lib_syms(libpath)
             self.blade.register_target(lib)
 
     def _add_location_reference_target(self, m):
@@ -795,6 +802,12 @@ class Target:
 
 
 class SystemLibrary(Target):
+    # Path to a pre-generated `.syms` cache when this is an absolute-path lib
+    # (the synthetic '#:abslib_<hash>'); consumed by the cc_check_undefined
+    # static check. None for alias-based system libs ('#m', '#pthread', ...),
+    # which resolve their cache via BuildManager.get_system_symbol_cache.
+    syms_cache = None
+
     def __init__(self, name, key=None, libpath=None):
         super().__init__(
                 name=name,


### PR DESCRIPTION
## Problem

Building a `proto_library` (or any target depending on an absolute-path lib, e.g. vcpkg protobuf via `proto_library_config.protobuf_libs`) produced:

```
Blade(warning): system_symbols: could not resolve "abslib_c82eb351c1c9" -- check rule will treat its symbols as undefined
Blade(warning): cc_check_undefined: suites/proto_basic:contact_proto has 57 undefined symbol(s) not covered by declared deps:
  ...protobuf / absl symbols...
```

The libs **are** linked (the final link succeeds) — this is a false positive of the experimental `check_undefined` static check.

## Root cause

An absolute lib path is registered as a synthetic `SystemLibrary` keyed `#:abslib_<hash>` (`Target._add_implicit_library`), with the real path in `libpath`. But the check located its symbols by resolving the **alias name** (`abslib_<hash>`, a hash) via `cc -print-file-name` → always fails → symbols treated as undefined. There was also a key mismatch (cache keyed by the hash alias, looked up by `dep.name`).

The path was known all along, and `system_symbols.ensure_cache` already consumes absolute paths verbatim (direct-path fast path + path-safe cache filename). The fix just feeds it the path instead of the hash.

## Change

- `BuildManager.ensure_external_lib_syms(libpath)` — enumerate an absolute-path lib's symbols once (via `system_symbols.ensure_cache`), cached; gated on `check_undefined`.
- `Target._add_system_library` — for an absolute-path `SystemLibrary`, stash the cache on the object (`lib.syms_cache`).
- `BuildManager._prepare_system_symbol_caches` — skip absolute-path libs in the alias-resolution pass (handled eagerly), removing the spurious "could not resolve" warning.
- `_generate_check_undefined` — prefer `dep.syms_cache` over the alias lookup.
- `SystemLibrary.syms_cache` class attribute (None default).

## Testing

- `//suites/proto_basic:contact_proto` and `//suites/cc_basic/...` build clean on Windows MSVC — the `could not resolve` warning and the 57-symbol false positive are gone.
- Unit tests: no new failures (pre-existing Windows-only `glob_test` / `check_hdrs_existence_test` failures are unrelated — identical count with and without this change).

## Follow-ups (separate issues)

The deeper prebuilt/import-library rework (a Bazel-style `cc_import`, deprecating `prebuilt_cc_library`, Windows import libraries, `foreign_cc_library` alignment) is tracked separately; this PR only fixes the absolute-path symbol-enumeration false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)