### PR TITLE
feat(windows_resources): let .rc #include generated headers from deps

### DIFF
--- a/src/blade/windows_resources_target.py
+++ b/src/blade/windows_resources_target.py
@@ -85,6 +85,33 @@ class WindowsResourcesTarget(Target):
     def _allow_duplicate_source(self):
         return True
 
+    def _dep_generated_headers(self):
+        """Generated headers (and their dirs) from transitive deps.
+
+        A `.rc` may `#include` a header produced by a gen_rule (e.g. PuTTY's
+        licence.h). Such headers live under the build dir, which rc.exe does not
+        otherwise search, and the rc edge must wait for them. Returns
+        ``(files, dirs)`` of full build-dir paths to feed `/i` and implicit_deps.
+        """
+        files, dirs = set(), set()
+        build_targets = self.blade.get_build_targets()
+        seen, stack = set(), list(self.deps)
+        while stack:
+            dkey = stack.pop()
+            if dkey in seen:
+                continue
+            seen.add(dkey)
+            dep = build_targets.get(dkey)
+            if not dep:
+                continue
+            for hdr in dep.attr.get('generated_hdrs', []):
+                files.add(hdr)
+                dirs.add(os.path.dirname(hdr))
+            for inc in dep.attr.get('generated_incs', []):
+                dirs.add(inc)
+            stack.extend(dep.deps)
+        return files, dirs
+
     def generate(self):
         """Generate Ninja build edges for compiling .rc files."""
         toolchain = self.blade.get_build_toolchain()
@@ -109,6 +136,13 @@ class WindowsResourcesTarget(Target):
         src_dir = os.path.normpath(os.path.join(self.blade.get_root_dir(), self.path))
         sdk_inc_flags.append('/i"%s"' % src_dir)
 
+        # Generated headers from deps (e.g. a gen_rule producing a header the
+        # .rc #includes) live under the build dir; add their dirs so rc.exe can
+        # resolve them, and the files to implicit_deps so rc waits for them.
+        gen_hdr_files, gen_hdr_dirs = self._dep_generated_headers()
+        for d in sorted(gen_hdr_dirs):
+            sdk_inc_flags.append('/i"%s"' % d if ' ' in d else '/i%s' % d)
+
         inc_flags = ' '.join(sdk_inc_flags)
 
         # Per-target ninja rule for rc.exe
@@ -125,7 +159,7 @@ class WindowsResourcesTarget(Target):
         # Resources and headers referenced by the .rc are implicit deps:
         # if they change Ninja rebuilds the .res, but they don't appear in
         # ${in} on the rc.exe command line.
-        implicit_deps = resource_inputs + hdr_inputs
+        implicit_deps = resource_inputs + hdr_inputs + sorted(gen_hdr_files)
 
         res_paths = []
         for i, rc_file in enumerate(self.attr['rc_files']):

--- a/src/tests/unit/windows_resources_root_path_test.py
+++ b/src/tests/unit/windows_resources_root_path_test.py
@@ -23,14 +23,16 @@ from blade import windows_resources_target as wrt  # noqa: E402
 
 
 class WindowsResourcesRootPathTest(unittest.TestCase):
-    def _run_generate(self, target_path):
+    def _make_target(self, target_path, deps=None, build_targets=None):
         t = wrt.WindowsResourcesTarget.__new__(wrt.WindowsResourcesTarget)
         t.path = target_path
         t.name = 'res'
         t.attr = {'rc_files': ['app.rc'], 'resources': [], 'hdrs': []}
         t.data = {}
+        t.deps = deps or []
         t.blade = mock.Mock()
         t.blade.get_root_dir.return_value = os.path.join('C:', os.sep, 'ws', 'proj')
+        t.blade.get_build_targets.return_value = build_targets or {}
         tc = t.blade.get_build_toolchain.return_value
         tc.tool.return_value = 'rc.exe'
         tc.get_system_include_paths.return_value = []
@@ -38,10 +40,14 @@ class WindowsResourcesRootPathTest(unittest.TestCase):
         t._target_file_path = lambda p: p
         t._add_target_file = mock.Mock()
         t.generate_build = mock.Mock()
-        rules = []
-        t._write_rule = lambda text: rules.append(text)
+        t._rules = []
+        t._write_rule = lambda text: t._rules.append(text)
+        return t
+
+    def _run_generate(self, target_path):
+        t = self._make_target(target_path)
         t.generate()
-        return '\n'.join(rules)
+        return '\n'.join(t._rules)
 
     def test_root_package_has_no_escaped_quote(self):
         cmd = self._run_generate('')          # BUILD at repo root
@@ -53,6 +59,36 @@ class WindowsResourcesRootPathTest(unittest.TestCase):
         cmd = self._run_generate(os.path.join('sub', 'dir'))
         self.assertIn('rc.exe', cmd)
         self.assertNotIn('\\"', cmd)
+
+    def test_generated_header_from_dep_on_rc_path_and_deps(self):
+        # A dep gen_rule produces a header the .rc #includes (e.g. licence.h).
+        # Its build-dir is added to rc's /i, and the file to the rc edge's
+        # implicit_deps so rc waits for it.
+        gen = mock.Mock()
+        gen.attr = {'generated_hdrs': [os.path.join('build64_release', 'licence.h')],
+                    'generated_incs': []}
+        gen.deps = []
+        t = self._make_target('', deps=['//:gen'],
+                              build_targets={'//:gen': gen})
+        t.generate()
+        cmd = '\n'.join(t._rules)
+        self.assertIn('build64_release', cmd)            # gen dir on rc /i
+        kw = t.generate_build.call_args.kwargs
+        self.assertIn(os.path.join('build64_release', 'licence.h'),
+                      kw.get('implicit_deps', []))       # rc waits for it
+
+    def test_dep_generated_headers_is_transitive(self):
+        leaf = mock.Mock()
+        leaf.attr = {'generated_hdrs': [os.path.join('bd', 'a.h')], 'generated_incs': []}
+        leaf.deps = []
+        mid = mock.Mock()
+        mid.attr = {'generated_hdrs': [], 'generated_incs': [os.path.join('bd', 'inc')]}
+        mid.deps = ['//:leaf']
+        t = self._make_target('', deps=['//:mid'],
+                              build_targets={'//:mid': mid, '//:leaf': leaf})
+        files, dirs = t._dep_generated_headers()
+        self.assertEqual(files, {os.path.join('bd', 'a.h')})
+        self.assertEqual(dirs, {'bd', os.path.join('bd', 'inc')})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A `.rc` often `#include`s a header produced by a `gen_rule` (e.g. PuTTY's `licence.h` from `licence.pl`). Those headers live under the build dir, which `rc.exe` doesn't search, and the rc edge didn't depend on them — so a generated header could be consumed by C/C++ compiles (via `generated_hdrs` on the include path) but **never by resources**, failing with `RC1015: cannot open include file`.

`windows_resources` now collects generated headers (`generated_hdrs`) and include dirs (`generated_incs`) from its **transitive deps**, adds their dirs to `rc.exe`'s `/i` path, and lists the files as `implicit_deps` so the `.res` builds after them. A `windows_resources` target can now depend on a `gen_rule` and `#include` its output.

### Verified end-to-end
With this, PuTTY's `licence.h` works as a `gen_rule` (run `licence.pl`) feeding **both** the C++ compiles and `version.rc2` — `plink` + `putty` build with no source-tree `licence.h` (the gen deletes it). Previously this required a prebuild step.

Unit coverage: transitive `_dep_generated_headers`, and that `generate()` puts the gen dir on rc `/i` + the gen file in `implicit_deps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)