### PR TITLE
fix(windows_resources): reach generated headers via build-dir, not per-header dirs

### DIFF
--- a/src/blade/windows_resources_target.py
+++ b/src/blade/windows_resources_target.py
@@ -86,26 +86,29 @@ class WindowsResourcesTarget(Target):
         return True
 
     def _dep_generated_headers(self):
-        """Generated headers (and their dirs) from all deps (direct + transitive).
+        """Generated headers + explicitly-exported include dirs from all deps
+        (direct + transitive).
 
         A `.rc` may `#include` a header produced by a gen_rule (e.g. PuTTY's
-        licence.h). Such headers live under the build dir, which rc.exe does not
-        otherwise search, and the rc edge must wait for them. Returns
-        ``(files, dirs)`` of full build-dir paths to feed `/i` and implicit_deps.
+        licence.h). Returns ``(files, inc_dirs)``: ``files`` are the generated
+        header paths, listed as implicit_deps so the rc edge waits for them;
+        ``inc_dirs`` are only the deps' **explicit** ``export_incs`` /
+        ``generated_incs``. We do NOT add each generated header's own directory
+        to the rc search path -- that auto-export raised the chance of a
+        generated header shadowing a system header. Generated headers are
+        instead reached by their build-dir-relative path via the build-dir on
+        the rc `/i` (added in `generate`), matching how cc consumes them.
         """
-        files, dirs = set(), set()
+        files, inc_dirs = set(), set()
         assert self.expanded_deps is not None, 'expanded_deps not expanded'
         build_targets = self.blade.get_build_targets()
         for dkey in self.expanded_deps:  # already direct + transitive
             dep = build_targets.get(dkey)
             if not dep:
                 continue
-            for hdr in dep.attr.get('generated_hdrs', []):
-                files.add(hdr)
-                dirs.add(os.path.dirname(hdr))
-            for inc in dep.attr.get('generated_incs', []):
-                dirs.add(inc)
-        return files, dirs
+            files.update(dep.attr.get('generated_hdrs', []))
+            inc_dirs.update(dep.attr.get('generated_incs', []))
+        return files, inc_dirs
 
     def generate(self):
         """Generate Ninja build edges for compiling .rc files."""
@@ -131,11 +134,15 @@ class WindowsResourcesTarget(Target):
         src_dir = os.path.normpath(os.path.join(self.blade.get_root_dir(), self.path))
         sdk_inc_flags.append('/i"%s"' % src_dir)
 
-        # Generated headers from deps (e.g. a gen_rule producing a header the
-        # .rc #includes) live under the build dir; add their dirs so rc.exe can
-        # resolve them, and the files to implicit_deps so rc waits for them.
-        gen_hdr_files, gen_hdr_dirs = self._dep_generated_headers()
-        for d in sorted(gen_hdr_dirs):
+        # The build dir, so a generated header a .rc #includes (e.g. PuTTY's
+        # licence.h) resolves by its build-dir-relative path -- mirrors cc's
+        # `-I<build_dir>`, and avoids auto-exporting each generated header's own
+        # directory (which risked shadowing a system header). Deps' explicit
+        # export_incs / generated_incs are still added; the generated header
+        # files become implicit_deps so the rc edge waits for them.
+        sdk_inc_flags.append('/i"%s"' % self.build_dir)
+        gen_hdr_files, gen_inc_dirs = self._dep_generated_headers()
+        for d in sorted(gen_inc_dirs):
             sdk_inc_flags.append('/i"%s"' % d if ' ' in d else '/i%s' % d)
 
         inc_flags = ' '.join(sdk_inc_flags)

--- a/src/tests/unit/windows_resources_root_path_test.py
+++ b/src/tests/unit/windows_resources_root_path_test.py
@@ -27,6 +27,7 @@ class WindowsResourcesRootPathTest(unittest.TestCase):
         t = wrt.WindowsResourcesTarget.__new__(wrt.WindowsResourcesTarget)
         t.path = target_path
         t.name = 'res'
+        t.build_dir = 'build64_release'
         t.attr = {'rc_files': ['app.rc'], 'resources': [], 'hdrs': []}
         t.data = {}
         # expanded_deps is the direct + transitive dep list (set by the
@@ -63,35 +64,43 @@ class WindowsResourcesRootPathTest(unittest.TestCase):
         self.assertIn('rc.exe', cmd)
         self.assertNotIn('\\"', cmd)
 
-    def test_generated_header_from_dep_on_rc_path_and_deps(self):
-        # A dep gen_rule produces a header the .rc #includes (e.g. licence.h).
-        # Its build-dir is added to rc's /i, and the file to the rc edge's
-        # implicit_deps so rc waits for it.
+    def test_generated_header_resolves_via_build_dir_not_its_own_dir(self):
+        # A dep gen_rule produces a header the .rc #includes (e.g. licence.h),
+        # here in a sub-build-dir. The build dir goes on rc /i (so the .rc
+        # resolves it by build-dir-relative path), the header's OWN dir is NOT
+        # auto-added (that risked shadowing a system header), and the file is an
+        # implicit_dep so rc waits for it.
+        hdr = os.path.join('build64_release', 'sub', 'licence.h')
         gen = mock.Mock()
-        gen.attr = {'generated_hdrs': [os.path.join('build64_release', 'licence.h')],
-                    'generated_incs': []}
-        gen.deps = []
-        t = self._make_target('', deps=['//:gen'],
-                              build_targets={'//:gen': gen})
+        gen.attr = {'generated_hdrs': [hdr], 'generated_incs': []}
+        t = self._make_target('', deps=['//:gen'], build_targets={'//:gen': gen})
         t.generate()
         cmd = '\n'.join(t._rules)
-        self.assertIn('build64_release', cmd)            # gen dir on rc /i
-        kw = t.generate_build.call_args.kwargs
-        self.assertIn(os.path.join('build64_release', 'licence.h'),
-                      kw.get('implicit_deps', []))       # rc waits for it
+        self.assertIn('/i"build64_release"', cmd)                       # build dir on rc /i
+        self.assertNotIn(os.path.join('build64_release', 'sub'), cmd)   # header's own dir NOT added
+        self.assertIn(hdr, t.generate_build.call_args.kwargs.get('implicit_deps', []))
+
+    def test_explicit_generated_inc_on_rc_path(self):
+        # Explicit export_incs / generated_incs ARE added to rc /i (opt-in).
+        inc = os.path.join('build64_release', 'pkg', 'inc')
+        gen = mock.Mock()
+        gen.attr = {'generated_hdrs': [], 'generated_incs': [inc]}
+        t = self._make_target('', deps=['//:gen'], build_targets={'//:gen': gen})
+        t.generate()
+        self.assertIn(inc, '\n'.join(t._rules))
 
     def test_dep_generated_headers_uses_expanded_deps(self):
-        # expanded_deps is already flattened (direct + transitive), so the
-        # helper just iterates it -- no manual graph walk.
+        # expanded_deps is already flattened (direct + transitive); the helper
+        # returns generated-header FILES + only the explicit generated_incs dirs.
         leaf = mock.Mock()
         leaf.attr = {'generated_hdrs': [os.path.join('bd', 'a.h')], 'generated_incs': []}
         mid = mock.Mock()
         mid.attr = {'generated_hdrs': [], 'generated_incs': [os.path.join('bd', 'inc')]}
         t = self._make_target('', deps=['//:mid', '//:leaf'],
                               build_targets={'//:mid': mid, '//:leaf': leaf})
-        files, dirs = t._dep_generated_headers()
+        files, inc_dirs = t._dep_generated_headers()
         self.assertEqual(files, {os.path.join('bd', 'a.h')})
-        self.assertEqual(dirs, {'bd', os.path.join('bd', 'inc')})
+        self.assertEqual(inc_dirs, {os.path.join('bd', 'inc')})  # only explicit generated_incs
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Follow-up to #1281. That PR let a `.rc` `#include` a gen_rule-produced header (PuTTY's `licence.h`) by **auto-adding each dep's generated-header directory** to `rc.exe`'s `/i`. As noted on review, that default export raises the chance of a generated header **shadowing a system header** of the same name (the classic `cfg.h`-style collision).

This switches to the convention blade uses elsewhere:
- Put the **build dir** on rc's `/i` (mirrors cc's `-I<build_dir>`), so a generated header resolves by its **build-dir-relative path** — no per-header directory export.
- Only honor deps' **explicit** `export_incs` / `generated_incs` on `/i` (opt-in, for short-name includes from a deliberately exported dir).
- Generated-header **files** remain `implicit_deps`, so the rc edge still waits for them (build order).

Verified end-to-end: PuTTY `plink` + `putty` still build (`licence.h` resolves, no RC1015/RC1107) with no per-header dir on `/i`. Updated `windows_resources_root_path_test` accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)