### PR TITLE
fix(gen_rule): work on Windows via cmd_bat/cmd_bash + portable output check (#1204)

### DIFF
--- a/doc/en/build_rules/gen_rule.md
+++ b/doc/en/build_rules/gen_rule.md
@@ -2,7 +2,16 @@
 
 ## gen\_rule
 
-> **Not supported on the Windows (MSVC) toolchain yet.** `gen_rule` runs its command through a POSIX shell — the scaffold uses `ls` / `/dev/null`, and commands are typically written for `sh` — which Windows `cmd.exe` does not provide. Tracked in [#1204](https://github.com/blade-build/blade-build/issues/1204).
+> **Windows note.** `cmd` is run by the host's default shell (`/bin/sh` on
+> POSIX, `cmd.exe` on Windows), so a `cmd` written for `sh` will not work on
+> Windows. Use `cmd_bat` (a `cmd.exe` command) and/or `cmd_bash` (a `bash`
+> command) for portability — the platform-appropriate one is selected
+> automatically. blade's own output-existence check is cross-platform.
+>
+> Keep gen_rule commands simple. For anything non-trivial, write a small Python
+> script and call it (`cmd = 'python $SRC_DIR/gen.py $SRCS $OUTS'`): Python is on
+> `PATH` on every platform, so it is naturally cross-platform, easy to debug, and
+> avoids per-shell quoting.
 
 Used to customize your own construction rules, parameters:
 
@@ -33,6 +42,14 @@ Used to customize your own construction rules, parameters:
     )
     ```
 
+- cmd\_bash: str, a command run via `bash` (with `set -e -o pipefail`). Preferred
+  on POSIX, and on Windows when `bash` is on `PATH` (e.g. Git Bash). Same
+  variables as `cmd`.
+- cmd\_bat: str, a Windows batch command run via `cmd.exe /S /E:ON /V:ON /D /c`.
+  Preferred on Windows. Same variables as `cmd`.
+  At least one of `cmd` / `cmd_bash` / `cmd_bat` must be set; the
+  platform-appropriate one is chosen automatically (Windows: `cmd_bat` →
+  `cmd_bash` → `cmd`; POSIX: `cmd_bash` → `cmd`).
 - cmd\_name: str, the name of the command, used to display in simplified mode, the default is `COMMAND`
 - generate\_hdrs: bool, indicates whether this target will generate C/C++ header files other than the file names already listed in `outs`.
   If a C/C ++ target depends on the gen\_rule target that generates header files, then these header files need to be generated before compilation can begin.
@@ -66,7 +83,7 @@ NOTE:
 to generate source code and want to reference the generated source code in other targets, just
 consider them as if they are generated in the source tree, without the BUILD\_DIR prefix.
 
-- `srcs` can be empty, but `outs` and `cmd` cannot be empty.
+- `srcs` can be empty, but `outs` cannot be empty, and at least one of `cmd` / `cmd_bash` / `cmd_bat` must be set.
 - `gen_rule` should only generate output files in the corresponding result output directory, and will not pollute the source code tree. But if you reference in other targets
   which generating source files with `gen_rule`, it is only necessary to assume that these files are generated in the source code directory, without considering the result directory prefix.
 - After the command is executed, the correct exit code must be returned, 0 means success, other values mean failure

--- a/doc/zh_CN/build_rules/gen_rule.md
+++ b/doc/zh_CN/build_rules/gen_rule.md
@@ -2,7 +2,13 @@
 
 ## gen\_rule
 
-> **暂不支持 Windows（MSVC）工具链。** `gen_rule` 的命令通过 POSIX shell 执行——脚手架用到 `ls` / `/dev/null`，且命令通常按 `sh` 编写——而 Windows 的 `cmd.exe` 不提供这些。进展见 [#1204](https://github.com/blade-build/blade-build/issues/1204)。
+> **Windows 说明。** `cmd` 由宿主默认 shell 执行（POSIX 上是 `/bin/sh`，Windows 上是
+> `cmd.exe`），所以按 `sh` 写的 `cmd` 在 Windows 上不工作。跨平台请用 `cmd_bat`（`cmd.exe`
+> 命令）和/或 `cmd_bash`（`bash` 命令）——会按平台自动选择。blade 自身的输出存在性检查已跨平台。
+>
+> gen_rule 的命令应尽量简单。稍复杂的逻辑,建议写一个小 Python 脚本来调用
+> （`cmd = 'python $SRC_DIR/gen.py $SRCS $OUTS'`）：Python 在各平台都在 `PATH` 上,
+> 天然跨平台、易调试,也免去各 shell 的引号转义。
 
 用于定制自己的构建规则，参数：
 
@@ -30,6 +36,11 @@
     )
     ```
 
