### PR TITLE
feat(msvc): prepend MSVC + SDK bin to PATH for the link step (mt.exe / LNK1158)

### DIFF
--- a/src/blade/cc_rule_support.py
+++ b/src/blade/cc_rule_support.py
@@ -179,9 +179,19 @@ import os, re, subprocess, sys
 # wrapper drops. Real diagnostics carry spaces/colons and never match.
 _BARE_FILENAME_RE = re.compile(r'^[\w.+\-]+\.[\w.+\-]+$')
 
-cmd = sys.argv[sys.argv.index('--') + 1:]
+sep = sys.argv.index('--')
+args = sys.argv[1:sep]
+cmd = sys.argv[sep + 1:]
 env = dict(os.environ)
 env['VSLANG'] = '1033'  # force English so the filter below matches
+# Prepend the MSVC + Windows SDK bin dirs so link.exe can find the helper
+# tools it spawns by name -- notably mt.exe (in the SDK bin, a different dir
+# from link.exe) for /MANIFEST:EMBED. blade invokes link by absolute path, but
+# tools link itself spawns are resolved via PATH. See cc_rule_support.
+if '--prepend-path' in args:
+    _dirs = args[args.index('--prepend-path') + 1]
+    if _dirs:
+        env['PATH'] = _dirs + os.pathsep + env.get('PATH', '')
 
 p = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE,
                      stderr=subprocess.STDOUT, universal_newlines=True,
@@ -512,24 +522,39 @@ class CcRuleGenerator:
 
         self._add_line('linkflags = %s\n' % ' '.join(linkflags))
 
+        # MSVC + Windows SDK bin dirs, so link.exe can find tools it spawns by
+        # name (e.g. mt.exe in the SDK bin for /MANIFEST:EMBED -- a different dir
+        # from link.exe). blade calls link by absolute path, but link resolves
+        # its own sub-tools via PATH; the link wrapper prepends these.
+        tool_dirs = []
+        for _key in ('ld', 'cc', 'rc', 'as'):
+            _t = self.build_toolchain.tool(_key)
+            if _t:
+                _d = os.path.dirname(_t)
+                if _d and _d not in tool_dirs:
+                    tool_dirs.append(_d)
+        prepend_path = os.pathsep.join(tool_dirs)
+
+        link_wrapper = self._msvc_link_wrapper_py()
+        wrap = f'"{sys.executable}" -B {link_wrapper} --prepend-path "{prepend_path}" --'
+
         self.generate_rule(name='link',
-                           command=f'{ld} /nologo /out:${{out}} ${{linkflags}} {libpath_flags} ${{target_linkflags}} ${{extra_linkflags}} ${{in}}',
+                           command=f'{wrap} {ld} /nologo /out:${{out}} ${{linkflags}} {libpath_flags} ${{target_linkflags}} ${{extra_linkflags}} ${{in}}',
                            description='LINK EXE ${out}')
 
         # ${dllflags} carries the per-target `/DEF:<def> /IMPLIB:<implib>` for a
         # cc_library DLL (empty for other solink edges, e.g. cc_plugin). The
         # `.def` (auto-export, COMDAT-filtered) makes the DLL export its symbols
         # without source annotations; the import library is what dependents link.
-        # Route the DLL link through a small Python wrapper that drops link.exe's
-        # redundant "Creating library ... and object ..." notice (the import lib
-        # is always created for a DLL, so it always prints). See
-        # `_MSVC_LINK_WRAPPER_PY`.
-        link_wrapper = self._msvc_link_wrapper_py()
+        # Route the DLL link through the same Python wrapper, which drops
+        # link.exe's redundant "Creating library ... and object ..." notice (the
+        # import lib is always created for a DLL, so it always prints) and
+        # prepends the tool dirs to PATH. See `_MSVC_LINK_WRAPPER_PY`.
         # restat: link.exe doesn't rewrite the import library (`/IMPLIB`) when
         # the DLL's exports are unchanged, so its mtime can lag; re-stat outputs
         # after linking so an unchanged DLL/implib prunes dependent relinks.
         self.generate_rule(name='solink',
-                           command=f'"{sys.executable}" -B {link_wrapper} -- {ld} /nologo /DLL ${{dllflags}} /out:${{out}} ${{linkflags}} {libpath_flags} ${{target_linkflags}} ${{extra_linkflags}} ${{in}}',
+                           command=f'{wrap} {ld} /nologo /DLL ${{dllflags}} /out:${{out}} ${{linkflags}} {libpath_flags} ${{target_linkflags}} ${{extra_linkflags}} ${{in}}',
                            description='LINK DLL ${out}',
                            restat=True)
 

