### PR TITLE
fix(msvc): thread per-target incs/defs into compile, fix flag filter & SDK includes

### DIFF
--- a/src/blade/cc_rule_support.py
+++ b/src/blade/cc_rule_support.py
@@ -429,7 +429,7 @@ class CcRuleGenerator:
         wrapper = self._msvc_tee_wrapper_py()
         template = '"%s" -B %s ${inclusion_stack} -- ' % (py, wrapper)
 
-        cc_command = template + ('"%s" /nologo /c /showIncludes %s %s %s %s /Fo${out} ${c_warnings} ${extra_compile_flags} ${in}' % (
+        cc_command = template + ('"%s" /nologo /c /showIncludes %s %s %s %s /Fo${out} ${c_warnings} /external:W0 ${cppflags} ${includes} ${extra_compile_flags} ${in}' % (
             cc, optimize, ' '.join(cppflags), ' '.join(cflags), include_flags))
         self.generate_rule(name='cc',
                            command=cc_command,
@@ -437,7 +437,7 @@ class CcRuleGenerator:
                            deps='msvc',
                            restat=True)
 
-        cxx_command = template + ('"%s" /nologo /c /showIncludes %s %s %s %s /Fo${out} ${cxx_warnings} ${extra_compile_flags} ${in}' % (
+        cxx_command = template + ('"%s" /nologo /c /showIncludes %s %s %s %s /Fo${out} ${cxx_warnings} /external:W0 ${cppflags} ${includes} ${extra_compile_flags} ${in}' % (
             cxx, optimize, ' '.join(cppflags), ' '.join(cxxflags), include_flags))
         self.generate_rule(name='cxx',
                            command=cxx_command,
@@ -450,7 +450,7 @@ class CcRuleGenerator:
         # The Python wrapper captures /showIncludes to ${out} (.incstk file);
         # /Fi writes the preprocessed body to ${out}.pre.
         hdrs_template = '"%s" -B %s ${out} -- ' % (py, wrapper)
-        hdrs_command = hdrs_template + ('"%s" /nologo /P /Tp${in} /showIncludes %s %s %s %s /Fi${out}.pre' % (
+        hdrs_command = hdrs_template + ('"%s" /nologo /P /Tp${in} /showIncludes %s /external:W0 ${cppflags} ${includes} %s %s %s /Fi${out}.pre' % (
             cxx, optimize, ' '.join(cppflags), ' '.join(cxxflags), include_flags))
         self.generate_rule(name='cxxhdrs',
                            command=hdrs_command,

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -670,8 +670,17 @@ class CcTarget(Target):
         cppflags, regular_incs, system_incs = self._get_cc_flags()
         if cppflags:
             vars['cppflags'] = ' '.join(cppflags)
-        inc_flags = (['-I%s' % inc for inc in regular_incs]
-                     + ['-isystem%s' % inc for inc in system_incs])
+        if self.blade.get_build_toolchain().cc_is('msvc'):
+            # MSVC: regular incs -> /I; system (3rd-party) incs -> /external:I,
+            # the cl.exe analog of GCC's -isystem. The rule also passes
+            # /external:W0 so warnings from headers under these dirs are
+            # silenced (/external:I alone only tags them). /external is stable
+            # since VS2019 16.10.
+            inc_flags = (['/I%s' % inc for inc in regular_incs]
+                         + ['/external:I "%s"' % inc for inc in system_incs])
+        else:
+            inc_flags = (['-I%s' % inc for inc in regular_incs]
+                         + ['-isystem%s' % inc for inc in system_incs])
         if inc_flags:
             vars['includes'] = ' '.join(inc_flags)
 

--- a/src/blade/toolchain.py
+++ b/src/blade/toolchain.py
@@ -932,7 +932,10 @@ class MsvcToolChain(ToolChain):
             paths.append(os.path.join(self._msvc_path, 'include'))
         if self._sdk_path and self._sdk_ver:
             sdk_inc = os.path.join(self._sdk_path, 'Include', self._sdk_ver)
-            for sub in ('ucrt', 'um', 'shared'):
+            # Same subdirs vcvarsall.bat puts on INCLUDE. 'winrt' provides WRL
+            # (wrl.h) used by Direct2D/DirectWrite code; 'cppwinrt' the C++/WinRT
+            # projections. Absent subdirs are skipped by the isdir guard.
+            for sub in ('ucrt', 'um', 'shared', 'winrt', 'cppwinrt'):
                 p = os.path.join(sdk_inc, sub)
                 if os.path.isdir(p):
                     paths.append(p)
@@ -1113,55 +1116,48 @@ class MsvcToolChain(ToolChain):
 
         valid_flags, unrecognized_flags = [], []
 
-        fd, obj = tempfile.mkstemp('.obj', 'filter_cc_flags_test')
-        try:
-            argv = [self.cc, '/nologo', '/c', '/Fo' + obj, '/WX', '/Tc-'] + to_test
-            proc = subprocess.Popen(
-                argv,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
-            _, _ = proc.communicate(input=b'int main() { return 0; }\n')
-            returncode = proc.returncode
-        finally:
-            try:
-                os.remove(obj)
-            except OSError:
-                # Temp file may already be deleted by the compiler on error.
-                pass
-            os.close(fd)
+        # cl.exe cannot read source from stdin (unlike gcc's '-'), so write a
+        # throwaway translation unit and compile that. Use the language's own
+        # extension so C++-only flags (e.g. /EHsc) are tested in C++ mode.
+        ext = '.cpp' if language in ('c++', 'cxx', 'cpp', 'cc') else '.c'
+        srcfd, src = tempfile.mkstemp(ext, 'filter_cc_flags_test')
+        os.write(srcfd, b'int main() { return 0; }\n')
+        os.close(srcfd)
 
-        if returncode == 0:
-            return trusted + to_test
-        # When a flag is unrecognized, MSVC puts it in the error output.
-        # Re-test each flag individually to identify bad ones.
-        for flag in to_test:
-            fd2, obj2 = tempfile.mkstemp('.obj', 'filter_cc_flags_test')
+        def _compiles(flags):
+            objfd, obj = tempfile.mkstemp('.obj', 'filter_cc_flags_test')
+            os.close(objfd)
             try:
-                test_argv = [self.cc, '/nologo', '/c', '/Fo' + obj2, '/WX', '/Tc-', flag]
                 proc = subprocess.Popen(
-                    test_argv,
-                    stdin=subprocess.PIPE,
+                    [self.cc, '/nologo', '/c', '/WX', '/Fo' + obj, src] + list(flags),
+                    stdin=subprocess.DEVNULL,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE)
-                _, _ = proc.communicate(input=b'int main() { return 0; }\n')
-                if proc.returncode == 0:
-                    valid_flags.append(flag)
-                else:
-                    unrecognized_flags.append(flag)
+                proc.communicate()
+                return proc.returncode == 0
             finally:
                 try:
-                    os.remove(obj2)
+                    os.remove(obj)
                 except OSError:
-                    # Temp file may not exist or be already cleaned up.
                     pass
-                os.close(fd2)
+
+        try:
+            if _compiles(to_test):
+                return trusted + to_test
+            # Something in to_test is bad; re-test each flag individually.
+            for flag in to_test:
+                (valid_flags if _compiles([flag]) else unrecognized_flags).append(flag)
+        finally:
+            try:
+                os.remove(src)
+            except OSError:
+                pass
 
         if unrecognized_flags:
             console.warning('config: Unrecognized {} flags: {}'.format(
                     language, ', '.join(unrecognized_flags)))
 
-        return valid_flags
+        return trusted + valid_flags
 
 
 # ------------------------------------------------------------------

--- a/src/tests/unit/msvc_compile_flags_test.py
+++ b/src/tests/unit/msvc_compile_flags_test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Regression tests for MSVC per-target compile-flag threading.
+
+The MSVC cc/cxx/cxxhdrs rules must consume the per-target ``${includes}`` and
+``${cppflags}`` ninja variables that ``CcTarget._get_cc_vars`` produces. They
+historically baked only the system include paths into the rule and dropped the
+per-target ones, so any target with ``incs`` / ``defs`` silently failed to
+compile on MSVC (the blade-test cc suites don't use ``incs``, so the gap went
+unnoticed). These tests pin the rule text so that can't regress.
+"""
+
+import os
+import sys
+import unittest
+import unittest.mock as mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import cc_rule_support  # noqa: E402
+
+
+class MsvcCompileFlagsTest(unittest.TestCase):
+    def _make_gen(self):
+        gen = cc_rule_support.CcRuleGenerator.__new__(cc_rule_support.CcRuleGenerator)
+        gen.build_toolchain = mock.Mock()
+        gen.build_toolchain.filter_cc_flags = lambda flags, *a: list(flags)
+        gen.build_toolchain.get_system_include_paths.return_value = []
+        gen.build_accelerator = mock.Mock()
+        gen.options = mock.Mock()
+        gen.options.profile = 'release'
+        gen.build_dir = 'build64_release'
+        gen._msvc_tee_wrapper_py = mock.Mock(return_value='cc_wrapper.py')
+        gen.generate_rule = mock.Mock()
+        return gen
+
+    def _rules(self):
+        gen = self._make_gen()
+        section = {
+            'msvc_config': {'cppflags': [], 'cflags': [], 'cxxflags': [],
+                            'optimize': {'release': ['/O2']}},
+            'cc_config': {'cflags': [], 'cxxflags': [], 'cppflags': [],
+                          'extra_incs': []},
+        }
+        with mock.patch('blade.cc_rule_support.config') as cfg:
+            cfg.get_section.side_effect = lambda n: section[n]
+            gen._generate_windows_cc_compile_rules('cl.exe', 'cl.exe')
+        return {c.kwargs['name']: c.kwargs['command']
+                for c in gen.generate_rule.call_args_list}
+
+    def test_rules_thread_per_target_includes(self):
+        """cc / cxx / cxxhdrs must pass per-target ${includes} (the incs)."""
+        rules = self._rules()
+        for name in ('cc', 'cxx', 'cxxhdrs'):
+            self.assertIn('${includes}', rules[name],
+                          '%s rule drops per-target includes' % name)
+
+    def test_rules_thread_per_target_cppflags(self):
+        """cc / cxx / cxxhdrs must pass per-target ${cppflags} (the defs)."""
+        rules = self._rules()
+        for name in ('cc', 'cxx', 'cxxhdrs'):
+            self.assertIn('${cppflags}', rules[name],
+                          '%s rule drops per-target cppflags' % name)
+
+    def test_external_w0_present(self):
+        """/external:W0 must be present so /external:I (the -isystem analog)
+        actually suppresses 3rd-party header warnings."""
+        rules = self._rules()
+        for name in ('cc', 'cxx', 'cxxhdrs'):
+            self.assertIn('/external:W0', rules[name])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Four MSVC-toolchain bugs found while building real Windows projects (Notepad++ and 7-Zip) with blade. None were caught by the existing cc suites because those use no per-target `incs`/`defs`.

### 1. Per-target `incs`/`defs` dropped on MSVC (the critical one)
The `cc`/`cxx`/`cxxhdrs` rules baked only the system include paths into the rule and never consumed the per-target `${includes}` / `${cppflags}` ninja vars that `CcTarget._get_cc_vars` emits. So **any** target with `incs` or `defs` compiled without them → `fatal error C1083: cannot open include file`. Fixed by passing `${cppflags} ${includes}` in the MSVC compile rules.

### 2. `-isystem` has no cl.exe equivalent
`_get_cc_vars` emitted GCC syntax (`-I`/`-isystem`/`-D`). cl.exe accepts `-I`/`-D` but not `-isystem`. Now emits `/I` for regular incs and **`/external:I`** for system incs (the MSVC `-isystem` analog), plus `/external:W0` on the rule so external-header warnings are actually suppressed.

### 3. `filter_cc_flags` silently dropped valid MSVC flags
It tested each flag with `cl /Tc-` reading source from **stdin**, but cl.exe cannot compile from stdin — so the test always failed and every non-whitelisted flag (`/EHsc`, `/utf-8`, `/GL`, …) was dropped. It also ignored `language` and dropped `trusted` flags in the per-flag branch. Now compiles a throwaway temp file with the language-appropriate extension and preserves trusted flags.

### 4. SDK include set missing `winrt`/`cppwinrt`
`get_system_include_paths` added only `ucrt`/`um`/`shared`, omitting `winrt` (WRL / `wrl.h`, used by Direct2D/DirectWrite) and `cppwinrt`. Added both (guarded by `isdir`), matching vcvarsall's `INCLUDE`. `km` is intentionally excluded (kernel-mode).

### Tests
`msvc_compile_flags_test.py` pins that the `cc`/`cxx`/`cxxhdrs` rules thread `${includes}`/`${cppflags}` and carry `/external:W0`. (A blade-test integration suite with `incs` + `/EHsc` follows separately.)

Verified by building Notepad++ (full GUI, 123 cpp + 26 rc) and the 7-Zip C++/C sources (322 files) end-to-end on MSVC x64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)