### PR TITLE
refactor(windows_resources): use expanded_deps instead of a manual dep walk

### DIFF
--- a/src/blade/windows_resources_target.py
+++ b/src/blade/windows_resources_target.py
@@ -86,7 +86,7 @@ class WindowsResourcesTarget(Target):
         return True
 
     def _dep_generated_headers(self):
-        """Generated headers (and their dirs) from transitive deps.
+        """Generated headers (and their dirs) from all deps (direct + transitive).
 
         A `.rc` may `#include` a header produced by a gen_rule (e.g. PuTTY's
         licence.h). Such headers live under the build dir, which rc.exe does not
@@ -94,13 +94,9 @@ class WindowsResourcesTarget(Target):
         ``(files, dirs)`` of full build-dir paths to feed `/i` and implicit_deps.
         """
         files, dirs = set(), set()
+        assert self.expanded_deps is not None, 'expanded_deps not expanded'
         build_targets = self.blade.get_build_targets()
-        seen, stack = set(), list(self.deps)
-        while stack:
-            dkey = stack.pop()
-            if dkey in seen:
-                continue
-            seen.add(dkey)
+        for dkey in self.expanded_deps:  # already direct + transitive
             dep = build_targets.get(dkey)
             if not dep:
                 continue
@@ -109,7 +105,6 @@ class WindowsResourcesTarget(Target):
                 dirs.add(os.path.dirname(hdr))
             for inc in dep.attr.get('generated_incs', []):
                 dirs.add(inc)
-            stack.extend(dep.deps)
         return files, dirs
 
     def generate(self):

--- a/src/tests/unit/windows_resources_root_path_test.py
+++ b/src/tests/unit/windows_resources_root_path_test.py
@@ -29,6 +29,9 @@ class WindowsResourcesRootPathTest(unittest.TestCase):
         t.name = 'res'
         t.attr = {'rc_files': ['app.rc'], 'resources': [], 'hdrs': []}
         t.data = {}
+        # expanded_deps is the direct + transitive dep list (set by the
+        # dependency analyzer before generate()).
+        t.expanded_deps = deps or []
         t.deps = deps or []
         t.blade = mock.Mock()
         t.blade.get_root_dir.return_value = os.path.join('C:', os.sep, 'ws', 'proj')
@@ -77,14 +80,14 @@ class WindowsResourcesRootPathTest(unittest.TestCase):
         self.assertIn(os.path.join('build64_release', 'licence.h'),
                       kw.get('implicit_deps', []))       # rc waits for it
 
-    def test_dep_generated_headers_is_transitive(self):
+    def test_dep_generated_headers_uses_expanded_deps(self):
+        # expanded_deps is already flattened (direct + transitive), so the
+        # helper just iterates it -- no manual graph walk.
         leaf = mock.Mock()
         leaf.attr = {'generated_hdrs': [os.path.join('bd', 'a.h')], 'generated_incs': []}
-        leaf.deps = []
         mid = mock.Mock()
         mid.attr = {'generated_hdrs': [], 'generated_incs': [os.path.join('bd', 'inc')]}
-        mid.deps = ['//:leaf']
-        t = self._make_target('', deps=['//:mid'],
+        t = self._make_target('', deps=['//:mid', '//:leaf'],
                               build_targets={'//:mid': mid, '//:leaf': leaf})
         files, dirs = t._dep_generated_headers()
         self.assertEqual(files, {os.path.join('bd', 'a.h')})


### PR DESCRIPTION
Follow-up to #1281. `_dep_generated_headers` hand-rolled a BFS over `.deps`; targets already have `expanded_deps` (direct + transitive, computed by the dependency analyzer, asserted-and-used throughout cc_targets). Iterate that — same result, less code, consistent with the codebase. Tests updated to set `expanded_deps`; putty rebuilt clean (gen_rule licence.h feeds both compiles and resources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)