### PR TITLE
refactor(backend): move simple builtin_command rule groups to target modules (M2 of #1264)

### DIFF
--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -936,15 +936,6 @@ class _NinjaFileHeaderGenerator:
                                            protoc, protobuf_incs, protoc_go_plugin, go_out),
                                description='PROTOCGOLANG ${in}')
 
-    def generate_resource_rules(self):
-        self.generate_rule(name='resource_index',
-                           command=self._builtin_command('resource_index',
-                                                         '${name} ${path} ${out} ${in}'),
-                           description='RESOURCE INDEX ${out}')
-        self.generate_rule(name='resource',
-                           command=self._builtin_command('resource', '${out} ${in}'),
-                           description='RESOURCE ${in}')
-
     def get_java_command(self, java_config, cmd):
         java_home = java_config['java_home']
         if java_home:
@@ -1101,17 +1092,6 @@ class _NinjaFileHeaderGenerator:
                                        thrift, gen_params, incs, self.build_dir),
                            description='THRIFT ${in}')
 
-    def generate_python_rules(self):
-        args = '--basedir=${basedir} --pylib=${out} ${in}'
-        self.generate_rule(name='pythonlibrary',
-                           command=self._builtin_command('python_library', args),
-                           description='PYTHON LIBRARY ${out}')
-        args = ('--basedir=${basedir} --exclusions=${exclusions} --mainentry=${mainentry} '
-                '--pybin=${out} ${in}')
-        self.generate_rule(name='pythonbinary',
-                           command=self._builtin_command('python_binary', args),
-                           description='PYTHON BINARY ${out}')
-
     def generate_go_rules(self):
         go_home = config.get_item('go_config', 'go_home')
         go = config.get_item('go_config', 'go')
@@ -1147,15 +1127,6 @@ class _NinjaFileHeaderGenerator:
                                description='GO TEST ${package}',
                                pool=go_pool)
 
-    def generate_shell_rules(self):
-        self.generate_rule(name='shelltest',
-                           command=self._builtin_command('shell_test'),
-                           description='SHELL TEST ${out}')
-        args = '${out} ${in} ${testdata}'
-        self.generate_rule(name='shelltestdata',
-                           command=self._builtin_command('shell_testdata', args),
-                           description='SHELL TEST DATA ${out}')
-
     def generate_lex_yacc_rules(self):
         lex_yacc_config = config.get_section('lex_yacc_config')
         lex_cmd = lex_yacc_config['flex']
@@ -1188,19 +1159,6 @@ class _NinjaFileHeaderGenerator:
             if matches and os.path.isdir(matches[0]):
                 return matches[0]
         return None
-
-    def generate_package_rules(self):
-        args = '${out} ${in} ${entries}'
-        self.generate_rule(name='package',
-                           command=self._builtin_command('package', args),
-                           description='PACKAGE ${out}')
-        self.generate_rule(name='package_tar',
-                           command='tar -c -f ${out} ${tarflags} -C ${packageroot} ${entries}',
-                           description='TAR ${out}')
-        self.generate_rule(name='package_zip',
-                           command='cd ${packageroot} && zip -q temp_archive.zip ${entries} && '
-                                   'cd - && mv ${packageroot}/temp_archive.zip ${out}',
-                           description='ZIP ${out}')
 
     def generate_version_rules(self):
         cc = self.build_toolchain.get_cc()
@@ -1419,22 +1377,18 @@ def _register_builtin_rule_providers():
         order=rule_registry.ORDER_CC, name='cc')
     reg(lambda ctx: ctx.generator.generate_proto_rules(),
         order=rule_registry.ORDER_PROTO, name='proto')
-    reg(lambda ctx: ctx.generator.generate_resource_rules(),
-        order=rule_registry.ORDER_RESOURCE, name='resource')
+    # 'resource' is registered by resource_library_target (M2: rule definition
+    # moved next to its target module).
     reg(lambda ctx: ctx.generator.generate_java_scala_rules(),
         order=rule_registry.ORDER_JAVA_SCALA, name='java_scala')
     reg(lambda ctx: ctx.generator.generate_thrift_rules(),
         order=rule_registry.ORDER_THRIFT, name='thrift')