--- a/src/tests/unit/msvc_link_tool_path_test.py
+++ b/src/tests/unit/msvc_link_tool_path_test.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""The MSVC link/solink rules must route through the link wrapper and prepend
+the MSVC + Windows SDK bin dirs to PATH.
+
+blade invokes link.exe by absolute path, but link itself spawns helper tools by
+name -- notably mt.exe (in the SDK bin, a different dir from link.exe) for
+/MANIFEST:EMBED. Without those dirs on PATH link fails with LNK1158. The link
+wrapper prepends them; these tests pin that the rules pass --prepend-path with
+both bin dirs.
+"""
+
+import os
+import sys
+import unittest
+import unittest.mock as mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import cc_rule_support  # noqa: E402
+
+_MSVC_BIN = os.path.join('C:', os.sep, 'msvc', 'bin')
+_SDK_BIN = os.path.join('C:', os.sep, 'sdk', 'bin')
+
+
+class MsvcLinkToolPathTest(unittest.TestCase):
+    def _rules(self):
+        gen = cc_rule_support.CcRuleGenerator.__new__(cc_rule_support.CcRuleGenerator)
+        gen.build_accelerator = mock.Mock()
+        gen.build_accelerator.get_cc_commands.return_value = (
+            'cl', 'cl', os.path.join(_MSVC_BIN, 'link.exe'))
+        tools = {
+            'ld': os.path.join(_MSVC_BIN, 'link.exe'),
+            'cc': os.path.join(_MSVC_BIN, 'cl.exe'),
+            'as': os.path.join(_MSVC_BIN, 'ml64.exe'),
+            'rc': os.path.join(_SDK_BIN, 'rc.exe'),
+        }
+        gen.build_toolchain = mock.Mock()
+        gen.build_toolchain.tool = tools.get
+        gen.build_toolchain.filter_cc_flags = lambda f, *a: list(f)
+        gen.build_toolchain.get_system_lib_paths.return_value = []
+        gen._msvc_link_wrapper_py = mock.Mock(return_value='link_wrapper.py')
+        gen._builtin_command = lambda builder, args='': 'cmd'  # for cc_windef
+        gen._add_line = mock.Mock()
+        gen.generate_rule = mock.Mock()
+        with mock.patch('blade.cc_rule_support.config') as cfg:
+            cfg.get_section.side_effect = lambda n: {
+                'msvc_config': {'linkflags': []}, 'cc_config': {'linkflags': []}}[n]
+            gen._generate_windows_link_rules()
+        return {c.kwargs['name']: c.kwargs['command']
+                for c in gen.generate_rule.call_args_list}
+
+    def test_link_rules_prepend_msvc_and_sdk_bin(self):
+        rules = self._rules()
+        for name in ('link', 'solink'):
+            cmd = rules[name]
+            self.assertIn('--prepend-path', cmd, name)
+            self.assertIn('link_wrapper.py', cmd, name)   # routed through wrapper
+            self.assertIn(_MSVC_BIN, cmd, name)            # cvtres etc.
+            self.assertIn(_SDK_BIN, cmd, name)             # mt.exe
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
blade invokes link.exe by absolute path, but **link spawns helper tools by name** (resolved via PATH) — notably **mt.exe** (in the Windows SDK bin, a *different* dir from link.exe) for `/MANIFEST:EMBED`. With no PATH set up, link fails:

```
LINK : fatal error LNK1158: cannot run 'mt.exe'
```

so manifest embedding (and other link options that shell out to SDK tools) didn't work.

### Fix
Route the exe `link` rule through the same Python wrapper `solink` already uses, and have the wrapper **prepend a scoped PATH** — just the MSVC bin + Windows SDK bin dirs (already resolved by the toolchain for cl/link/rc/ml64) — via a new `--prepend-path` arg. Tools blade calls itself stay absolute-path/hermetic; this only lets link find its *own* sub-tools. It's those two dirs, not the system PATH.

### Found via
Embedding Notepad++'s manifest (Common-Controls 6.0 + DPI awareness). Without it the v6-only comctl32 ordinal imports (e.g. #381) fail at startup with "Ordinal Not Found"; with `/MANIFEST:EMBED` working, the manifest embeds and the app loads.

Adds `msvc_link_tool_path_test` (link/solink route through the wrapper and pass both bin dirs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)