### PR TITLE
feat(msvc): assemble .asm via ml64/ml (MSVC assembler rule)

### DIFF
--- a/src/blade/cc_rule_support.py
+++ b/src/blade/cc_rule_support.py
@@ -375,6 +375,7 @@ class CcRuleGenerator:
         cc, cxx, ld = self.build_accelerator.get_cc_commands()
         self._generate_windows_cc_vars()
         self._generate_windows_cc_compile_rules(cc, cxx)
+        self._generate_windows_asm_rule()
         self._generate_cc_inclusion_check_rule()
         self._generate_cc_check_undefined_rule()
         self._generate_windows_ar_rules()
@@ -457,6 +458,26 @@ class CcRuleGenerator:
                            description='CXX HDRS ${in}',
                            deps='msvc',
                            restat=True)
+
+    def _generate_windows_asm_rule(self):
+        """Generate the MSVC assembler (``ml64`` / ``ml``) rule for ``.asm``.
+
+        ``cl.exe`` cannot assemble MASM source; ``.asm`` files must go through
+        ``ml64.exe`` (x64) / ``ml.exe`` (x86), resolved by the toolchain as the
+        ``'as'`` tool. ``CcTarget._get_rule_from_suffix`` routes ``.asm`` here on
+        MSVC. Per-target inc dirs ride on ``${includes}`` (already ``/I`` form
+        on MSVC) and per-target asm flags on ``${extra_compile_flags}`` (from
+        ``extra_asflags``). No ``/showIncludes`` / inclusion-stack plumbing --
+        assembly is not header-dependency-checked.
+        """
+        asm = self.build_toolchain.tool('as')
+        if not asm:
+            return
+        self.generate_rule(
+            name='as',
+            command='"%s" /nologo /c /Fo${out} ${extra_compile_flags} '
+                    '${includes} ${in}' % asm,
+            description='AS ${in}')
 
     def _generate_windows_ar_rules(self):
         """Generate Windows static library rules."""

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -643,6 +643,10 @@ class CcTarget(Target):
         for suffix in ('.cc', '.cpp', '.cxx'):
             if src.endswith(suffix):
                 return 'cxx'
+        # MASM .asm can't go through cl.exe; route to the ml64/ml 'as' rule.
+        # (GCC assembles .s/.S via the cc driver, so only MSVC needs this.)
+        if src.endswith('.asm') and self.blade.get_build_toolchain().cc_is('msvc'):
+            return 'as'
         return 'cc'
 
     def _extra_compile_flags_for(self, src):
@@ -877,11 +881,14 @@ class CcTarget(Target):
                 self.generate_build('phony', full_src, inputs=[], clean=[])
             obj = os.path.join(objs_dir, self.blade.get_build_toolchain().object_file_of(src))
             rule = self._get_rule_from_suffix(src, secret)
+            # The ml64/ml 'as' rule does not emit an inclusion stack (assembly
+            # is not header-dependency-checked), so don't declare that output.
+            emit_stack = emit_inclusion_stack and rule != 'as'
             objvars, stack = vars, None
             extra = self._extra_compile_flags_for(src)
-            if emit_inclusion_stack or extra:
+            if emit_stack or extra:
                 objvars = dict(vars)
-                if emit_inclusion_stack:
+                if emit_stack:
                     stack = os.path.join(objs_dir, src) + '.incstk'
                     objvars['inclusion_stack'] = stack
                 if extra:

--- a/src/tests/unit/msvc_asm_rule_test.py
+++ b/src/tests/unit/msvc_asm_rule_test.py
@@ -22,7 +22,7 @@ from blade.cc_targets import CcLibrary  # noqa: E402
 
 
 class MsvcAsmRuleTest(unittest.TestCase):
-    def _gen(self, asm_tool='ml64.exe'):
+    def _gen(self, asm_tool: 'str | None' = 'ml64.exe'):
         gen = cc_rule_support.CcRuleGenerator.__new__(cc_rule_support.CcRuleGenerator)
         gen.build_toolchain = mock.Mock()
         gen.build_toolchain.tool.return_value = asm_tool

