### PR TITLE
chore: use 'The Blade Authors' copyright for files created after 2026-05-15

### DIFF
--- a/src/blade/blade_types.py
+++ b/src/blade/blade_types.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 
 """

--- a/src/blade/cc_rule_support.py
+++ b/src/blade/cc_rule_support.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 
 """

--- a/src/blade/ninja_rule.py
+++ b/src/blade/ninja_rule.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 
 """

--- a/src/blade/rule_context.py
+++ b/src/blade/rule_context.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 
 """

--- a/src/blade/rule_registry.py
+++ b/src/blade/rule_registry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 
 """

--- a/src/blade/system_symbols.py
+++ b/src/blade/system_symbols.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 
 """System-library symbol enumeration for the cc check_undefined static check.

--- a/src/blade/windows_resources_target.py
+++ b/src/blade/windows_resources_target.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Tencent Inc.
+# Copyright (c) 2025 The Blade Authors.
 # All rights reserved.
 #
 # Author: Feng Chen <phongchen@tencent.com>

--- a/src/test/dsl_api_test.py
+++ b/src/test/dsl_api_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Author: chen3feng <chen3feng@gmail.com>

--- a/src/test/system_include_test.py
+++ b/src/test/system_include_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Author: chen3feng <chen3feng@gmail.com>

--- a/src/test/test_scheduler_test.py
+++ b/src/test/test_scheduler_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Author: chen3feng <chen3feng@gmail.com>

--- a/src/tests/unit/blade_types_test.py
+++ b/src/tests/unit/blade_types_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Unit tests for blade.blade_types.

--- a/src/tests/unit/builtin_tools_test.py
+++ b/src/tests/unit/builtin_tools_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Unit tests for blade.builtin_tools pybinary bootstrap generation.

--- a/src/tests/unit/cc_check_undefined_test.py
+++ b/src/tests/unit/cc_check_undefined_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Unit tests for the cc_check_undefined nm-based static check (issue #1225).

--- a/src/tests/unit/cc_config_pie_test.py
+++ b/src/tests/unit/cc_config_pie_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Unit tests for cc_config.pie and cc_config.no_semantic_interposition.

--- a/src/tests/unit/cc_library_config_test.py
+++ b/src/tests/unit/cc_library_config_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Unit tests for cc_library_config template defaults, validation,

--- a/src/tests/unit/cc_targets_test.py
+++ b/src/tests/unit/cc_targets_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Unit tests for blade.cc_targets._generate_link_all_symbols_link_flags.

--- a/src/tests/unit/check_hdrs_existence_test.py
+++ b/src/tests/unit/check_hdrs_existence_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Unit tests for CcTarget._check_hdrs_existence (issue #886).

--- a/src/tests/unit/detect_default_linked_libs_test.py
+++ b/src/tests/unit/detect_default_linked_libs_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Unit tests for _detect_default_linked_libs (PR #1233 follow-up).

--- a/src/tests/unit/find_inclusion_file_test.py
+++ b/src/tests/unit/find_inclusion_file_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 
 """Unit tests for inclusion_check.Checker._find_inclusion_file.

--- a/src/tests/unit/glob_test.py
+++ b/src/tests/unit/glob_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Unit tests for the glob() exclude pattern matching, covering the

--- a/src/tests/unit/java_targets_test.py
+++ b/src/tests/unit/java_targets_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Unit tests for blade.java_targets.JavaTest._apply_junit_libs_from_config.

--- a/src/tests/unit/load_build_files_excluded_dir_test.py
+++ b/src/tests/unit/load_build_files_excluded_dir_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Unit tests for load_build_files._is_load_excluded_dir (issue #518).

--- a/src/tests/unit/scala_targets_test.py
+++ b/src/tests/unit/scala_targets_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Unit tests for blade.scala_targets.ScalaTest._apply_scalatest_libs_from_config.

--- a/src/tests/unit/source_includes_test.py
+++ b/src/tests/unit/source_includes_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 
 """Unit tests for inclusion_check._scan_source_includes and

--- a/src/tests/unit/test_scheduler_test.py
+++ b/src/tests/unit/test_scheduler_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Unit tests for blade.test_scheduler.

--- a/src/tests/unit/toolchain_test.py
+++ b/src/tests/unit/toolchain_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Unit tests for blade.toolchain.

--- a/src/tests/unit/unused_deps_test.py
+++ b/src/tests/unit/unused_deps_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 
 """Unit tests for the unused cc dependency check (issue #1155).

--- a/src/tests/unit/util_test.py
+++ b/src/tests/unit/util_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Tencent Inc.
+# Copyright (c) 2026 The Blade Authors.
 # All rights reserved.
 #
 # Unit tests for blade.util normalization helpers.


### PR DESCRIPTION
Migrate the copyright header of all source files added after 2026-05-15 from the legacy `Tencent Inc.` attribution to `The Blade Authors.` (years preserved). New files going forward use `The Blade Authors`.

Comment-only change — 28 files, header line only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)