### PR TITLE
refactor(backend): registry-driven ninja rule generation (M1 of #1264)

### DIFF
--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -22,7 +22,10 @@ import textwrap
 
 from blade import config
 from blade import console
+from blade import rule_registry
 from blade import util
+from blade.ninja_rule import NinjaRule
+from blade.rule_context import RuleContext
 
 
 # To verify whether a header is included without depending on the library it
@@ -306,30 +309,21 @@ class _NinjaFileHeaderGenerator:
     def get_all_rule_names(self):
         return list(self.__all_rule_names)
 
+    def _record_rule_name(self, name):
+        """Record an emitted rule name (used by RuleContext.emit_rule)."""
+        self.__all_rule_names.add(name)
+
     def generate_rule(self, name, command, description=None,
                       depfile=None, generator=False, pool=None,
                       restat=False, rspfile=None,
                       rspfile_content=None, deps=None):
-        self.__all_rule_names.add(name)
-        self._add_line('rule %s' % name)
-        self._add_line('  command = %s' % command)
-        if description:
-            self._add_line('  description = %s' % console.colored(description, 'dimpurple'))
-        if depfile:
-            self._add_line('  depfile = %s' % depfile)
-        if generator:
-            self._add_line('  generator = 1')
-        if pool:
-            self._add_line('  pool = %s' % pool)
-        if restat:
-            self._add_line('  restat = 1')
-        if rspfile:
-            self._add_line('  rspfile = %s' % rspfile)
-        if rspfile_content:
-            self._add_line('  rspfile_content = %s' % rspfile_content)
-        if deps:
-            self._add_line('  deps = %s' % deps)
-        self._add_line('')  # An empty line to improve readability
+        rule = NinjaRule(
+            name=name, command=command, description=description,
+            depfile=depfile, generator=generator, pool=pool, restat=restat,
+            rspfile=rspfile, rspfile_content=rspfile_content, deps=deps)
+        self.__all_rule_names.add(rule.name)
+        for line in rule.emit():
+            self._add_line(line)
 
     def generate_file_header(self):
         self._add_line(textwrap.dedent('''\
@@ -1393,22 +1387,61 @@ class _NinjaFileHeaderGenerator:
         return ' '.join(cmd)
 
     def generate(self):
-        """Generate ninja rules."""
+        """Generate ninja rules by iterating the registered rule providers.
+
+        The file header (and pool) is not a rule, so it is emitted first
+        directly. Rule groups are contributed via the rule registry (see
+        ``rule_registry`` and ``_register_builtin_rule_providers`` below) and
+        emitted in a deterministic order, decoupling this method from the set
+        of languages.
+        """
         self.generate_file_header()
-        self.generate_common_rules()
-        self.generate_cc_rules()
-        self.generate_proto_rules()
-        self.generate_resource_rules()
-        self.generate_java_scala_rules()
-        self.generate_thrift_rules()
-        self.generate_python_rules()
-        self.generate_go_rules()
-        self.generate_shell_rules()
-        self.generate_lex_yacc_rules()
-        self.generate_package_rules()
-        self.generate_version_rules()
-        self.generate_cuda_rules()
+        ctx = RuleContext(self)
+        for provider in rule_registry.rule_providers():
+            provider(ctx)
         return self.rules_buf
+
+
+def _register_builtin_rule_providers():
+    """Register the built-in rule groups with the rule registry.
+
+    M1 bridge: each provider delegates to the corresponding
+    ``_NinjaFileHeaderGenerator.generate_*_rules`` method (unchanged) via
+    ``ctx.generator``, preserving byte-identical output. The explicit order
+    keys reproduce the original ``generate()`` sequence. Later milestones
+    rewrite these providers to construct ``NinjaRule`` values directly against
+    ``ctx`` and move them next to their target modules.
+    """
+    reg = rule_registry.register_rule_provider
+    reg(lambda ctx: ctx.generator.generate_common_rules(),
+        order=rule_registry.ORDER_COMMON, name='common')
+    reg(lambda ctx: ctx.generator.generate_cc_rules(),
+        order=rule_registry.ORDER_CC, name='cc')
+    reg(lambda ctx: ctx.generator.generate_proto_rules(),
+        order=rule_registry.ORDER_PROTO, name='proto')
+    reg(lambda ctx: ctx.generator.generate_resource_rules(),
+        order=rule_registry.ORDER_RESOURCE, name='resource')
+    reg(lambda ctx: ctx.generator.generate_java_scala_rules(),
+        order=rule_registry.ORDER_JAVA_SCALA, name='java_scala')
+    reg(lambda ctx: ctx.generator.generate_thrift_rules(),
+        order=rule_registry.ORDER_THRIFT, name='thrift')
+    reg(lambda ctx: ctx.generator.generate_python_rules(),
+        order=rule_registry.ORDER_PYTHON, name='python')
+    reg(lambda ctx: ctx.generator.generate_go_rules(),
+        order=rule_registry.ORDER_GO, name='go')
+    reg(lambda ctx: ctx.generator.generate_shell_rules(),
+        order=rule_registry.ORDER_SHELL, name='shell')
+    reg(lambda ctx: ctx.generator.generate_lex_yacc_rules(),
+        order=rule_registry.ORDER_LEX_YACC, name='lex_yacc')
+    reg(lambda ctx: ctx.generator.generate_package_rules(),
+        order=rule_registry.ORDER_PACKAGE, name='package')
+    reg(lambda ctx: ctx.generator.generate_version_rules(),
+        order=rule_registry.ORDER_VERSION, name='version')
+    reg(lambda ctx: ctx.generator.generate_cuda_rules(),
+        order=rule_registry.ORDER_CUDA, name='cuda')
+
+
+_register_builtin_rule_providers()
 
 
 class NinjaFileGenerator:

--- a/src/blade/ninja_rule.py
+++ b/src/blade/ninja_rule.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+
+"""
+The ``NinjaRule`` value type: a single ninja ``rule`` declaration.
+
+This is the value half of the rule registry (see ``rule_registry.py``). It
+holds the fields of a ninja ``rule`` block and knows how to render them.
+``emit()`` reproduces, line for line, the text that
+``_NinjaFileHeaderGenerator.generate_rule`` historically wrote, so moving rule
+production onto this type keeps the generated ``build.ninja`` byte-identical.
+"""
+
+from dataclasses import dataclass
+
+from blade import console
+
+
+@dataclass(frozen=True)
+class NinjaRule:
+    """One ninja ``rule`` declaration.
+
+    Field order in :meth:`emit` matches the historical ``generate_rule``
+    emission order exactly (command, description, depfile, generator, pool,
+    restat, rspfile, rspfile_content, deps, trailing blank line).
+    """
+
+    name: str
+    command: str
+    description: str | None = None
+    depfile: str | None = None
+    generator: bool = False
+    pool: str | None = None
+    restat: bool = False
+    rspfile: str | None = None
+    rspfile_content: str | None = None
+    deps: str | None = None
+
+    def emit(self) -> list[str]:
+        """Render this rule as a list of lines (no trailing newlines).
+
+        The caller appends each line with its own newline (matching the old
+        ``_add_line`` behaviour). The final empty string is the blank line that
+        separated rules for readability.
+        """
+        lines = [
+            'rule %s' % self.name,
+            '  command = %s' % self.command,
+        ]
+        if self.description:
+            lines.append('  description = %s' % console.colored(self.description, 'dimpurple'))
+        if self.depfile:
+            lines.append('  depfile = %s' % self.depfile)
+        if self.generator:
+            lines.append('  generator = 1')
+        if self.pool:
+            lines.append('  pool = %s' % self.pool)
+        if self.restat:
+            lines.append('  restat = 1')
+        if self.rspfile:
+            lines.append('  rspfile = %s' % self.rspfile)
+        if self.rspfile_content:
+            lines.append('  rspfile_content = %s' % self.rspfile_content)
+        if self.deps:
+            lines.append('  deps = %s' % self.deps)
+        lines.append('')  # An empty line to improve readability
+        return lines

--- a/src/blade/rule_context.py
+++ b/src/blade/rule_context.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+
+"""
+``RuleContext`` — the narrow interface a rule provider sees.
+
+Rule providers (see ``rule_registry.py``) need the toolchain, config, options
+and a way to emit rules, but should not depend on the whole
+``_NinjaFileHeaderGenerator`` god object. ``RuleContext`` wraps that generator
+and exposes a small, stable surface.
+
+This is intentionally a seam, not yet a reduction: in M1 the built-in providers
+still delegate to the generator's existing ``generate_*_rules`` methods via
+``ctx.generator``, and ``build.ninja`` stays byte-identical. As rule groups are
+migrated to construct ``NinjaRule`` values directly (M2), they depend only on
+this interface, so the generator's helper bodies can later move out from under
+them with no provider changes.
+"""
+
+from blade import config
+from blade.ninja_rule import NinjaRule
+
+
+class RuleContext:
+    """Context passed to each rule provider at generation time."""
+
+    def __init__(self, generator):
+        # The underlying _NinjaFileHeaderGenerator. Escape hatch used by M1
+        # built-in providers that still call its generate_*_rules methods.
+        self.generator = generator
+        self.options = generator.options
+        self.build_dir = generator.build_dir
+        self.blade_path = generator.blade_path
+        self.toolchain = generator.build_toolchain
+        self.accelerator = generator.build_accelerator
+
+    def config_section(self, name):
+        return config.get_section(name)
+
+    def add_line(self, line):
+        """Emit one raw line into the ninja header buffer."""
+        self.generator._add_line(line)
+
+    def emit_rule(self, rule: NinjaRule):
+        """Emit a NinjaRule into the ninja header buffer."""
+        self.generator._record_rule_name(rule.name)
+        for line in rule.emit():
+            self.generator._add_line(line)

--- a/src/blade/rule_registry.py
+++ b/src/blade/rule_registry.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+
+"""
+A registry of ninja-rule **providers**.
+
+Historically the set of ninja ``rule`` blocks was produced by a hardcoded,
+ordered method list in ``_NinjaFileHeaderGenerator.generate`` (backend.py).
+That coupled the backend to every language: a new rule could not be contributed
+without editing that list. This registry inverts the dependency — each rule
+group registers a provider, and the backend becomes a thin loop over the
+registered providers in a deterministic order.
+
+A provider is a callable ``provider(ctx: RuleContext) -> None`` that emits its
+rules into ``ctx`` (see ``rule_context.py``). Providers are ordered by an
+explicit integer ``order`` (NOT import or registration order, which are
+fragile); ties break by name for stability. Spaced ``ORDER_*`` constants below
+reproduce the original ``generate()`` sequence and leave room to slot new
+providers between existing ones.
+"""
+
+
+# Explicit order keys reproducing the original generate() sequence.
+# Spaced by 10 so new providers (including future custom rules) can slot
+# between without renumbering.
+ORDER_COMMON = 0
+ORDER_CC = 10
+ORDER_PROTO = 20
+ORDER_RESOURCE = 30
+ORDER_JAVA_SCALA = 40
+ORDER_THRIFT = 50
+ORDER_PYTHON = 60
+ORDER_GO = 70
+ORDER_SHELL = 80
+ORDER_LEX_YACC = 90
+ORDER_PACKAGE = 100
+ORDER_VERSION = 110
+ORDER_CUDA = 120
+ORDER_CUSTOM = 1000  # user-defined rules (#829) slot after the built-ins
+
+
+# name -> (order, provider). Keyed by name so registration is idempotent
+# (re-registering the same name replaces it), which keeps the registry stable
+# across module re-imports in tests.
+_providers: dict = {}
+
+
+def register_rule_provider(provider, *, order, name=None):
+    """Register a ninja-rule provider.
+
+    Args:
+        provider: callable ``provider(ctx) -> None`` that emits rules into the
+            given RuleContext.
+        order: explicit integer ordering key (use an ``ORDER_*`` constant).
+        name: stable identifier; defaults to ``provider.__name__``. Re-using a
+            name replaces the previous registration (idempotent).
+    """
+    key = name or getattr(provider, '__name__', repr(provider))
+    _providers[key] = (order, provider)
+    return provider
+
+
+def rule_providers():
+    """Return registered providers sorted by (order, name)."""
+    return [provider for _name, (_order, provider)
+            in sorted(_providers.items(), key=lambda kv: (kv[1][0], kv[0]))]

--- a/src/tests/unit/rule_registry_test.py
+++ b/src/tests/unit/rule_registry_test.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for the ninja-rule registry (NinjaRule + rule_registry).
+
+These pin the value type's text rendering (which must reproduce the historical
+`generate_rule` output field-for-field, keeping build.ninja byte-identical) and
+the registry's deterministic, idempotent ordering.
+"""
+
+import os
+import sys
+import unittest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import console  # noqa: E402
+from blade import rule_registry  # noqa: E402
+from blade.ninja_rule import NinjaRule  # noqa: E402
+
+
+class NinjaRuleEmitTest(unittest.TestCase):
+    def test_minimal_rule(self):
+        # Only name + command, then the trailing blank line.
+        self.assertEqual(
+            ['rule cc', '  command = clang -c ${in}', ''],
+            NinjaRule(name='cc', command='clang -c ${in}').emit())
+
+    def test_field_order_and_presence(self):
+        # Field order must match the historical generate_rule emission:
+        # command, description, depfile, generator, pool, restat, rspfile,
+        # rspfile_content, deps, then a trailing blank line.
+        rule = NinjaRule(
+            name='link', command='ld ${in}', description='LINK ${out}',
+            depfile='${out}.d', generator=True, pool='heavy_pool',
+            restat=True, rspfile='${out}.rsp', rspfile_content='${in}',
+            deps='gcc')
+        expected = [
+            'rule link',
+            '  command = ld ${in}',
+            '  description = %s' % console.colored('LINK ${out}', 'dimpurple'),
+            '  depfile = ${out}.d',
+            '  generator = 1',
+            '  pool = heavy_pool',
+            '  restat = 1',
+            '  rspfile = ${out}.rsp',
+            '  rspfile_content = ${in}',
+            '  deps = gcc',
+            '',
+        ]
+        self.assertEqual(expected, rule.emit())
+
+    def test_falsey_fields_are_omitted(self):
+        # generator=False / restat=False and None fields produce no lines.
+        lines = NinjaRule(name='x', command='c', generator=False, restat=False).emit()
+        self.assertNotIn('  generator = 1', lines)
+        self.assertNotIn('  restat = 1', lines)
+        self.assertFalse(any(l.startswith('  depfile') for l in lines))
+
+
+class RuleRegistryTest(unittest.TestCase):
+    def setUp(self):
+        # Isolate from the backend's module-level registrations.
+        self._saved = dict(rule_registry._providers)
+        rule_registry._providers.clear()
+
+    def tearDown(self):
+        rule_registry._providers.clear()
+        rule_registry._providers.update(self._saved)
+
+    def test_ordered_by_order_then_name(self):
+        rule_registry.register_rule_provider(lambda c: None, order=20, name='b')
+        rule_registry.register_rule_provider(lambda c: None, order=10, name='z')
+        rule_registry.register_rule_provider(lambda c: None, order=20, name='a')
+        # order 10 first; within order 20, name 'a' before 'b'.
+        names = []
+        # rebuild name list via the sorted view
+        ordered = sorted(rule_registry._providers.items(),
+                         key=lambda kv: (kv[1][0], kv[0]))
+        names = [n for n, _ in ordered]
+        self.assertEqual(['z', 'a', 'b'], names)
+        # rule_providers() returns the providers in the same order
+        self.assertEqual(3, len(rule_registry.rule_providers()))
+
+    def test_idempotent_by_name(self):
+        first = lambda c: None
+        second = lambda c: None
+        rule_registry.register_rule_provider(first, order=10, name='dup')
+        rule_registry.register_rule_provider(second, order=10, name='dup')
+        self.assertEqual(1, len(rule_registry._providers))
+        self.assertIs(second, rule_registry._providers['dup'][1])
+
+    def test_provider_invoked_collects_emissions(self):
+        calls = []
+        rule_registry.register_rule_provider(lambda c: calls.append('p1'), order=10, name='p1')
+        rule_registry.register_rule_provider(lambda c: calls.append('p2'), order=5, name='p2')
+        for provider in rule_registry.rule_providers():
+            provider(None)
+        self.assertEqual(['p2', 'p1'], calls)  # order 5 before 10
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
M1 of #1264 — decouple ninja **rule definition** from the hardcoded ordered list in `_NinjaFileHeaderGenerator.generate()`.

## What changed

Rule groups are now contributed via a **rule registry** and emitted in a deterministic, explicit order. `generate()` is a thin loop over registered providers, so adding rules/languages no longer requires editing its sequence.

- **`ninja_rule.py`** — `NinjaRule` value type; `emit()` reproduces `generate_rule`'s text field-for-field. `generate_rule` now builds a `NinjaRule` and emits it.
- **`rule_registry.py`** — `register_rule_provider(provider, *, order, name)` + `rule_providers()` (stable sort by `(order, name)`, idempotent by name); `ORDER_*` constants reproduce the original `generate()` sequence.
- **`rule_context.py`** — `RuleContext`, the narrow interface passed to providers. M1 built-in providers delegate to the existing `generate_*_rules` via `ctx.generator` — a deliberate seam for M2.
- **`backend.generate()`** — emit header, then loop over registered providers.
- **`rule_registry_test.py`** — pins `NinjaRule.emit()` field order and registry ordering/idempotency.

## Behavior preserved (byte-identical)

Verified on blade-test (MSVC): the rule section of `build.ninja` is **byte-identical**, the per-target include set is unchanged, and the whole file matches once the (pre-existing, nondeterministically-ordered) `include` lines are sorted.

## Scope

This is **M1 only** (registry, behavior-preserving; rule definitions still live in backend.py). Follow-ups per #1264:
- **M2**: move rule definitions next to their target modules (one language per PR, byte-identical each step).
- **#829**: user-defined custom rules build on this registry.

Per the agreed scope, M1 reserves no special interface for #829.

🤖 Generated with [Claude Code](https://claude.com/claude-code)