--- a/src/tests/unit/msvc_asm_rule_test.py
+++ b/src/tests/unit/msvc_asm_rule_test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Tests for the MSVC assembler (ml64/ml) rule and .asm routing.
+
+cl.exe cannot assemble MASM; .asm sources must go through the toolchain's 'as'
+tool (ml64.exe / ml.exe). These pin both halves: the 'as' rule is emitted and
+runs that tool, and _get_rule_from_suffix routes .asm there on MSVC only.
+"""
+
+import os
+import sys
+import unittest
+import unittest.mock as mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import cc_rule_support  # noqa: E402
+from blade.cc_targets import CcLibrary  # noqa: E402
+
+
+class MsvcAsmRuleTest(unittest.TestCase):
+    def _gen(self, asm_tool='ml64.exe'):
+        gen = cc_rule_support.CcRuleGenerator.__new__(cc_rule_support.CcRuleGenerator)
+        gen.build_toolchain = mock.Mock()
+        gen.build_toolchain.tool.return_value = asm_tool
+        gen.generate_rule = mock.Mock()
+        return gen
+
+    def test_asm_rule_runs_ml64(self):
+        gen = self._gen('ml64.exe')
+        gen._generate_windows_asm_rule()
+        self.assertTrue(gen.generate_rule.called)
+        kw = gen.generate_rule.call_args.kwargs
+        self.assertEqual('as', kw['name'])
+        for tok in ('ml64.exe', '/c', '/Fo${out}', '${includes}', '${in}'):
+            self.assertIn(tok, kw['command'])
+
+    def test_no_rule_when_assembler_absent(self):
+        gen = self._gen(None)
+        gen._generate_windows_asm_rule()
+        self.assertFalse(gen.generate_rule.called)
+
+
+class AsmRoutingTest(unittest.TestCase):
+    def _target(self, vendor):
+        t = CcLibrary.__new__(CcLibrary)
+        tc = mock.Mock()
+        tc.cc_is = lambda v: v == vendor
+        t.blade = mock.Mock()
+        t.blade.get_build_toolchain.return_value = tc
+        return t
+
+    def test_asm_routed_to_as_on_msvc(self):
+        t = self._target('msvc')
+        self.assertEqual('as', t._get_rule_from_suffix('foo.asm', False))
+        self.assertEqual('cxx', t._get_rule_from_suffix('foo.cpp', False))
+        self.assertEqual('cc', t._get_rule_from_suffix('foo.c', False))
+
+    def test_asm_not_routed_on_gcc(self):
+        t = self._target('gcc')
+        # GCC assembles .s/.S via the cc driver; .asm has no special routing.
+        self.assertEqual('cc', t._get_rule_from_suffix('foo.asm', False))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
blade already resolved the MSVC assembler (`ml64.exe`/`ml.exe`) as the `'as'` tool and accepted `.asm` as a source extension — but had **no rule to run it**. `.asm` was routed to the `cc` rule (cl.exe), which can't assemble MASM. (GCC/Clang assemble `.s`/`.S` via the cc driver, so only MSVC was affected.)

### Changes
- New **`as`** rule on the MSVC path: `ml64 /nologo /c /Fo${out} ${extra_compile_flags} ${includes} ${in}` — per-target asm flags via `extra_asflags`, include dirs via `${includes}`. No `/showIncludes` inclusion-stack plumbing (assembly isn't header-dependency-checked).
- `CcTarget._get_rule_from_suffix` routes `.asm` → `as` on **MSVC only**; the per-source inclusion-stack output is skipped for `as` edges (ml64 emits none).

### Tests
`msvc_asm_rule_test.py` pins the rule text (runs ml64, `/c /Fo${out} ${includes}`) and the routing (`.asm`→`as` on MSVC, `.c`→`cc`, `.cpp`→`cxx`; `.asm`→`cc` on GCC). A blade-test `cc_asm` smoke (a real `.asm` assembled + linked into a `cc_test`, guarded MSVC-only) follows separately.

Found while building 7-Zip, whose x64 codecs ship MASM `.asm` for AES/SHA/CRC/LzFind. Validated locally: `AS suites\cc_asm\asm_add.asm` assembles and the test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)