### PR TITLE
feat(gen_rule): index/name single out/src refs + $(locations) for multi-output deps

### DIFF
--- a/doc/en/build_rules/gen_rule.md
+++ b/doc/en/build_rules/gen_rule.md
@@ -24,15 +24,25 @@ Used to customize your own construction rules, parameters:
 - cmd: str, the called command line, may contain the following variables, which will be replaced with actual values before running:
     - $SRCS, space-separated list of source file names, relative to WORKSPACE
     - $OUTS, space-separated list of output files, relative to WORKSPACE
+    - $SRCS[i] / $SRCS[name], a single input by index (all-digits) or by declared
+      name / basename, e.g. `$SRCS[0]`, `$SRCS[calc.y]`
+    - $OUTS[i] / $OUTS[name], a single output by index or name, e.g. `$OUTS[0]`,
+      `$OUTS[parser.h]`. When there is exactly one output, `$OUTS[0]` and `$OUTS`
+      are equivalent. Prefer by-name (`$OUTS[parser.h]`) over by-index, since the
+      index shifts if you reorder `outs`.
     - $SRC\_DIR, the directory where the input file is located
     - $OUT\_DIR, the directory where the output file is located
-    - $FIRST\_SRC, first input file path
-    - $FIRST\_OUT, the path of the first output file
+    - $FIRST\_SRC, first input file path (**deprecated** — use `$SRCS[0]`)
+    - $FIRST\_OUT, the path of the first output file (**deprecated** — use `$OUTS[0]`)
     - BUILD\_DIR, The root output directory, such as build[64,32]\_[release, debug]