-    reg(lambda ctx: ctx.generator.generate_python_rules(),
-        order=rule_registry.ORDER_PYTHON, name='python')
+    # 'python', 'shell', 'package' are registered by their target modules
+    # (py_targets / sh_test_target / package_target) -- M2.
     reg(lambda ctx: ctx.generator.generate_go_rules(),
         order=rule_registry.ORDER_GO, name='go')
-    reg(lambda ctx: ctx.generator.generate_shell_rules(),
-        order=rule_registry.ORDER_SHELL, name='shell')
     reg(lambda ctx: ctx.generator.generate_lex_yacc_rules(),
         order=rule_registry.ORDER_LEX_YACC, name='lex_yacc')
-    reg(lambda ctx: ctx.generator.generate_package_rules(),
-        order=rule_registry.ORDER_PACKAGE, name='package')
     reg(lambda ctx: ctx.generator.generate_version_rules(),
         order=rule_registry.ORDER_VERSION, name='version')
     reg(lambda ctx: ctx.generator.generate_cuda_rules(),

--- a/src/blade/package_target.py
+++ b/src/blade/package_target.py
@@ -14,7 +14,9 @@ import os
 
 from blade import build_manager
 from blade import build_rules
+from blade import rule_registry
 from blade.blade_types import StrOrListOpt
+from blade.ninja_rule import NinjaRule
 from blade.target import Target, LOCATION_RE
 from blade.util import which, var_to_list, var_to_list_or_none
 
@@ -217,3 +219,24 @@ def package(name: str,
 
 
 build_rules.register_function(package)
+
+
+def _generate_package_rules(ctx):
+    """Ninja rules for package."""
+    ctx.emit_rule(NinjaRule(
+        name='package',
+        command=ctx.builtin_command('package', '${out} ${in} ${entries}'),
+        description='PACKAGE ${out}'))
+    ctx.emit_rule(NinjaRule(
+        name='package_tar',
+        command='tar -c -f ${out} ${tarflags} -C ${packageroot} ${entries}',
+        description='TAR ${out}'))
+    ctx.emit_rule(NinjaRule(
+        name='package_zip',
+        command='cd ${packageroot} && zip -q temp_archive.zip ${entries} && '
+                'cd - && mv ${packageroot}/temp_archive.zip ${out}',
+        description='ZIP ${out}'))
+
+
+rule_registry.register_rule_provider(
+    _generate_package_rules, order=rule_registry.ORDER_PACKAGE, name='package')

--- a/src/blade/py_targets.py
+++ b/src/blade/py_targets.py
@@ -15,7 +15,9 @@ import os
 
 from blade import build_manager
 from blade import build_rules
+from blade import rule_registry
 from blade.blade_types import StrOrListOpt
+from blade.ninja_rule import NinjaRule
 from blade.target import Target
 from blade.util import var_to_list, var_to_list_or_none
 
@@ -335,3 +337,22 @@ def py_test(name: str,
 
 
 build_rules.register_function(py_test)
+
+
+def _generate_python_rules(ctx):
+    """Ninja rules for python_library / python_binary."""
+    ctx.emit_rule(NinjaRule(
+        name='pythonlibrary',
+        command=ctx.builtin_command('python_library', '--basedir=${basedir} --pylib=${out} ${in}'),
+        description='PYTHON LIBRARY ${out}'))
+    ctx.emit_rule(NinjaRule(
+        name='pythonbinary',
+        command=ctx.builtin_command(
+            'python_binary',
+            '--basedir=${basedir} --exclusions=${exclusions} --mainentry=${mainentry} '
+            '--pybin=${out} ${in}'),
+        description='PYTHON BINARY ${out}'))
+
+
+rule_registry.register_rule_provider(
+    _generate_python_rules, order=rule_registry.ORDER_PYTHON, name='python')

--- a/src/blade/resource_library_target.py
+++ b/src/blade/resource_library_target.py
@@ -12,7 +12,9 @@ Define resource_library target.
 from blade import build_manager
 from blade import build_rules
 from blade import cc_targets
+from blade import rule_registry
 from blade.blade_types import StrOrListOpt
+from blade.ninja_rule import NinjaRule
 from blade.util import regular_variable_name, var_to_list, var_to_list_or_none
 
 
@@ -109,3 +111,19 @@ def resource_library(name: str | None = None,
 
 
 build_rules.register_function(resource_library)
+
+
+def _generate_resource_rules(ctx):
+    """Ninja rules for resource_library (registered with the rule registry)."""
+    ctx.emit_rule(NinjaRule(
+        name='resource_index',
+        command=ctx.builtin_command('resource_index', '${name} ${path} ${out} ${in}'),
+        description='RESOURCE INDEX ${out}'))
+    ctx.emit_rule(NinjaRule(
+        name='resource',
+        command=ctx.builtin_command('resource', '${out} ${in}'),
+        description='RESOURCE ${in}'))
+
+
+rule_registry.register_rule_provider(
+    _generate_resource_rules, order=rule_registry.ORDER_RESOURCE, name='resource')

--- a/src/blade/rule_context.py
+++ b/src/blade/rule_context.py
@@ -37,6 +37,14 @@ class RuleContext:
     def config_section(self, name):
         return config.get_section(name)
 
+    def builtin_command(self, builder, args=''):
+        """Build the command line that runs a blade builtin tool.
+
+        Forwards to the generator's `_builtin_command`, which handles the
+        per-platform PYTHONPATH / interpreter wrapping.
+        """
+        return self.generator._builtin_command(builder, args)
+
     def add_line(self, line):
         """Emit one raw line into the ninja header buffer."""
         self.generator._add_line(line)

--- a/src/blade/sh_test_target.py
+++ b/src/blade/sh_test_target.py
@@ -13,7 +13,9 @@ import os
 
 from blade import build_manager
 from blade import build_rules
+from blade import rule_registry
 from blade.blade_types import StrOrListOpt
+from blade.ninja_rule import NinjaRule
 from blade.target import Target, LOCATION_RE
 from blade.util import var_to_list, var_to_list_or_none
 
@@ -120,3 +122,19 @@ def sh_test(name: str,
 
 
 build_rules.register_function(sh_test)
+
+
+def _generate_shell_rules(ctx):
+    """Ninja rules for sh_test."""
+    ctx.emit_rule(NinjaRule(
+        name='shelltest',
+        command=ctx.builtin_command('shell_test'),
+        description='SHELL TEST ${out}'))
+    ctx.emit_rule(NinjaRule(
+        name='shelltestdata',
+        command=ctx.builtin_command('shell_testdata', '${out} ${in} ${testdata}'),
+        description='SHELL TEST DATA ${out}'))
+
+
+rule_registry.register_rule_provider(
+    _generate_shell_rules, order=rule_registry.ORDER_SHELL, name='shell')


### PR DESCRIPTION
First **M2** step of #1264 — move rule **definitions** out of `backend.py` to live next to their target modules.

This PR migrates the trivial, self-contained groups — **resource, python, shell, package** — pure `builtin_command` / literal-string rules with no toolchain/flags/branching, so the move is mechanical and behavior-preserving.

## Changes

- **`RuleContext.builtin_command()`** — forward to the generator's `_builtin_command` (the first forwarding helper providers need).
- **`resource_library_target` / `py_targets` / `sh_test_target` / `package_target`** — each now defines its rule provider and registers it with `rule_registry` (`ORDER_RESOURCE/PYTHON/SHELL/PACKAGE`), emitting via `ctx.emit_rule(NinjaRule(...))`.
- **`backend.py`** — delete the corresponding `generate_*_rules` methods and their delegating lambdas from `_register_builtin_rule_providers`.

Providers still register on language-module import (the existing `_load_build_rules` mechanism), so the rule set is unchanged.

## Behavior preserved (byte-identical)

`build.ninja` rule section is **byte-identical to the pre-M1 baseline** on blade-test (MSVC). Registry unit tests green; real `py_basic` / `resource_basic` builds pass.

## Remaining for dedicated PRs

Complex groups stay in `backend.py` for now — they need shared flag/var helpers, MSVC/GCC branching, or relocated helpers: **cc, cuda, java_scala, proto, version, thrift** (needs `_incs_list_to_string`), **lex_yacc** (needs `_find_win_bison_data_dir`), **go** (pool line + conditional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)