+- `cmd_bash`: str，通过 `bash` 执行的命令（带 `set -e -o pipefail`）。POSIX 上优先,Windows 上当
+  `bash` 在 `PATH`（如 Git Bash）时也用。变量同 `cmd`。
+- `cmd_bat`: str，通过 `cmd.exe /S /E:ON /V:ON /D /c` 执行的 Windows 批处理命令。Windows 上优先。变量同 `cmd`。
+  `cmd` / `cmd_bash` / `cmd_bat` 至少要设一个;按平台自动选（Windows：`cmd_bat` → `cmd_bash` → `cmd`；
+  POSIX：`cmd_bash` → `cmd`）。
 - `cmd_name`: str，命令的名字，用于简略模式下显示，默认为 `COMMAND`
 - generate\_hdrs bool，指示这个目标是否会生成 outs 里列出的文件名之外的 C/C++ 头文件。
   如果一个 C/C++ 目标依赖会生成头文件的 gen\_rule 目标，那么需要这些头文件生成后才能开始编译。
@@ -54,7 +65,7 @@ gen_rule(
 
 注意：
 
-- `srcs` 可以为空，但是 `outs` 和 `cmd` 不能为空。
+- `srcs` 可以为空，但是 `outs` 不能为空，且 `cmd` / `cmd_bash` / `cmd_bat` 至少要设一个。
 - `gen_rule` 只应该把输出文件生成在相应的结果输出目录下，不应该污染源代码树。但是你在其他目标中引用
   `gen_rule` 生成的源文件时，只需要假设这些文件是生成在源代码目录下，不需要考虑结果目录前缀。
 - 命令执行后务必返回正确的退出码，0 表示成功，其他值表示失败。

--- a/src/blade/gen_rule_target.py
+++ b/src/blade/gen_rule_target.py
@@ -161,7 +161,10 @@ class GenRuleTarget(Target):
         explicit per-output check in the given shell's syntax, using the known
         output paths (so no ``${out}`` separator / for-loop quirks).
         """
-        outs = self.attr['outputs']
+        # Absolute paths so the check is immune to any `cd` the user command did
+        # (the old scaffold added an explicit `cd <root>` for this).
+        root = self.blade.get_root_dir()
+        outs = [os.path.join(root, o) for o in self.attr['outputs']]
         if shell == 'cmd':
             return ' && '.join('if not exist "%s" exit /b 1' % o for o in outs)
         # sh/bash: forward slashes so backslashes aren't treated as escapes

--- a/src/blade/gen_rule_target.py
+++ b/src/blade/gen_rule_target.py
@@ -11,6 +11,7 @@ Allow users defining their custom build rules.
 
 
 import os
+import shutil
 
 from blade import build_manager
 from blade import build_rules
@@ -22,10 +23,12 @@ from blade.util import regular_variable_name
 from blade.util import var_to_list, var_to_list_or_none
 
 
-# The rule template for gen_rule
+# The rule template for gen_rule. The command is fully wrapped by
+# `_wrap_command` (interpreter + output-existence check), so nothing
+# shell-specific is hard-coded here -- see issue #1204.
 _RULE_FORMAT = '''\
 rule %s
-  command = %s && cd %s && ls ${out} > /dev/null
+  command = %s
   description = %s
 '''
 
@@ -42,6 +45,8 @@ class GenRuleTarget(Target):
                  tags: StrOrListOpt,
                  outs: StrOrListOpt,
                  cmd: str,
+                 cmd_bash: str,
+                 cmd_bat: str,
                  cmd_name: str,
                  generated_hdrs: StrOrListOpt,
                  generated_incs: StrOrListOpt,
@@ -71,8 +76,12 @@ class GenRuleTarget(Target):
         self._add_tags('type:gen_rule')
         if not outs:
             self.error('"outs" can not be empty')
-        if not cmd:
-            self.error('"cmd" can not be empty')
+        selected_cmd, self._gen_kind, self._bash = self._select_command(
+            cmd, cmd_bash, cmd_bat)
+        if not selected_cmd:
+            self.error('one of "cmd", "cmd_bash", "cmd_bat" must be set '
+                       '(and usable on this platform)')
+            selected_cmd = ''
         outs = var_to_list(outs)
         # self._check_path_list(outs, "outs", must_exist=False)
         outs = [os.path.normpath(o) for o in outs]
@@ -83,7 +92,7 @@ class GenRuleTarget(Target):
         self.attr['outs'] = var_to_list(outs)
         self.attr['outputs'] = [self._target_file_path(o) for o in self.attr['outs']]
         self.attr['locations'] = []
-        self.attr['cmd'] = LOCATION_RE.sub(self._process_location_reference, cmd)
+        self.attr['cmd'] = LOCATION_RE.sub(self._process_location_reference, selected_cmd)
         self.attr['cmd_name'] = cmd_name
         self.attr['heavy'] = heavy
         self.attr['exclude_dep_labels'] = exclude_dep_labels
@@ -113,6 +122,71 @@ class GenRuleTarget(Target):
         if system_export_incs:
             self.attr['system_export_incs'] = self._expand_incs(
                 var_to_list(system_export_incs))
+
+    @staticmethod
+    def _select_command(cmd, cmd_bash, cmd_bat):
+        """Pick the command + how to run it for the host platform (issue #1204).
+
+        Borrowed from Bazel's per-shell genrule commands, simplified:
+          * Windows: prefer ``cmd_bat`` (cmd.exe); else ``cmd_bash`` if bash is
+            available; else the generic ``cmd``.
+          * POSIX: prefer ``cmd_bash`` if bash is available; else ``cmd``.
+        ``cmd`` is the back-compat generic, run by the host's default shell.
+        Returns ``(command, kind, bash_path)`` with kind in
+        ``{'bat', 'bash', 'raw'}``; ``(None, None, bash)`` if nothing usable.
+        """
+        bash = shutil.which('bash')
+        if os.name == 'nt':
+            if cmd_bat:
+                return cmd_bat, 'bat', bash
+            if cmd_bash and bash:
+                return cmd_bash, 'bash', bash
+            if cmd:
+                return cmd, 'raw', bash
+            if cmd_bash:  # no bash found -- best effort via the host shell
+                return cmd_bash, 'raw', bash
+        else:
+            if cmd_bash and bash:
+                return cmd_bash, 'bash', bash
+            if cmd:
+                return cmd, 'raw', bash
+            if cmd_bash:
+                return cmd_bash, 'raw', bash
+        return None, None, bash
+
+    def _output_check(self, shell):
+        """A command that fails the build if any declared output is missing.
+
+        Replaces the old POSIX-only ``ls ${out} > /dev/null`` scaffold with an
+        explicit per-output check in the given shell's syntax, using the known
+        output paths (so no ``${out}`` separator / for-loop quirks).
+        """
+        outs = self.attr['outputs']
+        if shell == 'cmd':
+            return ' && '.join('if not exist "%s" exit /b 1' % o for o in outs)
+        # sh/bash: forward slashes so backslashes aren't treated as escapes
+        return ' && '.join('test -e "%s"' % o.replace('\\', '/') for o in outs)
+
+    def _wrap_command(self, cmd):
+        """Wrap the user command with the right interpreter + output check.
+
+        Launch arguments follow Bazel: ``cmd.exe /S /E:ON /V:ON /D /c`` for bat,
+        ``bash -c`` with ``set -e -o pipefail`` for bash.
+        """
+        kind = self._gen_kind
+        if kind == 'bash':
+            inner = 'set -e -o pipefail;%s && %s' % (cmd, self._output_check('sh'))
+            # single-quote the bash script so the double-quoted paths in the
+            # output check don't clash with bash -c's own quoting.
+            return '"%s" -c \'%s\'' % (self._bash, inner)
+        if kind == 'bat' or os.name == 'nt':
+            # On Windows wrap in an explicit cmd.exe (Bazel's launch args). This
+            # also gives ninja a clean outer process to pipe -- a raw command
+            # doing its own `>` redirection in ninja's directly-piped cmd can
+            # trip "ninja: fatal: GetOverlappedResult".
+            return 'cmd /S /E:ON /V:ON /D /c "%s && %s"' % (cmd, self._output_check('cmd'))
+        # raw on POSIX: the host's /bin/sh -c runs it directly.
+        return '%s && %s' % (cmd, self._output_check('sh'))
 
     def _expand_incs(self, incs):
         """Expand incs"""
@@ -175,9 +249,9 @@ class GenRuleTarget(Target):
         # Because the `command` variable is not lazy evaluated althrough it can be overridden in a
         # `build` statement, so any other build scoped variables are expanded to empty.
         rule = '%s__rule__' % regular_variable_name(self._source_file_path(self.name))
-        cmd = self._expand_command()
+        cmd = self._wrap_command(self._expand_command())
         description = console.colored('{} {}'.format(self.attr['cmd_name'], self.fullname), 'dimpurple')
-        self._write_rule(_RULE_FORMAT % (rule, cmd, self.blade.get_root_dir(), description))
+        self._write_rule(_RULE_FORMAT % (rule, cmd, description))
 
         outputs = self.attr['outputs']
         inputs = self._expand_srcs()
@@ -204,6 +278,8 @@ def gen_rule(
         tags: StrOrListOpt = None,
         outs: StrOrListOpt = None,
         cmd: str = '',
+        cmd_bash: str = '',
+        cmd_bat: str = '',
         cmd_name: str = 'COMMAND',
         generated_hdrs: StrOrListOpt = None,
         generated_incs: StrOrListOpt = None,
@@ -215,6 +291,14 @@ def gen_rule(
         **kwargs: object):
     """General Build Rule
     Args:
+        cmd: str, the command, run by the host's default shell (``/bin/sh`` on
+            POSIX, ``cmd.exe`` on Windows). The generic, back-compatible form.
+        cmd_bash: str, a command run via ``bash`` (``set -e -o pipefail``).
+            Preferred on POSIX, and on Windows when bash is available.
+        cmd_bat: str, a Windows batch command run via
+            ``cmd.exe /S /E:ON /V:ON /D /c``. Preferred on Windows.
+            At least one of ``cmd`` / ``cmd_bash`` / ``cmd_bat`` is required;
+            the platform-appropriate one is selected automatically (#1204).
         src_exts: List[str],
             Valid extension names for file in "srcs", can be None, which means any is valid.
             NOTE the empty string is also a valid extension, which means NO extension.
@@ -250,6 +334,8 @@ def gen_rule(
             tags=tags,
             outs=outs,
             cmd=cmd,
+            cmd_bash=cmd_bash,
+            cmd_bat=cmd_bat,
             cmd_name=cmd_name,
             generated_hdrs=generated_hdrs,
             generated_incs=generated_incs,

--- a/src/tests/unit/gen_rule_cmd_test.py
+++ b/src/tests/unit/gen_rule_cmd_test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Tests for gen_rule per-platform command selection and wrapping (issue #1204).
+
+gen_rule used a POSIX-only scaffold (`... && cd <dir> && ls ${out} > /dev/null`)
+that broke on Windows cmd.exe. Now it picks cmd_bat / cmd_bash / cmd per
+platform and wraps with the right interpreter + a portable output-existence
+check. These tests pin that logic and that the old POSIX scaffold is gone.
+"""
+
+import os
+import sys
+import unittest
+import unittest.mock as mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import gen_rule_target as grt  # noqa: E402
+from blade.gen_rule_target import GenRuleTarget  # noqa: E402
+
+
+class GenRuleSelectTest(unittest.TestCase):
+    def _select(self, cmd, cmd_bash, cmd_bat, osname, bash):
+        with mock.patch.object(grt.os, 'name', osname), \
+             mock.patch.object(grt.shutil, 'which', return_value=bash):
+            return GenRuleTarget._select_command(cmd, cmd_bash, cmd_bat)
+
+    def test_windows_prefers_bat(self):
+        self.assertEqual(self._select('c', 'cb', 'bat', 'nt', 'bash')[:2], ('bat', 'bat'))
+
+    def test_windows_bash_when_no_bat_and_bash_available(self):
+        self.assertEqual(self._select('c', 'cb', '', 'nt', 'bash')[:2], ('cb', 'bash'))
+
+    def test_windows_falls_back_to_cmd_without_bash(self):
+        self.assertEqual(self._select('c', 'cb', '', 'nt', None)[:2], ('c', 'raw'))
+
+    def test_windows_cmd_bash_raw_when_no_cmd_no_bash(self):
+        self.assertEqual(self._select('', 'cb', '', 'nt', None)[:2], ('cb', 'raw'))
+
+    def test_posix_prefers_bash(self):
+        self.assertEqual(self._select('c', 'cb', '', 'posix', '/bin/bash')[:2], ('cb', 'bash'))
+
+    def test_posix_falls_back_to_cmd_without_bash(self):
+        self.assertEqual(self._select('c', 'cb', '', 'posix', None)[:2], ('c', 'raw'))
+
+    def test_none_usable(self):
+        self.assertIsNone(self._select('', '', '', 'posix', '/bin/bash')[0])
+        # cmd_bat is ignored on POSIX
+        self.assertIsNone(self._select('', '', 'bat', 'posix', '/bin/bash')[0])
+
+
+class GenRuleWrapTest(unittest.TestCase):
+    def _wrap(self, kind, osname, cmd='do_it'):
+        t = GenRuleTarget.__new__(GenRuleTarget)
+        t._gen_kind = kind
+        t._bash = '/usr/bin/bash'
+        t.attr = {'outputs': ['build/o1', 'build/o2']}
+        with mock.patch.object(grt.os, 'name', osname):
+            return t._wrap_command(cmd)
+
+    def _no_posix_scaffold(self, w):
+        self.assertNotIn('/dev/null', w)
+        self.assertNotIn(' ls ', w)
+
+    def test_bash_kind(self):
+        w = self._wrap('bash', 'posix')
+        self.assertIn('/usr/bin/bash', w)
+        self.assertIn('-c', w)
+        self.assertIn('set -e -o pipefail', w)
+        self.assertIn('test -e "build/o1"', w)
+        self._no_posix_scaffold(w)
+
+    def test_bat_kind(self):
+        w = self._wrap('bat', 'nt')
+        self.assertIn('cmd /S /E:ON /V:ON /D /c', w)
+        self.assertIn('if not exist "build/o1" exit /b 1', w)
+        self._no_posix_scaffold(w)
+
+    def test_raw_windows_is_wrapped_in_cmd(self):
+        w = self._wrap('raw', 'nt')
+        self.assertIn('cmd /S /E:ON /V:ON /D /c', w)
+        self.assertIn('if not exist', w)
+        self._no_posix_scaffold(w)
+
+    def test_raw_posix_is_plain_sh(self):
+        w = self._wrap('raw', 'posix')
+        self.assertNotIn('cmd /', w)
+        self.assertIn('do_it && test -e "build/o1"', w)
+        self._no_posix_scaffold(w)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/unit/gen_rule_cmd_test.py
+++ b/src/tests/unit/gen_rule_cmd_test.py
@@ -58,6 +58,9 @@ class GenRuleWrapTest(unittest.TestCase):
         t._gen_kind = kind
         t._bash = '/usr/bin/bash'
         t.attr = {'outputs': ['build/o1', 'build/o2']}
+        # get_root_dir='' so os.path.join leaves the relative paths unchanged
+        t.blade = mock.Mock()
+        t.blade.get_root_dir.return_value = ''
         with mock.patch.object(grt.os, 'name', osname):
             return t._wrap_command(cmd)
 


### PR DESCRIPTION
Fixes #1204. `gen_rule` wrapped the user command in a POSIX-only scaffold — `<cmd> && cd <dir> && ls ${out} > /dev/null` — and `ls` / `/dev/null` don't exist in `cmd.exe` (and user commands are usually written for `sh`), so gen_rule never worked on the Windows MSVC toolchain.

### Borrowed from Bazel's genrule (trimmed down)
- **`cmd_bash`** — run via `bash` (`set -e -o pipefail`). Preferred on POSIX, and on Windows when `bash` is on PATH.
- **`cmd_bat`** — Windows batch, run via `cmd.exe /S /E:ON /V:ON /D /c` (Bazel's launch args).
- `cmd` stays the generic, back-compatible form (host default shell).
- Auto-selected per platform: Windows → `cmd_bat` → `cmd_bash`(if bash) → `cmd`; POSIX → `cmd_bash`(if bash) → `cmd`. At least one required.

### Portable output check
Replaced `ls ${out} > /dev/null` with an explicit per-output existence check in the target shell's syntax (`if not exist "..." exit /b 1` / `test -e "..."`) using the known output paths — no POSIX dependency, no `${out}` separator/quoting quirks. On Windows, raw commands are also wrapped in an explicit `cmd.exe /c`, which additionally avoids `ninja: fatal: GetOverlappedResult` when a directly-piped command does its own `>` redirection.

### Deliberately not adding `cmd_ps`
gen_rule commands should stay simple; PowerShell startup is slow; complex logic is better written as a Python script invoked from `cmd` (`cmd = 'python $SRC_DIR/gen.py $SRCS $OUTS'`) — cross-platform, on PATH everywhere, no per-shell quoting. Documented that pattern.

### Tests / docs
`gen_rule_cmd_test` covers selection + wrapping across platforms and pins that the POSIX `ls`/`/dev/null` scaffold is gone. Verified end-to-end on Windows (cmd_bat creates output; missing output correctly fails the build). Docs updated (en + zh_CN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)