### PR TITLE
refactor(backend): move thrift/go/lex_yacc rule groups to target modules (M2 of #1264)

### DIFF
--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -14,9 +14,7 @@ objects to generate build rules.
 """
 
 
-import glob
 import os
-import shutil
 import sys
 import textwrap
 
@@ -234,15 +232,6 @@ for line in p.stdout:
     sys.stdout.flush()
 sys.exit(p.wait())
 '''
-
-
-def _incs_list_to_string(incs):
-    """Convert incs list to string.
-
-    Example:
-        ['thirdparty', 'include'] -> "-I thirdparty -I include"
-    """
-    return ' '.join(['-I ' + path for path in incs])
 
 
 def protoc_import_path_option(incs):
@@ -1077,89 +1066,6 @@ class _NinjaFileHeaderGenerator:
         self.generate_scalac_rule(java_config)
         self.generate_scalatest_rule(java_config)
 
-    def generate_thrift_rules(self):
-        thrift_config = config.get_section('thrift_config')
-        incs = _incs_list_to_string(thrift_config['thrift_incs'])
-        gen_params = thrift_config['thrift_gen_params']
-        thrift = thrift_config['thrift']
-        if thrift.startswith('//'):
-            thrift = thrift.replace('//', self.build_dir + '/')
-            thrift = thrift.replace(':', '/')
-        self.generate_rule(name='thrift',
-                           command='%s --gen %s '
-                                   '-I . %s -I `dirname ${in}` '
-                                   '-out %s/`dirname ${in}` ${in}' % (
-                                       thrift, gen_params, incs, self.build_dir),
-                           description='THRIFT ${in}')
-
-    def generate_go_rules(self):
-        go_home = config.get_item('go_config', 'go_home')
-        go = config.get_item('go_config', 'go')
-        go_module_enabled = config.get_item('go_config', 'go_module_enabled')
-        go_module_relpath = config.get_item('go_config', 'go_module_relpath')
-        if go_home and go:
-            go_pool = 'golang_pool'
-            self._add_line(textwrap.dedent('''\
-                    pool %s
-                      depth = 1
-                    ''') % go_pool)
-            go_path = os.path.normpath(os.path.abspath(go_home))
-            out_relative = ""
-            if go_module_enabled:
-                prefix = go
-                if go_module_relpath:
-                    relative_prefix = os.path.relpath(prefix, go_module_relpath)
-                    prefix = f"cd {go_module_relpath} && {relative_prefix}"
-                    # add slash to the end of the relpath
-                    out_relative = os.path.join(os.path.relpath("./", go_module_relpath), "")
-            else:
-                prefix = f'GOPATH={go_path} {go}'
-            self.generate_rule(name='gopackage',
-                               command='%s install ${extra_goflags} ${package}' % prefix,
-                               description='GO INSTALL ${package}',
-                               pool=go_pool)
-            self.generate_rule(name='gocommand',
-                               command=f'{prefix} build -o {out_relative}${{out}} ${{extra_goflags}} ${{package}}',
-                               description='GO BUILD ${package}',
-                               pool=go_pool)
-            self.generate_rule(name='gotest',
-                               command=f'{prefix} test -c -o {out_relative}${{out}} ${{extra_goflags}} ${{package}}',
-                               description='GO TEST ${package}',
-                               pool=go_pool)
-
-    def generate_lex_yacc_rules(self):
-        lex_yacc_config = config.get_section('lex_yacc_config')
-        lex_cmd = lex_yacc_config['flex']
-        yacc_cmd = lex_yacc_config['bison']
-        # Windows-only: when the user hasn't overridden the bison command and
-        # we're falling back to the platform default `win_bison`, sniff the
-        # WinFlexBison data dir. win_bison invoked via the WinGet Links
-        # hardlink otherwise looks for data/m4sugar/ next to the link itself
-        # instead of the real install dir.
-        if os.name == 'nt' and yacc_cmd == 'win_bison':
-            bison_data_dir = self._find_win_bison_data_dir()
-            if bison_data_dir:
-                yacc_cmd = f'cmd /c set "BISON_PKGDATADIR={bison_data_dir}" && win_bison'
-        self.generate_rule(name='lex',
-                           command=f'{lex_cmd} ${{lexflags}} -o ${{out}} ${{in}}',
-                           description='LEX ${in}')
-        self.generate_rule(name='yacc',
-                           command=f'{yacc_cmd} ${{yaccflags}} -o ${{out}} ${{in}}',
-                           description='YACC ${in}')
-
-    @staticmethod
-    def _find_win_bison_data_dir():
-        for pattern in [
-            os.path.join(os.path.dirname(shutil.which('win_bison') or ''), 'data'),
-            os.path.join(os.environ.get('LOCALAPPDATA', ''),
-                         'Microsoft', 'WinGet', 'Packages',
-                         'WinFlexBison*', 'data'),
-        ]:
-            matches = glob.glob(pattern)
-            if matches and os.path.isdir(matches[0]):
-                return matches[0]
-        return None
-
     def generate_version_rules(self):
         cc = self.build_toolchain.get_cc()
         cc_version = self.build_toolchain.get_cc_version()
@@ -1381,14 +1287,8 @@ def _register_builtin_rule_providers():
     # moved next to its target module).
     reg(lambda ctx: ctx.generator.generate_java_scala_rules(),
         order=rule_registry.ORDER_JAVA_SCALA, name='java_scala')
-    reg(lambda ctx: ctx.generator.generate_thrift_rules(),
-        order=rule_registry.ORDER_THRIFT, name='thrift')
-    # 'python', 'shell', 'package' are registered by their target modules
-    # (py_targets / sh_test_target / package_target) -- M2.
-    reg(lambda ctx: ctx.generator.generate_go_rules(),
-        order=rule_registry.ORDER_GO, name='go')
-    reg(lambda ctx: ctx.generator.generate_lex_yacc_rules(),
-        order=rule_registry.ORDER_LEX_YACC, name='lex_yacc')
+    # 'thrift', 'go', 'lex_yacc' (plus 'resource', 'python', 'shell',
+    # 'package') are registered by their target modules -- M2.
     reg(lambda ctx: ctx.generator.generate_version_rules(),
         order=rule_registry.ORDER_VERSION, name='version')
     reg(lambda ctx: ctx.generator.generate_cuda_rules(),

--- a/src/blade/go_targets.py
+++ b/src/blade/go_targets.py
@@ -13,12 +13,15 @@ gets totally.
 
 import os
 import re
+import textwrap
 
 from blade import build_manager
 from blade import build_rules
 from blade import config
 from blade import console
+from blade import rule_registry
 from blade.blade_types import StrOrListOpt
+from blade.ninja_rule import NinjaRule
 from blade.target import Target
 from blade.util import run_command, var_to_list, var_to_list_or_none
 
@@ -339,3 +342,52 @@ build_rules.register_function(go_library)
 build_rules.register_function(go_binary)
 build_rules.register_function(go_test)
 build_rules.register_function(go_package)
+
+
+def _generate_go_rules(ctx):
+    """Ninja rules for go_library / go_binary / go_test.
+
+    No-op unless go is configured (go_home + go), matching the original
+    behaviour of emitting nothing when there is no go toolchain.
+    """
+    go_home = config.get_item('go_config', 'go_home')
+    go = config.get_item('go_config', 'go')
+    go_module_enabled = config.get_item('go_config', 'go_module_enabled')
+    go_module_relpath = config.get_item('go_config', 'go_module_relpath')
+    if not (go_home and go):
+        return
+    go_pool = 'golang_pool'
+    ctx.add_line(textwrap.dedent('''\
+            pool %s
+              depth = 1
+            ''') % go_pool)
+    go_path = os.path.normpath(os.path.abspath(go_home))
+    out_relative = ""
+    if go_module_enabled:
+        prefix = go
+        if go_module_relpath:
+            relative_prefix = os.path.relpath(prefix, go_module_relpath)
+            prefix = f"cd {go_module_relpath} && {relative_prefix}"
+            # add slash to the end of the relpath
+            out_relative = os.path.join(os.path.relpath("./", go_module_relpath), "")
+    else:
+        prefix = f'GOPATH={go_path} {go}'
+    ctx.emit_rule(NinjaRule(
+        name='gopackage',
+        command='%s install ${extra_goflags} ${package}' % prefix,
+        description='GO INSTALL ${package}',
+        pool=go_pool))
+    ctx.emit_rule(NinjaRule(
+        name='gocommand',
+        command=f'{prefix} build -o {out_relative}${{out}} ${{extra_goflags}} ${{package}}',
+        description='GO BUILD ${package}',
+        pool=go_pool))
+    ctx.emit_rule(NinjaRule(
+        name='gotest',
+        command=f'{prefix} test -c -o {out_relative}${{out}} ${{extra_goflags}} ${{package}}',
+        description='GO TEST ${package}',
+        pool=go_pool))
+
+
+rule_registry.register_rule_provider(
+    _generate_go_rules, order=rule_registry.ORDER_GO, name='go')

--- a/src/blade/lex_yacc_target.py
+++ b/src/blade/lex_yacc_target.py
@@ -9,10 +9,17 @@ Define lex_yacc_library target.
 """
 
 
+import glob
+import os
+import shutil
+
 from blade import build_manager
 from blade import build_rules
+from blade import config
+from blade import rule_registry
 from blade.blade_types import StrOrListOpt
 from blade.cc_targets import CcTarget
+from blade.ninja_rule import NinjaRule
 from blade.util import var_to_list, var_to_list_or_none
 
 
@@ -199,3 +206,43 @@ def lex_yacc_library(
 
 
 build_rules.register_function(lex_yacc_library)
+
+
+def _find_win_bison_data_dir():
+    for pattern in [
+        os.path.join(os.path.dirname(shutil.which('win_bison') or ''), 'data'),
+        os.path.join(os.environ.get('LOCALAPPDATA', ''),
+                     'Microsoft', 'WinGet', 'Packages',
+                     'WinFlexBison*', 'data'),
+    ]:
+        matches = glob.glob(pattern)
+        if matches and os.path.isdir(matches[0]):
+            return matches[0]
+    return None
+
+
+def _generate_lex_yacc_rules(ctx):
+    """Ninja rules for lex_yacc_library."""
+    lex_yacc_config = ctx.config_section('lex_yacc_config')
+    lex_cmd = lex_yacc_config['flex']
+    yacc_cmd = lex_yacc_config['bison']
+    # Windows-only: when the user hasn't overridden the bison command and we're
+    # falling back to the platform default `win_bison`, sniff the WinFlexBison
+    # data dir. win_bison invoked via the WinGet Links hardlink otherwise looks
+    # for data/m4sugar/ next to the link itself instead of the real install dir.
+    if os.name == 'nt' and yacc_cmd == 'win_bison':
+        bison_data_dir = _find_win_bison_data_dir()
+        if bison_data_dir:
+            yacc_cmd = f'cmd /c set "BISON_PKGDATADIR={bison_data_dir}" && win_bison'
+    ctx.emit_rule(NinjaRule(
+        name='lex',
+        command=f'{lex_cmd} ${{lexflags}} -o ${{out}} ${{in}}',
+        description='LEX ${in}'))
+    ctx.emit_rule(NinjaRule(
+        name='yacc',
+        command=f'{yacc_cmd} ${{yaccflags}} -o ${{out}} ${{in}}',
+        description='YACC ${in}'))
+
+
+rule_registry.register_rule_provider(
+    _generate_lex_yacc_rules, order=rule_registry.ORDER_LEX_YACC, name='lex_yacc')

--- a/src/blade/thrift_library.py
+++ b/src/blade/thrift_library.py
@@ -18,8 +18,10 @@ import os
 from blade import build_manager
 from blade import build_rules
 from blade import config
+from blade import rule_registry
 from blade.blade_types import StrOrListOpt
 from blade.cc_targets import CcTarget
+from blade.ninja_rule import NinjaRule
 from blade.thrift_helper import ThriftHelper
 from blade.util import var_to_list, var_to_list_or_none
 
@@ -138,3 +140,34 @@ def thrift_library(
 
 
 build_rules.register_function(thrift_library)
+
+
+def _incs_list_to_string(incs):
+    """Convert incs list to string.
+
+    Example:
+        ['thirdparty', 'include'] -> "-I thirdparty -I include"
+    """
+    return ' '.join(['-I ' + path for path in incs])
+
+
+def _generate_thrift_rules(ctx):
+    """Ninja rule for thrift_library."""
+    thrift_config = ctx.config_section('thrift_config')
+    incs = _incs_list_to_string(thrift_config['thrift_incs'])
+    gen_params = thrift_config['thrift_gen_params']
+    thrift = thrift_config['thrift']
+    if thrift.startswith('//'):
+        thrift = thrift.replace('//', ctx.build_dir + '/')
+        thrift = thrift.replace(':', '/')
+    ctx.emit_rule(NinjaRule(
+        name='thrift',
+        command='%s --gen %s '
+                '-I . %s -I `dirname ${in}` '
+                '-out %s/`dirname ${in}` ${in}' % (
+                    thrift, gen_params, incs, ctx.build_dir),
+        description='THRIFT ${in}'))
+
+
+rule_registry.register_rule_provider(
+    _generate_thrift_rules, order=rule_registry.ORDER_THRIFT, name='thrift')

--- a/src/tests/unit/lex_yacc_config_test.py
+++ b/src/tests/unit/lex_yacc_config_test.py
@@ -85,46 +85,39 @@ class LexYaccConfigRuleTest(unittest.TestCase):
         self.assertEqual(section['bison'], '/usr/local/bin/bison')
 
 
+class _FakeRuleContext:
+    """Minimal RuleContext stand-in for the lex_yacc rule provider.
+
+    Captures emitted rules by name->command and serves the lex_yacc config
+    section.
+    """
+
+    def __init__(self, lex_yacc_section):
+        self._section = lex_yacc_section
+        self.commands = {}
+
+    def config_section(self, _name):
+        return self._section
+
+    def emit_rule(self, rule):
+        self.commands[rule.name] = rule.command
+
+
 class LexYaccBackendWiringTest(unittest.TestCase):
-    """The backend rule generation must read from lex_yacc_config; users
-    pinning a path via the BLADE_ROOT rule are entitled to see it surface in
-    the ninja command line."""
+    """The lex_yacc rule provider (now in lex_yacc_target) must read from
+    lex_yacc_config; users pinning a path via the BLADE_ROOT rule are entitled
+    to see it surface in the ninja command line."""
 
-    def _make_gen(self, target_os='posix'):
-        """Build a _NinjaFileHeaderGenerator with just enough state for the
-        lex/yacc rule generator to run.
-
-        Mirrors the helper used by cc_library_config_test.CcArchiveRulesTest.
-        """
-        from blade import backend
-        gen = backend._NinjaFileHeaderGenerator.__new__(
-            backend._NinjaFileHeaderGenerator)
-        gen._NinjaFileHeaderGenerator__all_rule_names = set()
-        gen.rules_buf = []
-        gen._add_line = mock.Mock()
-        return gen
-
-    def _capture_rules(self, gen, lex_yacc_section, fake_os_name='posix'):
-        """Run generate_lex_yacc_rules with mocked config + os, collect the
-        generated rule commands by name."""
-        from blade import backend
-        commands = {}
-
-        def fake_generate_rule(name, command, description):
-            commands[name] = command
-
-        with mock.patch.object(gen, 'generate_rule',
-                               side_effect=fake_generate_rule), \
-             mock.patch('blade.backend.config') as mock_config, \
-             mock.patch('blade.backend.os.name', fake_os_name):
-            mock_config.get_section.return_value = lex_yacc_section
-            gen.generate_lex_yacc_rules()
-        return commands
+    def _capture_rules(self, lex_yacc_section, fake_os_name='posix'):
+        """Run the provider with mocked os.name, collect rule commands by name."""
+        from blade import lex_yacc_target
+        ctx = _FakeRuleContext(lex_yacc_section)
+        with mock.patch('blade.lex_yacc_target.os.name', fake_os_name):
+            lex_yacc_target._generate_lex_yacc_rules(ctx)
+        return ctx.commands
 
     def test_posix_uses_config_values(self):
-        gen = self._make_gen()
         cmds = self._capture_rules(
-            gen,
             {'flex': '/opt/homebrew/opt/flex/bin/flex',
              'bison': '/opt/homebrew/opt/bison/bin/bison'},
             fake_os_name='posix')
@@ -135,14 +128,11 @@ class LexYaccBackendWiringTest(unittest.TestCase):
     def test_windows_default_wraps_bison_pkgdatadir_when_unchanged(self):
         # When the user hasn't overridden bison, we keep the existing WinGet
         # data-dir sniff so win_bison can find m4sugar/.
-        gen = self._make_gen()
-        from blade import backend
+        from blade import lex_yacc_target
         with mock.patch.object(
-                backend._NinjaFileHeaderGenerator,
-                '_find_win_bison_data_dir',
+                lex_yacc_target, '_find_win_bison_data_dir',
                 return_value=r'C:\Program Files\WinFlexBison\data'):
             cmds = self._capture_rules(
-                gen,
                 {'flex': 'win_flex --wincompat', 'bison': 'win_bison'},
                 fake_os_name='nt')
         # The data-dir sniff is applied, but only because bison == 'win_bison'.
@@ -152,14 +142,11 @@ class LexYaccBackendWiringTest(unittest.TestCase):
     def test_windows_custom_bison_skips_pkgdatadir_sniff(self):
         # If the user pinned a specific bison binary, the WinGet hack should
         # NOT muddy the command line — the user knows what they want.
-        gen = self._make_gen()
-        from blade import backend
+        from blade import lex_yacc_target
         with mock.patch.object(
-                backend._NinjaFileHeaderGenerator,
-                '_find_win_bison_data_dir',
+                lex_yacc_target, '_find_win_bison_data_dir',
                 return_value=r'C:\Program Files\WinFlexBison\data'):
             cmds = self._capture_rules(
-                gen,
                 {'flex': 'win_flex --wincompat',
                  'bison': r'C:\custom\bison.exe'},
                 fake_os_name='nt')


### PR DESCRIPTION
Second **M2** step of #1264 — migrate the remaining non-cc-family rule groups out of `backend.py`, relocating their small helpers with them.

- **thrift** → `thrift_library.py`: provider + the (thrift-only) `_incs_list_to_string` helper moved out of backend.py.
- **go** → `go_targets.py`: provider; emits the conditional `golang_pool` line via `ctx.add_line`, no-op unless go is configured (unchanged behavior).
- **lex_yacc** → `lex_yacc_target.py`: provider + the `_find_win_bison_data_dir` helper (now a module function); the module now imports `glob`/`shutil`/`os`.
- **backend.py**: delete the three `generate_*_rules` methods, `_find_win_bison_data_dir`, `_incs_list_to_string`, the three delegating lambdas, and the now-unused `glob`/`shutil` imports.

## Behavior preserved (byte-identical)

`build.ninja` rule section is **byte-identical to baseline** on blade-test (MSVC). Registry unit tests green; real `lex_yacc_basic` build passes.

## Remaining for dedicated PRs

The cc family and the groups with heavier flag/var computation: **cc, cuda, java_scala, proto, version**. After these, `backend.py`'s `_register_builtin_rule_providers` will only hold the cc-family/complex groups, and M2 is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)