-  - `$(location target)` and `$(location target label)` — replaced with the output
-    file path(s) of the referenced target. The optional `label` parameter specifies
-    a particular output (e.g. `$(location //bin:server bin)`). Commonly used in
-    `gen_rule.cmd`, `testdata`, `package`, and `sh_test`. Example:
+  - `$(location target)` / `$(location target label)` — replaced with the output
+    file path of the referenced target. The optional `label` parameter selects a
+    particular output (e.g. `$(location //bin:server bin)`). The target must have
+    exactly one output (for that label).
+  - `$(locations target)` — replaced with **all** output files of the referenced
+    target, space-separated. Use when the target produces several files, e.g.
+    `cmd = 'cat $(locations //idl:msgs) > $OUTS'`.
+    Commonly used in `gen_rule.cmd`, `testdata`, `package`, and `sh_test`. Example:
 
     ```python
     gen_rule(

--- a/doc/zh_CN/build_rules/gen_rule.md
+++ b/doc/zh_CN/build_rules/gen_rule.md
@@ -21,12 +21,16 @@
   可含有如下变量，运行前会被替换为实际的值：
   - $SRCS 空格分开的源文件名列表，相对 WORKSPACE
   - $OUTS 空格分开的输出文件列表，相对 WORKSPACE
+  - $SRCS[i] / $SRCS[名字] 按下标（纯数字）或按声明名/basename 取**单个**输入，如 `$SRCS[0]`、`$SRCS[calc.y]`
+  - $OUTS[i] / $OUTS[名字] 按下标或名字取**单个**输出，如 `$OUTS[0]`、`$OUTS[parser.h]`。
+    只有一个输出时，`$OUTS[0]` 与 `$OUTS` 等价。建议优先按名（`$OUTS[parser.h]`）——按下标在重排 `outs` 后会错位。
   - $SRC\_DIR 输入文件所在的目录
   - $OUT\_DIR 输出文件所在的目录
-  - $FIRST\_SRC 第一个输入文件的路径
-  - $FIRST\_OUT 第一个输出文件的路径
+  - $FIRST\_SRC 第一个输入文件的路径（**已废弃** — 请用 `$SRCS[0]`）
+  - $FIRST\_OUT 第一个输出文件的路径（**已废弃** — 请用 `$OUTS[0]`）
   - $BUILD\_DIR 输出的根目录，比如 build[64,32]\_[release,debug]
-  - `$(location target)` 和 `$(location target label)` — 被替换为所引用目标的输出文件路径。可选的 `label` 参数指定特定输出（如 `$(location //bin:server bin)` 表示可执行文件）。常用于 `gen_rule.cmd`、`testdata`、`package`、`sh_test` 等场景。示例：
+  - `$(location target)` / `$(location target label)` — 被替换为所引用目标的**单个**输出文件路径。可选的 `label` 指定特定输出（如 `$(location //bin:server bin)`）。该目标（在该 label 下）须只有一个输出。
+  - `$(locations target)` — 被替换为所引用目标的**全部**输出文件（空格分隔）。当目标产出多个文件时用，如 `cmd = 'cat $(locations //idl:msgs) > $OUTS'`。常用于 `gen_rule.cmd`、`testdata`、`package`、`sh_test` 等场景。示例：
 
     ```python
     gen_rule(

--- a/src/blade/gen_rule_target.py
+++ b/src/blade/gen_rule_target.py
@@ -253,6 +253,9 @@ class GenRuleTarget(Target):
         vars + OS-native separators (correct for cmd.exe / POSIX sh).
         """
         cmd = self.attr['cmd']
+        # bash treats '\' as an escape, so paths must use '/' for the bash kind.
+        # cmd.exe and POSIX sh both accept '/' in file-path args, so no
+        # conversion is needed for the cmd/raw kinds.
         posix = self._gen_kind == 'bash'
 
         def _p(path):

--- a/src/blade/gen_rule_target.py
+++ b/src/blade/gen_rule_target.py
@@ -11,6 +11,7 @@ Allow users defining their custom build rules.
 
 
 import os
+import re
 import shutil
 
 from blade import build_manager
@@ -18,9 +19,21 @@ from blade import build_rules
 from blade import cc_targets
 from blade import console
 from blade.blade_types import StrOrListOpt
-from blade.target import Target, LOCATION_RE
+from blade.target import Target
 from blade.util import regular_variable_name
 from blade.util import var_to_list, var_to_list_or_none
+
+
+# $(location //x:y) -> a dep's single output; $(locations //x:y) -> all of its
+# outputs (space-joined). Combined into one regex so left-to-right order is
+# preserved for the positional %s expansion. Group 1 = the optional plural 's',
+# group 2 = the target key, group 3 = the optional output label.
+_LOCATION_RE = re.compile(r'\$\(location(s)?\s+(\S*:\S+)(\s+\w*)?\)')
+
+# $OUTS[i] / $OUTS[name] / $SRCS[i] / $SRCS[name] -- reference a single output or
+# input by index (all-digits) or by declared name / basename.
+_OUTS_INDEX_RE = re.compile(r'\$OUTS\[([^\]]+)\]')
+_SRCS_INDEX_RE = re.compile(r'\$SRCS\[([^\]]+)\]')
 
 
 # The rule template for gen_rule. The command is fully wrapped by
@@ -92,7 +105,7 @@ class GenRuleTarget(Target):
         self.attr['outs'] = var_to_list(outs)
         self.attr['outputs'] = [self._target_file_path(o) for o in self.attr['outs']]
         self.attr['locations'] = []
-        self.attr['cmd'] = LOCATION_RE.sub(self._process_location_reference, selected_cmd)
+        self.attr['cmd'] = _LOCATION_RE.sub(self._process_location_reference, selected_cmd)
         self.attr['cmd_name'] = cmd_name
         self.attr['heavy'] = heavy
         self.attr['exclude_dep_labels'] = exclude_dep_labels
@@ -196,10 +209,36 @@ class GenRuleTarget(Target):
         return [self._target_file_path(inc) for inc in incs]
 
     def _process_location_reference(self, m):
-        """Process target location reference in the command."""
-        key, type = self._add_location_reference_target(m)
-        self.attr['locations'].append((key, type))
+        """Process a $(location ...) / $(locations ...) reference.
+
+        Registers the referenced target as a dep and records (key, label,
+        plural) for expansion. Returns a '%s' placeholder, filled positionally
+        in `_expand_command` (one combined regex keeps left-to-right order).
+        """
+        plural = bool(m.group(1))
+        key = self._unify_dep(m.group(2))
+        label = (m.group(3) or '').strip()
+        if key and key not in self.deps:
+            self.deps.append(key)
+        self.attr['locations'].append((key, label, plural))
         return '%s'  # Will be expanded in `_expand_command`
+
+    def _index_ref(self, sel, names, paths, what):
+        """Resolve a single $OUTS[sel] / $SRCS[sel] to one concrete path.
+
+        ``sel`` is an index when all-digits, else a declared name or basename.
+        """
+        if sel.isdigit():
+            i = int(sel)
+            if 0 <= i < len(paths):
+                return paths[i]
+            self.error('$%s index out of range: [%s]' % (what.upper(), sel))
+            return ''
+        for i, n in enumerate(names):
+            if n == sel or os.path.basename(n) == sel:
+                return paths[i]
+        self.error('$%s has no entry named "%s"' % (what.upper(), sel))
+        return ''
 
     def _allow_duplicate_source(self):
         return True
@@ -207,6 +246,14 @@ class GenRuleTarget(Target):
     def _expand_command(self):
         """Expand vars and location references in command"""
         cmd = self.attr['cmd']
+        # Indexed/named refs first: a bare `$OUTS` replace below would otherwise
+        # turn `$OUTS[0]` into `${out}[0]`.
+        cmd = _OUTS_INDEX_RE.sub(
+            lambda m: self._index_ref(m.group(1), self.attr['outs'],
+                                      self.attr['outputs'], 'outs'), cmd)
+        inputs = self._expand_srcs()
+        cmd = _SRCS_INDEX_RE.sub(
+            lambda m: self._index_ref(m.group(1), self.srcs, inputs, 'srcs'), cmd)
         cmd = cmd.replace('$SRCS', '${in}')
         cmd = cmd.replace('$OUTS', '${out}')
         cmd = cmd.replace('$FIRST_SRC', '${_in_1}')
@@ -218,7 +265,14 @@ class GenRuleTarget(Target):
         if locations:
             targets = self.blade.get_build_targets()
             locations_paths = []
-            for key, label in locations:
+            for key, label, plural in locations:
+                if plural:
+                    files = targets[key]._get_target_files()
+                    if not files:
+                        self.error('Invalid locations reference %s' % ':'.join(key))
+                        continue
+                    locations_paths.append(' '.join(files))
+                    continue
                 path = targets[key]._get_target_file(label)
                 if not path:
                     self.error('Invalid location reference {} {}'.format(':'.join(key), label))

--- a/src/blade/gen_rule_target.py
+++ b/src/blade/gen_rule_target.py
@@ -244,23 +244,41 @@ class GenRuleTarget(Target):
         return True
 
     def _expand_command(self):
-        """Expand vars and location references in command"""
+        """Expand vars and location references in command.
+
+        For the bash kind, all paths are emitted with forward slashes (Windows
+        backslashes are escapes in bash) -- and `$SRCS`/`$OUTS`/`$FIRST_*` are
+        substituted as concrete paths rather than ninja `${in}`/`${out}`, which
+        ninja would render with backslashes on Windows. cmd/raw keep the ninja
+        vars + OS-native separators (correct for cmd.exe / POSIX sh).
+        """
         cmd = self.attr['cmd']
+        posix = self._gen_kind == 'bash'
+
+        def _p(path):
+            return path.replace('\\', '/') if posix else path
+
+        outputs = self.attr['outputs']
+        inputs = self._expand_srcs()
         # Indexed/named refs first: a bare `$OUTS` replace below would otherwise
         # turn `$OUTS[0]` into `${out}[0]`.
         cmd = _OUTS_INDEX_RE.sub(
-            lambda m: self._index_ref(m.group(1), self.attr['outs'],
-                                      self.attr['outputs'], 'outs'), cmd)
-        inputs = self._expand_srcs()
+            lambda m: _p(self._index_ref(m.group(1), self.attr['outs'], outputs, 'outs')), cmd)
         cmd = _SRCS_INDEX_RE.sub(
-            lambda m: self._index_ref(m.group(1), self.srcs, inputs, 'srcs'), cmd)
-        cmd = cmd.replace('$SRCS', '${in}')
-        cmd = cmd.replace('$OUTS', '${out}')
-        cmd = cmd.replace('$FIRST_SRC', '${_in_1}')
-        cmd = cmd.replace('$FIRST_OUT', '${_out_1}')
-        cmd = cmd.replace('$SRC_DIR', self.path)
-        cmd = cmd.replace('$OUT_DIR', os.path.join(self.build_dir, self.path))
-        cmd = cmd.replace('$BUILD_DIR', self.build_dir)
+            lambda m: _p(self._index_ref(m.group(1), self.srcs, inputs, 'srcs')), cmd)
+        if posix:
+            cmd = cmd.replace('$SRCS', ' '.join(_p(i) for i in inputs))
+            cmd = cmd.replace('$OUTS', ' '.join(_p(o) for o in outputs))
+            cmd = cmd.replace('$FIRST_SRC', _p(inputs[0]) if inputs else '')
+            cmd = cmd.replace('$FIRST_OUT', _p(outputs[0]) if outputs else '')
+        else:
+            cmd = cmd.replace('$SRCS', '${in}')
+            cmd = cmd.replace('$OUTS', '${out}')
+            cmd = cmd.replace('$FIRST_SRC', '${_in_1}')
+            cmd = cmd.replace('$FIRST_OUT', '${_out_1}')
+        cmd = cmd.replace('$SRC_DIR', _p(self.path))
+        cmd = cmd.replace('$OUT_DIR', _p(os.path.join(self.build_dir, self.path)))
+        cmd = cmd.replace('$BUILD_DIR', _p(self.build_dir))
         locations = self.attr['locations']
         if locations:
             targets = self.blade.get_build_targets()
@@ -271,13 +289,13 @@ class GenRuleTarget(Target):
                     if not files:
                         self.error('Invalid locations reference %s' % ':'.join(key))
                         continue
-                    locations_paths.append(' '.join(files))
+                    locations_paths.append(' '.join(_p(f) for f in files))
                     continue
                 path = targets[key]._get_target_file(label)
                 if not path:
                     self.error('Invalid location reference {} {}'.format(':'.join(key), label))
                     continue
-                locations_paths.append(path)
+                locations_paths.append(_p(path))
             cmd = cmd % tuple(locations_paths)
         return cmd
 

--- a/src/tests/unit/gen_rule_cmd_test.py
+++ b/src/tests/unit/gen_rule_cmd_test.py
@@ -98,17 +98,19 @@ class GenRuleWrapTest(unittest.TestCase):
 class GenRuleExpandTest(unittest.TestCase):
     """$OUTS[i|name] / $SRCS[i|name] indexed/named references."""
 
-    def _target(self, cmd):
+    def _target(self, cmd, kind='raw', outputs=None, inputs=None):
         t = GenRuleTarget.__new__(GenRuleTarget)
         t.error = mock.Mock()
+        t._gen_kind = kind
         t.path = 'pkg'
         t.build_dir = 'bd'
         t.srcs = ['in.y']
-        t._expand_srcs = lambda: ['pkg/in.y']
+        t._expand_srcs = lambda: (inputs if inputs is not None else ['pkg/in.y'])
         t.attr = {
             'cmd': cmd,
             'outs': ['parser.cc', 'parser.h'],
-            'outputs': ['bd/pkg/parser.cc', 'bd/pkg/parser.h'],
+            'outputs': outputs if outputs is not None
+                       else ['bd/pkg/parser.cc', 'bd/pkg/parser.h'],
             'locations': [],
         }
         return t
@@ -140,6 +142,18 @@ class GenRuleExpandTest(unittest.TestCase):
     def test_index_does_not_clobber_bare_outs(self):
         t = self._target('$OUTS[0] then $OUTS')
         self.assertEqual(t._expand_command(), 'bd/pkg/parser.cc then ${out}')
+
+    def test_bash_kind_forward_slashes_and_concrete_paths(self):
+        # bash kind: backslash -> '/', and $OUTS/$SRCS are concrete (not ${out})
+        t = self._target(
+            'gen $OUTS[0] all $OUTS in $SRCS',
+            kind='bash',
+            outputs=[r'bd\pkg\parser.cc', r'bd\pkg\parser.h'],
+            inputs=[r'pkg\in.y'])
+        out = t._expand_command()
+        self.assertEqual(out, 'gen bd/pkg/parser.cc all bd/pkg/parser.cc bd/pkg/parser.h in pkg/in.y')
+        self.assertNotIn('\\', out)
+        self.assertNotIn('${out}', out)
 
 
 if __name__ == '__main__':

--- a/src/tests/unit/gen_rule_cmd_test.py
+++ b/src/tests/unit/gen_rule_cmd_test.py
@@ -95,5 +95,52 @@ class GenRuleWrapTest(unittest.TestCase):
         self._no_posix_scaffold(w)
 
 
+class GenRuleExpandTest(unittest.TestCase):
+    """$OUTS[i|name] / $SRCS[i|name] indexed/named references."""
+
+    def _target(self, cmd):
+        t = GenRuleTarget.__new__(GenRuleTarget)
+        t.error = mock.Mock()
+        t.path = 'pkg'
+        t.build_dir = 'bd'
+        t.srcs = ['in.y']
+        t._expand_srcs = lambda: ['pkg/in.y']
+        t.attr = {
+            'cmd': cmd,
+            'outs': ['parser.cc', 'parser.h'],
+            'outputs': ['bd/pkg/parser.cc', 'bd/pkg/parser.h'],
+            'locations': [],
+        }
+        return t
+
+    def test_index_ref_helper(self):
+        t = self._target('')
+        names, paths = ['a.cc', 'b.h'], ['o/a.cc', 'o/b.h']
+        self.assertEqual(t._index_ref('0', names, paths, 'outs'), 'o/a.cc')
+        self.assertEqual(t._index_ref('1', names, paths, 'outs'), 'o/b.h')
+        self.assertEqual(t._index_ref('b.h', names, paths, 'outs'), 'o/b.h')
+        t._index_ref('9', names, paths, 'outs')   # out of range
+        t._index_ref('nope', names, paths, 'outs')  # unknown name
+        self.assertEqual(t.error.call_count, 2)
+
+    def test_outs_index_and_name(self):
+        t = self._target('gen $OUTS[0] --hdr=$OUTS[parser.h]')
+        self.assertEqual(t._expand_command(),
+                         'gen bd/pkg/parser.cc --hdr=bd/pkg/parser.h')
+
+    def test_srcs_index(self):
+        t = self._target('use $SRCS[0]')
+        self.assertEqual(t._expand_command(), 'use pkg/in.y')
+
+    def test_bare_vars_still_expand(self):
+        # $OUTS (no bracket) must still become ${out}, not be eaten by indexing
+        t = self._target('all $OUTS first $FIRST_OUT')
+        self.assertEqual(t._expand_command(), 'all ${out} first ${_out_1}')
+
+    def test_index_does_not_clobber_bare_outs(self):
+        t = self._target('$OUTS[0] then $OUTS')
+        self.assertEqual(t._expand_command(), 'bd/pkg/parser.cc then ${out}')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Follow-up to the gen_rule Windows work — the "multiple outputs" ergonomics discussed after #1204.

### New command references
- **`$OUTS[i]` / `$OUTS[name]`** and **`$SRCS[i]` / `$SRCS[name]`** — reference a single output/input by index (all-digits) or by declared name / basename. Resolved at generate time to a concrete path; out-of-range index or unknown name errors. When there is exactly one output, `$OUTS[0]` ≡ `$OUTS`.
  ```python
  cmd_bat = 'bison -o $OUTS[parser.cc] --defines=$OUTS[parser.h] $SRCS[0]'
  ```
- **`$(locations //x:y)`** — expands to **all** output files of a referenced target (space-joined), vs `$(location ...)` which is a single output. One combined regex keeps left-to-right order for the positional `%s` expansion.
  ```python
  cmd = 'cat $(locations //idl:msgs) > $OUTS'
  ```

### Notes
- `$FIRST_SRC` / `$FIRST_OUT` are now documented as **deprecated** in favor of `$SRCS[0]` / `$OUTS[0]`.
- Deliberately **no** cryptic `$@` / `$<` / `$(@D)` — blade keeps meaningful names. This is the named-output capability Bazel offers via `$(location :name)`, plus index addressing; by-name is recommended (index shifts if you reorder `outs`).
- Compiler-toolchain make-vars (`$(CC)` etc.) deliberately not added (low value for gen_rule).

### Tests / docs
`gen_rule_cmd_test` covers index/name resolution and that bare `$OUTS`/`$SRCS` still expand (not clobbered by indexing). Verified end-to-end on Windows. Docs updated (en + zh_CN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)