### PR TITLE
fix(windows_resources): normpath source dir for root-package BUILDs (RC1107)

### DIFF
--- a/src/blade/windows_resources_target.py
+++ b/src/blade/windows_resources_target.py
@@ -103,7 +103,10 @@ class WindowsResourcesTarget(Target):
 
         # Add the source directory so rc.exe can resolve #include "..." and
         # ICON / BITMAP references relative to the .rc file's location.
-        src_dir = os.path.join(self.blade.get_root_dir(), self.path)
+        # normpath drops a trailing separator: for a root-package BUILD
+        # self.path is '', so join() yields '<root>\' and the quoted form
+        # '/i"<root>\"' makes rc.exe see an escaped quote -> RC1107.
+        src_dir = os.path.normpath(os.path.join(self.blade.get_root_dir(), self.path))
         sdk_inc_flags.append('/i"%s"' % src_dir)
 
         inc_flags = ' '.join(sdk_inc_flags)

--- a/src/tests/unit/windows_resources_root_path_test.py
+++ b/src/tests/unit/windows_resources_root_path_test.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Regression test for windows_resources at the repo root.
+
+For a BUILD at the workspace root, target.path is '', so
+os.path.join(root, path) yields '<root>/' (trailing separator). Quoted into the
+rc.exe command as /i"<root>\\" that backslash-escapes the closing quote and
+rc.exe fails with RC1107. The rule must normpath the dir so no trailing
+separator leaks into the quoted include flag.
+"""
+
+import os
+import sys
+import unittest
+import unittest.mock as mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import windows_resources_target as wrt  # noqa: E402
+
+
+class WindowsResourcesRootPathTest(unittest.TestCase):
+    def _run_generate(self, target_path):
+        t = wrt.WindowsResourcesTarget.__new__(wrt.WindowsResourcesTarget)
+        t.path = target_path
+        t.name = 'res'
+        t.attr = {'rc_files': ['app.rc'], 'resources': [], 'hdrs': []}
+        t.data = {}
+        t.blade = mock.Mock()
+        t.blade.get_root_dir.return_value = os.path.join('C:', os.sep, 'ws', 'proj')
+        tc = t.blade.get_build_toolchain.return_value
+        tc.tool.return_value = 'rc.exe'
+        tc.get_system_include_paths.return_value = []
+        t._source_file_path = lambda p: p
+        t._target_file_path = lambda p: p
+        t._add_target_file = mock.Mock()
+        t.generate_build = mock.Mock()
+        rules = []
+        t._write_rule = lambda text: rules.append(text)
+        t.generate()
+        return '\n'.join(rules)
+
+    def test_root_package_has_no_escaped_quote(self):
+        cmd = self._run_generate('')          # BUILD at repo root
+        self.assertNotIn('\\"', cmd, 'trailing backslash escapes the rc /i quote')
+        # the include dir is normpathed (no trailing separator before the quote)
+        self.assertNotIn(os.sep + '"', cmd)
+
+    def test_subdir_package_still_quoted(self):
+        cmd = self._run_generate(os.path.join('sub', 'dir'))
+        self.assertIn('rc.exe', cmd)
+        self.assertNotIn('\\"', cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
A `windows_resources` target in a BUILD at the **workspace root** has `target.path == ''`, so `os.path.join(root, path)` yields `<root>/` (trailing separator). Quoted into the rc.exe command as `/i"<root>\"`, the trailing backslash **escapes the closing quote** and rc.exe aborts with `RC1107: invalid usage`.

`normpath` drops the trailing separator. Subdir-package targets were unaffected (e.g. notepad++'s resources live in `PowerEditor/src`), which is why it went unnoticed — found building **PuTTY**, whose BUILD sits at the repo root.

Adds `windows_resources_root_path_test` (asserts no escaped quote / trailing-sep before the quote, for root and subdir packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)