### PR TITLE
feat(progress): live multi-line build panel (tri-state grayscale bar + sliding window)

### DIFF
--- a/doc/en/develop.md
+++ b/doc/en/develop.md
@@ -97,6 +97,7 @@ roughly the order they appear in a `blade build` invocation:
 - [How `proto_library` handles multi-language codegen](develop/protobuf_build.md)
 - [How Java and Scala programs are built](develop/java_scala_build.md)
 - [How Python targets are built and packaged](develop/python_build.md)
+- [The console: the build progress panel and the ninja status pipeline](develop/console.md)
 - [How `blade test` runs user tests](develop/test_execution.md)
 - [How blade-build itself is tested](develop/self_testing.md)
 

--- a/doc/en/develop/console.md
+++ b/doc/en/develop/console.md
@@ -128,4 +128,6 @@ their own `description`.
   summary appear.
 - **Color off** (`_color_enabled` false): the bar uses glyph shades and
   descriptions are plain.
+- **Quiet** (`is_quiet()`): the recent-completions window is dropped — only the
+  aggregate bar is shown, no per-step descriptions.
 - **Verbose**: no panel at all; ninja owns the terminal.

--- a/doc/en/develop/console.md
+++ b/doc/en/develop/console.md
@@ -1,0 +1,131 @@
+# The console: the build progress panel and the ninja status pipeline
+
+`console.py` owns all of Blade's terminal decoration — colors, the cursor, and
+the live **build progress panel**. The interesting part is how that panel is
+driven: stock ninja exposes no structured progress API, so Blade reconstructs
+the panel from ninja's plain status text. This note explains that pipeline.
+
+| File | Role |
+| --- | --- |
+| `src/blade/console.py` | Color, cursor, the progress panel renderer + clear path |
+| `src/blade/ninja_runner.py` | Runs ninja, captures its output, parses the status stream |
+| `src/blade/ninja_rule.py` | `NinjaRule.emit()` — bakes the (colored) `description` into each rule |
+| `src/blade/gen_rule_target.py`, `src/blade/windows_resources_target.py` | Per-target local rules; must color their own `description` |
+
+## 1. Why parse ninja's stdout (and not an event API)
+
+Ninja has **no** structured progress channel in the upstream tree. The protobuf
+"frontend" interface (ninja PR #1210) was never merged, and bundling a fork just
+for it isn't worth a protobuf dependency. So the only live signal is ninja's
+status text.
+
+Two facts about that text (see ninja `src/status_printer.cc`) shape the design:
+
+- **Smart terminal**: ninja prints a status line on edge *start* and *finish*,
+  overwriting in place with `\r`, and leaves the last line on screen — this is
+  the leftover `[226/226] LINK …` line Blade used to show.
+- **Piped / dumb** (what Blade uses): ninja prints **only on edge finish**, one
+  line per completed edge, newline-terminated — and a separate `FAILED:` /
+  `ninja: …` block on error. Edge *starts* are not printed.
+
+So when Blade pipes ninja, it gets a clean, parseable stream: one
+`[finished/total](running) <desc>` per completion, plus distinct error blocks.
+The format is fixed by `NINJA_STATUS='[%f/%t](%r) '` (`%f`/`%t`/`%r` =
+finished/total/running). Because dumb mode is finish-only, Blade can show the
+**count** of running edges (`%r`) but not *which* edges are running — the
+per-running-task identity would require the (unavailable) frontend protocol.
+
+## 2. Two run modes (`ninja_runner._run_ninja_build`)
+
+- **Verbose** (`-v`): hand the terminal straight to ninja
+  (`_run_ninja_command`) so every command is printed in full. No panel.
+- **Otherwise** (default + quiet): redirect ninja's stdout+stderr to
+  `blade-bin/ninja_output.log` and tail it with `_show_progress`. Redirecting is
+  what puts ninja in dumb mode, giving the finish-only stream above.
+
+## 3. The parse loop (`ninja_runner._show_progress`)
+
+A single reader loop classifies each line:
+
+- Matches `^\[(\d+)/(\d+)\]\((\d+)\)\s+(.*)$` → a completed edge: update
+  finished/total/running, push the description into a bounded
+  `deque(maxlen=_PANEL_MAX_RECENT)`, compute ETA, and call
+  `console.render_build_panel(...)`. (`%r` is decremented by one — ninja prints
+  the finishing edge before decrementing its running counter.)
+- Anything else → `console.output(line)`: a **permanent** line (warnings,
+  errors, `ninja: …`). Leading indentation is preserved.
+- On exit: clear the panel; on clean success print `"<N> build steps
+  completed"`, which replaces the panel — no leftover `[N/N]` line.
+
+## 4. Transient panel vs permanent output
+
+The whole design rests on one split:
+
+- The **panel** is *transient* — it lives at the bottom of the screen and is
+  redrawn / erased in place.
+- Everything else is *permanent* — printed with a trailing newline so it scrolls
+  up and stays.
+
+`console.output()` → `_do_print()` calls `_clear_progress_bar_locked()` **before**
+printing. So when an error/warning arrives, the panel is wiped first, the message
+is printed permanently above, and the next progress line repaints the panel below
+it. Consequently **only Blade's own panel is ever erased — a real error is never
+overwritten.** This is what makes "the last line might be an error" a non-issue.
+
+## 5. Rendering the panel (`console.render_build_panel`)
+
+The panel is a list of lines: a header (the bar) + the recent-completions window.
+Drawing in place:
+
+- Track `_region_height` = lines currently on screen.
+- To redraw: move the cursor up `_region_height` lines (`\033[{n}A`), then
+  `\r\033[J` (carriage return + clear-to-end-of-display) wipes the old panel and
+  anything below, then print the new lines and park the cursor on the empty line
+  *below* the panel — so the next redraw moves up exactly `_region_height`.
+- The cursor is hidden while the panel is on screen (`_hide_cursor_locked`) and
+  restored on clear and via an `atexit` hook, so an interrupted build never
+  leaves the terminal cursorless.
+- Repaints are throttled (`_PROGRESS_REFRESH_INTERVAL`), but the final 100% frame
+  always paints.
+
+The clear path is unified: `_clear_progress_bar_locked()` wipes the multi-line
+panel when `_region_height > 0`, else the single-line bar (`\r` + clear-to-EOL).
+Both also re-show the cursor.
+
+## 6. The tri-state grayscale bar (`console._tri_state_bar`)
+
+`%f`/`%r`/`%t` give three zones: **done** (finished), **running**, and
+**remaining** (`total - finished - running`). The bar paints them in three
+grayscale shades — bright / mid / dark (`\033[38;5;{252,245,238}m` block glyphs)
+— so the build state reads at a glance. Segment widths use a **cumulative floor**
+so they always sum to the bar width exactly:
+
+```python
+done_w = width * finished // total
+run_w  = width * (finished + running) // total - done_w
+rem_w  = width - done_w - run_w
+```
+
+When color is off, it falls back to distinct block glyphs (`█` / `▒` / `░`). The
+bar width is sized so the header (`finished/total pct% ·running running  ETA …`)
+fits one line; the recent-window lines are truncated to the terminal width — both
+matter because a wrapped line would break the cursor-up math.
+
+## 7. Rule descriptions are colored at generation time
+
+What shows after `[N/N]` is the rule's ninja `description`, expanded by ninja.
+Color is baked into that string **when the ninja file is generated**, not at
+print time: `NinjaRule.emit()` wraps it in `console.colored(desc, 'dimpurple')`
+(which returns plain text when color is off). Per-target *local* rules must do
+the same, or they show up uncolored in the panel while every other step is
+colored — this is why `gen_rule` and `windows_resources` (the `RC` rule) color
+their own `description`.
+
+## 8. Degradation
+
+- **Non-TTY / redirected** (`_cursor_control` false): `render_build_panel` is a
+  no-op — no escape codes leak into a pipe or log; only permanent lines + the
+  summary appear.
+- **Color off** (`_color_enabled` false): the bar uses glyph shades and
+  descriptions are plain.
+- **Verbose**: no panel at all; ninja owns the terminal.

--- a/doc/zh_CN/develop.md
+++ b/doc/zh_CN/develop.md
@@ -95,6 +95,7 @@ Blade 调用后端构建工具（Ninja）执行实际构建，完成后删除生
 - [`proto_library` 的多语言代码生成](develop/protobuf_build.md)
 - [Java 与 Scala 程序的构建](develop/java_scala_build.md)
 - [Python 目标的构建与打包](develop/python_build.md)
+- [console：构建进度面板与 ninja 状态流水线](develop/console.md)
 - [`blade test` 如何运行用户测试](develop/test_execution.md)
 - [blade-build 自身是如何被测试的](develop/self_testing.md)
 

--- a/doc/zh_CN/develop/console.md
+++ b/doc/zh_CN/develop/console.md
@@ -1,0 +1,110 @@
+# console：构建进度面板与 ninja 状态流水线
+
+`console.py` 掌管 Blade 所有终端修饰——颜色、光标,以及实时的**构建进度面板**。
+有意思的是这个面板**怎么来的**:官方 ninja 没有结构化的进度 API,所以 Blade
+从 ninja 的纯文本状态流里把面板重建出来。本文讲这条流水线。
+
+| 文件 | 作用 |
+| --- | --- |
+| `src/blade/console.py` | 颜色、光标、进度面板渲染 + 擦除路径 |
+| `src/blade/ninja_runner.py` | 运行 ninja、捕获输出、解析状态流 |
+| `src/blade/ninja_rule.py` | `NinjaRule.emit()`——把(带色的)`description` 烤进每条 rule |
+| `src/blade/gen_rule_target.py`、`src/blade/windows_resources_target.py` | 每目标本地 rule;须自己给 `description` 上色 |
+
+## 1. 为什么解析 ninja 的 stdout（而不是事件 API）
+
+上游 ninja **没有**结构化进度通道。protobuf 的「frontend」接口(ninja PR #1210)
+从未合入主线,为它单独绑一个 fork + protobuf 依赖不值当。所以唯一的实时信号
+就是 ninja 的状态文本。
+
+关于这段文本的两个事实(见 ninja `src/status_printer.cc`)决定了设计:
+
+- **智能终端**:ninja 在 edge *开始*和*结束*各打一行状态,用 `\r` 原地覆盖,
+  并把最后一行留屏——这就是 Blade 以前残留的 `[226/226] LINK …`。
+- **管道 / dumb**(Blade 用的):ninja **只在 edge 结束时**打印,每完成一条一行、
+  以换行结尾;出错另有 `FAILED:` / `ninja: …` 块。edge *开始*不打印。
+
+所以 Blade 一旦用管道,就得到一条干净可解析的流:每完成一条一行
+`[finished/total](running) <desc>`,外加独立的报错块。格式由
+`NINJA_STATUS='[%f/%t](%r) '` 固定(`%f`/`%t`/`%r` = 完成/总数/在跑)。因为
+dumb 模式只在结束时打印,Blade 能显示在跑的**数量**(`%r`),却拿不到**是哪几条**
+在跑——逐个在跑任务的身份需要(不可用的)frontend 协议。
+
+## 2. 两种运行模式（`ninja_runner._run_ninja_build`）
+
+- **verbose**(`-v`):把终端直接交给 ninja(`_run_ninja_command`),完整打印每条
+  命令。无面板。
+- **其它**(默认 + quiet):把 ninja 的 stdout+stderr 重定向到
+  `blade-bin/ninja_output.log`,用 `_show_progress` 追读。重定向正是让 ninja 进入
+  dumb 模式、给出上面那条「只在结束时」的流。
+
+## 3. 解析循环（`ninja_runner._show_progress`）
+
+单个读取循环对每行分类:
+
+- 匹配 `^\[(\d+)/(\d+)\]\((\d+)\)\s+(.*)$` → 一条完成的 edge:更新
+  完成/总数/在跑,把描述压入有界的 `deque(maxlen=_PANEL_MAX_RECENT)`,算出 ETA,
+  调 `console.render_build_panel(...)`。(`%r` 减一——ninja 在给在跑计数减一之前
+  就打印了正在结束的这条。)
+- 其它 → `console.output(line)`:**永久**行(警告、错误、`ninja: …`)。保留前导缩进。
+- 退出时:擦掉面板;干净成功则打印 `"<N> build steps completed"` 取代面板——
+  不留 `[N/N]` 残行。
+
+## 4. 瞬态面板 vs 永久输出
+
+整个设计建立在一个区分上:
+
+- **面板**是*瞬态*的——它待在屏幕底部,原地重绘 / 擦除。
+- 其它都是*永久*的——带换行打印,滚上去并留住。
+
+`console.output()` → `_do_print()` 会在打印**之前**调 `_clear_progress_bar_locked()`。
+所以报错/警告一到,先擦掉面板,消息永久打印在上方,下一条进度行再在其下方重画面板。
+于是**被擦的永远只是 Blade 自己的面板——真正的报错绝不会被覆盖**。这正是让
+「最后一行可能是报错」不再成为问题的关键。
+
+## 5. 渲染面板（`console.render_build_panel`）
+
+面板是一组行:表头(进度条)+ 最近完成窗口。原地绘制:
+
+- 记 `_region_height` = 当前在屏行数。
+- 重绘:光标上移 `_region_height` 行(`\033[{n}A`),再 `\r\033[J`(回车 +
+  清到屏幕末尾)擦掉旧面板及其下方一切,然后打印新行,并把光标停在面板*下方*的
+  空行——这样下次重绘正好上移 `_region_height`。
+- 面板在屏时隐藏光标(`_hide_cursor_locked`),并在擦除时及 `atexit` 钩子里恢复,
+  所以被中断的构建不会留下没有光标的终端。
+- 重绘有节流(`_PROGRESS_REFRESH_INTERVAL`),但最后的 100% 帧一定画。
+
+擦除路径是统一的:`_clear_progress_bar_locked()` 在 `_region_height > 0` 时擦多行
+面板,否则擦单行进度条(`\r` + 清到行尾)。两者都会重新显示光标。
+
+## 6. 三段灰度进度条（`console._tri_state_bar`）
+
+`%f`/`%r`/`%t` 给出三段:**已完成**、**进行中**、**未开始**
+(`total - finished - running`)。进度条用三档灰度——亮 / 中 / 暗
+(`\033[38;5;{252,245,238}m` 的方块字符)——一眼看出构建状态。段宽用**累积取整**,
+保证三段之和恒等于条宽:
+
+```python
+done_w = width * finished // total
+run_w  = width * (finished + running) // total - done_w
+rem_w  = width - done_w - run_w
+```
+
+无颜色时退回三种可辨的方块字符(`█` / `▒` / `░`)。条宽按「表头一行放得下」来定
+(`finished/total pct% ·running running  ETA …`),最近窗口的行按终端宽度截断——
+两者都重要,因为一旦折行就会打乱「上移 N 行」的计算。
+
+## 7. rule 的 description 在生成期就上好色
+
+`[N/N]` 后面显示的是 rule 的 ninja `description`,由 ninja 展开。颜色是
+**在生成 ninja 文件时**烤进那个字符串的,而非打印时:`NinjaRule.emit()` 用
+`console.colored(desc, 'dimpurple')` 包起来(颜色关闭时返回纯文本)。每目标的
+*本地* rule 必须照做,否则它在面板里没颜色、而其它步骤都有色——这就是
+`gen_rule` 和 `windows_resources`(`RC` rule)要给自己的 `description` 上色的原因。
+
+## 8. 退化
+
+- **非 TTY / 重定向**(`_cursor_control` 为假):`render_build_panel` 直接空操作——
+  不往管道/日志里漏控制码;只出现永久行 + 汇总。
+- **颜色关闭**(`_color_enabled` 为假):进度条用方块字符档位,描述为纯文本。
+- **verbose**:完全没有面板;ninja 独占终端。

--- a/doc/zh_CN/develop/console.md
+++ b/doc/zh_CN/develop/console.md
@@ -107,4 +107,5 @@ rem_w  = width - done_w - run_w
 - **非 TTY / 重定向**(`_cursor_control` 为假):`render_build_panel` 直接空操作——
   不往管道/日志里漏控制码;只出现永久行 + 汇总。
 - **颜色关闭**(`_color_enabled` 为假):进度条用方块字符档位,描述为纯文本。
+- **quiet**(`is_quiet()`):去掉最近完成窗口——只显示聚合进度条,不显示逐条描述。
 - **verbose**:完全没有面板;ninja 独占终端。

--- a/src/blade/console.py
+++ b/src/blade/console.py
@@ -257,13 +257,13 @@ def _compute_progress_bar_width(total):
 
 
 def _progress_bar(progress, current, total):
-    """Progress bar drawing text, like this:
-    [===========================================================----] 46/50 92%
+    """Single-line progress bar in the panel's grayscale style (a two-zone case
+    of the tri-state bar: done / remaining), like this:
+    ██████████████████████████████████████████░░░░░░░░░░ 46/50 92%
     """
     bar_width = _compute_progress_bar_width(total)
-    filled = progress * bar_width // 100
-    return '[{}{}] {}/{} {:g}%'.format('=' * filled, '-' * (bar_width - filled),
-                                  current, total, progress)
+    return '%s %d/%d %d%%' % (_tri_state_bar(current, 0, total, bar_width),
+                              current, total, progress)
 
 
 def _need_refresh_progress_bar(current, total, now):

--- a/src/blade/console.py
+++ b/src/blade/console.py
@@ -100,6 +100,9 @@ _COLORS = {
 # column 0 and the whole visible line is wiped, including any tail left by a
 # previous, longer frame (e.g. "99/100 99%" -> "1/100 1%").
 _CLEAR_TO_EOL = '\033[K'
+# Erase from the cursor to the end of the screen -- used to wipe the whole
+# multi-line build panel in one shot (the panel always sits at the bottom).
+_CLEAR_TO_DISPLAY_END = '\033[J'
 
 # Cursor visibility. Hide while the progress bar owns the last line so the
 # blinking block at the end of the bar doesn't sit there looking sloppy.
@@ -229,6 +232,12 @@ _PROGRESS_REFRESH_INTERVAL = 0.2
 
 _last_progress_value = -1  # The last progress bar value, -1 means none
 _last_progress_time = 0
+# Number of lines the multi-line build panel currently occupies on screen
+# (0 = none). When > 0 the clear path wipes the whole panel instead of a single
+# bar line. The panel and the single-line bar are mutually exclusive per build.
+_region_height = 0
+# Cap on the sliding window of recent completed steps shown in the panel.
+_PANEL_MAX_RECENT = 10
 # True iff a progress frame is currently on screen and we owe both a clear
 # (\r + \033[K) and a show-cursor (\033[?25h). Tracks "there's a frame to wipe"
 # and "we hid the cursor" together because those two facts are flipped in
@@ -292,12 +301,19 @@ def show_progress_bar(current, total):
 
 
 def _clear_progress_bar_locked():
-    """Erase the progress bar in place. Caller must hold _print_lock."""
-    global _cursor_hidden, _last_progress_value, _last_progress_time
-    if _cursor_hidden and _cursor_control:
+    """Erase the progress bar / panel in place. Caller must hold _print_lock."""
+    global _cursor_hidden, _last_progress_value, _last_progress_time, _region_height
+    if _cursor_control and (_cursor_hidden or _region_height):
         # Wipe the frame and hand the cursor back, in a single flush so that
         # any subsequent message lands on a clean line with a visible cursor.
-        sys.stderr.write('\r' + _CLEAR_TO_EOL + _SHOW_CURSOR)
+        if _region_height:
+            # Multi-line panel: go to its top line and clear it + everything
+            # below (the panel always sits at the bottom of the screen).
+            sys.stderr.write('\033[%dA\r%s%s' % (
+                _region_height, _CLEAR_TO_DISPLAY_END, _SHOW_CURSOR))
+            _region_height = 0
+        else:
+            sys.stderr.write('\r' + _CLEAR_TO_EOL + _SHOW_CURSOR)
         sys.stderr.flush()
     _cursor_hidden = False
     _last_progress_value = -1
@@ -307,6 +323,87 @@ def _clear_progress_bar_locked():
 def clear_progress_bar():
     with _print_lock:
         _clear_progress_bar_locked()
+
+
+# Grayscale ramp for the tri-state bar: done (bright) / running (mid) /
+# remaining (dark). 256-color grays; falls back to shade glyphs without color.
+_GRAY_DONE = '\033[38;5;252m'
+_GRAY_RUNNING = '\033[38;5;245m'
+_GRAY_REMAINING = '\033[38;5;238m'
+_GRAY_RESET = '\033[0m'
+_BLOCK = '█'  # full block
+
+
+def _tri_state_bar(finished, running, total, width):
+    """A progress bar split into done / running / remaining zones, shaded by
+    grayscale when color is on, or by block glyphs (full/medium/light) otherwise.
+    Segment widths use a cumulative floor so they always sum to ``width``.
+    """
+    if total <= 0:
+        total = 1
+    done_w = width * finished // total
+    run_w = width * (finished + running) // total - done_w
+    rem_w = width - done_w - run_w
+    if _color_enabled:
+        return (_GRAY_DONE + _BLOCK * done_w + _GRAY_RUNNING + _BLOCK * run_w +
+                _GRAY_REMAINING + _BLOCK * rem_w + _GRAY_RESET)
+    return _BLOCK * done_w + '▒' * run_w + '░' * rem_w
+
+
+def _format_eta(seconds):
+    if seconds is None or seconds < 0:
+        return ''
+    seconds = int(seconds)
+    if seconds >= 3600:
+        return '  ETA %d:%02d:%02d' % (seconds // 3600, seconds % 3600 // 60, seconds % 60)
+    return '  ETA %d:%02d' % (seconds // 60, seconds % 60)
+
+
+def _truncate(text, width):
+    """Clip a plain (uncolored) line to ``width`` columns with an ellipsis."""
+    if width <= 0:
+        return ''
+    return text if len(text) <= width else text[:width - 1] + '…'
+
+
+def _build_panel_lines(finished, running, total, recent, eta):
+    size = shutil.get_terminal_size((80, 24))
+    pct = finished * 100 // total if total else 0
+    head = ' %d/%d %d%% ·%d running%s' % (finished, total, pct, running, _format_eta(eta))
+    # Size the bar so the header fits one line (the bar glyphs are 1 column each;
+    # color codes are zero-width). 1 column of right margin avoids auto-wrap.
+    bar_w = max(_MIN_PROGRESS_BAR_WIDTH,
+                min(_MAX_PROGRESS_BAR_WIDTH, size.columns - len(head) - 1))
+    lines = [_tri_state_bar(finished, running, total, bar_w) + head]
+    # Cap the recent-window height to both the configured max and the terminal.
+    max_recent = max(1, min(len(recent), _PANEL_MAX_RECENT, size.lines - 2))
+    for desc in list(recent)[-max_recent:]:
+        lines.append(_truncate('  ' + desc, size.columns - 1))
+    return lines
+
+
+def render_build_panel(finished, running, total, recent, eta=None):
+    """Draw the live build panel: a tri-state grayscale bar + a sliding window of
+    the most recent completed steps. Redrawn in place at the bottom of the
+    screen; throttled, but always paints the final 100% frame.
+    """
+    global _region_height, _last_progress_time
+    if not _cursor_control or total <= 0:
+        return
+    now = time.time()
+    if finished != total and now - _last_progress_time < _PROGRESS_REFRESH_INTERVAL:
+        return
+    lines = _build_panel_lines(finished, running, total, recent, eta)
+    with _print_lock:
+        _hide_cursor_locked()
+        if _region_height:
+            sys.stderr.write('\033[%dA' % _region_height)  # to top of old panel
+        # Clear the old panel + anything below, then paint; park the cursor on
+        # the empty line under the panel so the next redraw moves up exactly N.
+        sys.stderr.write('\r' + _CLEAR_TO_DISPLAY_END + '\n'.join(lines) + '\n')
+        sys.stderr.flush()
+        _region_height = len(lines)
+        _last_progress_time = now
 
 
 def _restore_cursor_at_exit():

--- a/src/blade/ninja_runner.py
+++ b/src/blade/ninja_runner.py
@@ -95,6 +95,8 @@ def _show_progress(process, file_reader):
     """
     progress_re = re.compile(r'^\[(\d+)/(\d+)\]\((\d+)\)\s+(.*)$')
     recent = collections.deque(maxlen=console._PANEL_MAX_RECENT)
+    # In quiet mode show only the aggregate bar, not the per-step descriptions.
+    quiet = console.is_quiet()
     total = finished = 0
     start = time.time()
     try:
@@ -110,7 +112,8 @@ def _show_progress(process, file_reader):
                     recent.append(m.group(4))
                     elapsed = time.time() - start
                     eta = (total - finished) * elapsed / finished if finished else None
-                    console.render_build_panel(finished, running, total, recent, eta)
+                    window = () if quiet else recent
+                    console.render_build_panel(finished, running, total, window, eta)
                 elif line:
                     console.output(line)
             elif process.returncode is not None:

--- a/src/blade/ninja_runner.py
+++ b/src/blade/ninja_runner.py
@@ -9,6 +9,7 @@ The ninja runner module.
 """
 
 
+import collections
 import os
 import re
 import subprocess
@@ -58,12 +59,15 @@ def _build_options(options):
 def _run_ninja_build(cmd, options):
     """Run the "ninja" program with interactive."""
     cmdstr = ' '.join(cmd)
-    if options.verbosity > console.Verbosity.QUIET:
+    if options.verbosity >= console.Verbosity.VERBOSE:
+        # Verbose: let ninja own the terminal and print every command in full.
         return _run_ninja_command(cmdstr)
-    # In quiet mode, redirect ninja output to the file
+    # Otherwise capture ninja's output and render our own build panel: ninja,
+    # writing to a pipe/file (not a smart terminal), emits one line per finished
+    # edge as '[finished/total](running) <desc>' -- easy to parse.
     ninja_output = 'blade-bin/ninja_output.log'
+    os.environ['NINJA_STATUS'] = '[%f/%t](%r) '  # the panel parser depends on this
     with open(ninja_output, 'w', buffering=1) as wf, open(ninja_output, buffering=1) as rf:
-        os.environ['NINJA_STATUS'] = '[%f/%t] '  # The progress depends on this format
         p = subprocess.Popen(cmdstr, shell=True, stdout=wf, stderr=subprocess.STDOUT)
         _show_progress(p, rf)
     return p.returncode
@@ -81,28 +85,43 @@ def _run_ninja_command(cmdstr):
 
 
 def _show_progress(process, file_reader):
+    """Render ninja's '[finished/total](running) <desc>' status stream as a live
+    build panel: a tri-state grayscale bar + a sliding window of recent steps.
+
+    Each parsed line drives the panel; anything else (compiler warnings/errors,
+    'ninja: ...') is printed permanently -- console.output auto-clears the panel
+    first, so those messages scroll above it and are never overwritten. On clean
+    success a one-line summary replaces the panel.
     """
-    Convert description message such as '[1/123] CC xxx.cc' into progress bar.
-    """
-    progress_re = re.compile(r'^\[(\d+)/(\d+)\]\s+')
+    progress_re = re.compile(r'^\[(\d+)/(\d+)\]\((\d+)\)\s+(.*)$')
+    recent = collections.deque(maxlen=console._PANEL_MAX_RECENT)
+    total = finished = 0
+    start = time.time()
     try:
         while True:
             process.poll()
-            line = file_reader.readline().strip()
+            line = file_reader.readline()
             if line:
+                line = line.rstrip('\r\n')  # keep leading indent of error output
                 m = progress_re.match(line)
                 if m:
-                    console.show_progress_bar(int(m.group(1)), int(m.group(2)))
-                else:
-                    console.clear_progress_bar()
+                    finished, total = int(m.group(1)), int(m.group(2))
+                    running = max(0, int(m.group(3)) - 1)  # %r counts the finishing edge
+                    recent.append(m.group(4))
+                    elapsed = time.time() - start
+                    eta = (total - finished) * elapsed / finished if finished else None
+                    console.render_build_panel(finished, running, total, recent, eta)
+                elif line:
                     console.output(line)
             elif process.returncode is not None:
                 break
             else:
                 # Avoid cost too much cpu
-                time.sleep(0.1)
+                time.sleep(0.05)
     finally:
-        console.clear_progress_bar()
+        console.clear_progress_bar()  # wipe the panel
+        if process.returncode == 0 and total:
+            console.output('%d build steps completed' % total)
 
 
 def _show_slow_builds(build_dir, build_start_time, show_builds_slower_than):

--- a/src/blade/windows_resources_target.py
+++ b/src/blade/windows_resources_target.py
@@ -150,8 +150,11 @@ class WindowsResourcesTarget(Target):
         # Per-target ninja rule for rc.exe
         rule_name = 'rc_%s' % regular_variable_name(self._source_file_path(self.name))
         rc_command = '"%s" /nologo /fo${out} %s ${in}' % (rc_exe, inc_flags)
-        self._write_rule('rule %s\n  command = %s\n  description = RC ${in}\n' % (
-            rule_name, rc_command))
+        # Color the description like the backend rules (ninja_rule.emit) and
+        # gen_rule do, so it shows up colored in the build progress panel.
+        description = console.colored('RC ${in}', 'dimpurple')
+        self._write_rule('rule %s\n  command = %s\n  description = %s\n' % (
+            rule_name, rc_command, description))
 
         # Build edges: one per .rc file
         rc_inputs = [self._source_file_path(rc) for rc in self.attr['rc_files']]

--- a/src/tests/unit/build_panel_test.py
+++ b/src/tests/unit/build_panel_test.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Tests for the multi-line build progress panel: the tri-state grayscale bar,
+ETA/truncation helpers, panel-line assembly, in-place redraw/clear escape
+sequences, and the ninja status-line parser format.
+"""
+
+import io
+import os
+import re
+import sys
+import unittest
+import unittest.mock as mock
+from contextlib import redirect_stderr
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import console  # noqa: E402
+
+
+class TriStateBarTest(unittest.TestCase):
+    def test_segments_sum_to_width_no_color(self):
+        with mock.patch.object(console, '_color_enabled', False):
+            bar = console._tri_state_bar(2, 3, 10, 10)
+        # 10 glyphs total: 2 done (█), 3 running (▒), 5 remaining (░)
+        self.assertEqual(len(bar), 10)
+        self.assertEqual(bar, '█' * 2 + '▒' * 3 + '░' * 5)
+
+    def test_rounding_keeps_total_width(self):
+        with mock.patch.object(console, '_color_enabled', False):
+            for f in range(0, 8):
+                for r in range(0, 8 - f):
+                    bar = console._tri_state_bar(f, r, 7, 23)
+                    self.assertEqual(len(bar), 23, (f, r))
+
+    def test_color_uses_grayscale_ramp(self):
+        with mock.patch.object(console, '_color_enabled', True):
+            bar = console._tri_state_bar(1, 1, 4, 4)
+        self.assertIn(console._GRAY_DONE, bar)
+        self.assertIn(console._GRAY_RUNNING, bar)
+        self.assertIn(console._GRAY_REMAINING, bar)
+        self.assertTrue(bar.endswith(console._GRAY_RESET))
+
+
+class HelperTest(unittest.TestCase):
+    def test_format_eta(self):
+        self.assertEqual(console._format_eta(None), '')
+        self.assertEqual(console._format_eta(-1), '')
+        self.assertEqual(console._format_eta(5), '  ETA 0:05')
+        self.assertEqual(console._format_eta(125), '  ETA 2:05')
+        self.assertEqual(console._format_eta(3725), '  ETA 1:02:05')
+
+    def test_truncate(self):
+        self.assertEqual(console._truncate('abc', 10), 'abc')
+        self.assertEqual(console._truncate('abcdef', 4), 'abc…')
+        self.assertEqual(console._truncate('abc', 0), '')
+
+
+class PanelLinesTest(unittest.TestCase):
+    def test_header_and_window(self):
+        with mock.patch.object(console.shutil, 'get_terminal_size',
+                               return_value=os.terminal_size((120, 40))), \
+             mock.patch.object(console, '_color_enabled', False):
+            lines = console._build_panel_lines(8, 2, 10, ['CC a.cc', 'CC b.cc'], 5)
+        self.assertIn('8/10', lines[0])
+        self.assertIn('80%', lines[0])
+        self.assertIn('2 running', lines[0])
+        self.assertIn('ETA 0:05', lines[0])
+        self.assertEqual(lines[1:], ['  CC a.cc', '  CC b.cc'])
+
+    def test_window_capped_by_max(self):
+        recent = ['step %d' % i for i in range(50)]
+        with mock.patch.object(console.shutil, 'get_terminal_size',
+                               return_value=os.terminal_size((120, 100))), \
+             mock.patch.object(console, '_color_enabled', False):
+            lines = console._build_panel_lines(50, 0, 50, recent, None)
+        self.assertEqual(len(lines), 1 + console._PANEL_MAX_RECENT)  # header + cap
+        self.assertEqual(lines[-1], '  step 49')                     # newest kept
+
+
+class RenderClearTest(unittest.TestCase):
+    def setUp(self):
+        # reset module render state between tests
+        console._region_height = 0
+        console._cursor_hidden = False
+        console._last_progress_time = 0
+
+    def tearDown(self):
+        # don't leak the singleton render state into other test modules
+        console._region_height = 0
+        console._cursor_hidden = False
+        console._last_progress_time = 0
+
+    def _render(self, **kw):
+        buf = io.StringIO()
+        with mock.patch.object(console, '_cursor_control', True), \
+             mock.patch.object(console, '_color_enabled', False), \
+             mock.patch.object(console.shutil, 'get_terminal_size',
+                               return_value=os.terminal_size((120, 40))), \
+             mock.patch.object(console.sys, 'stderr', buf), \
+             redirect_stderr(buf):
+            console.render_build_panel(**kw)
+        return buf.getvalue()
+
+    def test_first_render_sets_height_no_cursor_up(self):
+        out = self._render(finished=1, running=1, total=3, recent=['a', 'b'])
+        self.assertNotIn('\033[0A', out)
+        self.assertNotIn('A', out.replace('ETA', ''))  # no cursor-up on first frame
+        self.assertIn(console._CLEAR_TO_DISPLAY_END, out)
+        self.assertEqual(console._region_height, 3)    # header + 2 recent
+
+    def test_redraw_moves_cursor_up_by_prev_height(self):
+        self._render(finished=3, running=0, total=3, recent=['a', 'b'])  # height 3
+        out = self._render(finished=3, running=0, total=3, recent=['a', 'b', 'c'])
+        self.assertIn('\033[3A', out)  # moved up by the previous panel height
+
+    def test_clear_wipes_panel(self):
+        self._render(finished=3, running=0, total=3, recent=['a', 'b'])  # height 3
+        buf = io.StringIO()
+        with mock.patch.object(console, '_cursor_control', True), \
+             mock.patch.object(console.sys, 'stderr', buf):
+            console.clear_progress_bar()
+        self.assertIn('\033[3A', buf.getvalue())
+        self.assertIn(console._CLEAR_TO_DISPLAY_END, buf.getvalue())
+        self.assertEqual(console._region_height, 0)
+
+
+class NinjaStatusFormatTest(unittest.TestCase):
+    def test_parse_finished_total_running_desc(self):
+        rx = re.compile(r'^\[(\d+)/(\d+)\]\((\d+)\)\s+(.*)$')
+        m = rx.match('[12/100](4) CC foo/bar.cc')
+        self.assertEqual(m.groups(), ('12', '100', '4', 'CC foo/bar.cc'))
+        self.assertIsNone(rx.match('FAILED: [code=1] foo.o'))
+        self.assertIsNone(rx.match('ninja: build stopped: subcommand failed.'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/unit/build_panel_test.py
+++ b/src/tests/unit/build_panel_test.py
@@ -71,6 +71,14 @@ class PanelLinesTest(unittest.TestCase):
         self.assertIn('ETA 0:05', lines[0])
         self.assertEqual(lines[1:], ['  CC a.cc', '  CC b.cc'])
 
+    def test_empty_window_is_header_only(self):
+        # quiet mode passes an empty window -> just the aggregate bar line
+        with mock.patch.object(console.shutil, 'get_terminal_size',
+                               return_value=os.terminal_size((120, 40))), \
+             mock.patch.object(console, '_color_enabled', False):
+            lines = console._build_panel_lines(3, 1, 10, [], None)
+        self.assertEqual(len(lines), 1)
+
     def test_window_capped_by_max(self):
         recent = ['step %d' % i for i in range(50)]
         with mock.patch.object(console.shutil, 'get_terminal_size',

--- a/src/tests/unit/console_test.py
+++ b/src/tests/unit/console_test.py
@@ -90,8 +90,11 @@ class ProgressBarFrameTest(_ConsoleStateMixin, unittest.TestCase):
         # doesn't affect the redraw geometry.
         console.show_progress_bar(5, 10)
         out = self.stderr.getvalue()
-        self.assertIn('\r[', out,
-                      f'expected CR + [ inside the frame, got {out!r}')
+        # column 0 (\r) then the bar (grayscale blocks); trailing \033[K wipes
+        # any leftover tail from a previous, longer frame.
+        self.assertIn('\r' + console._GRAY_DONE, out,
+                      f'expected CR + bar start inside the frame, got {out!r}')
+        self.assertIn('5/10', out)
         self.assertTrue(out.endswith('\x1b[K'),
                         f'expected trailing \\033[K, got {out[-6:]!r}')
 
@@ -135,7 +138,7 @@ class ProgressBarRefreshLogicTest(_ConsoleStateMixin, unittest.TestCase):
         console.show_progress_bar(1, 100)
         # Immediately push a distinct value — still within the 200ms window.
         console.show_progress_bar(2, 100)
-        self.assertEqual(self.stderr.getvalue().count('\r['), 1,
+        self.assertEqual(self.stderr.getvalue().count('\r' + console._GRAY_DONE), 1,
                          'second frame within throttle window should be dropped')
 
     def test_100_percent_is_always_painted_even_when_throttled(self):
@@ -299,7 +302,7 @@ class ConcurrencyTest(_ConsoleStateMixin, unittest.TestCase):
 
     def test_messages_never_split_a_progress_frame(self):
         # Run many progress redraws and many message prints in parallel.
-        # With the lock, every frame ('\r[' ... '\033[K') must be a
+        # With the lock, every frame ('\r' + bar-start ... '\033[K') must be a
         # contiguous, uninterrupted byte range — no message text in the
         # middle.
         with patch.object(console, '_PROGRESS_REFRESH_INTERVAL', 0):
@@ -317,14 +320,16 @@ class ConcurrencyTest(_ConsoleStateMixin, unittest.TestCase):
             t1.start(); t2.start(); t1.join(); t2.join()
 
         out = self.stderr.getvalue()
-        # Walk the byte stream looking for frame starts. '\r[' marks a frame
-        # (note: '\r\033[K' from a clear doesn't match — '\r' is followed by
-        # '\033', not '['). Between '\r[' and the next '\033[K' there must
-        # be no newline, otherwise a message leaked into the frame.
+        # Walk the byte stream looking for frame starts. '\r' + the grayscale
+        # "done" code marks a painted bar frame (a clear is '\r\033[K', whose
+        # '\r' is followed by the EOL-clear, not the gray code). Between the
+        # frame start and the next '\033[K' there must be no newline, otherwise
+        # a message leaked into the frame.
+        marker = '\r' + console._GRAY_DONE
         i = 0
         frames_seen = 0
         while True:
-            start = out.find('\r[', i)
+            start = out.find(marker, i)
             if start < 0:
                 break
             end = out.find('\x1b[K', start)

--- a/src/tests/unit/console_test.py
+++ b/src/tests/unit/console_test.py
@@ -55,6 +55,7 @@ class _ConsoleStateMixin:
             '_last_progress_value': console._last_progress_value,
             '_last_progress_time': console._last_progress_time,
             '_cursor_hidden': console._cursor_hidden,
+            '_region_height': console._region_height,
             '_log': console._log,
         }
         console._cursor_control = True
@@ -62,6 +63,7 @@ class _ConsoleStateMixin:
         console._last_progress_value = -1
         console._last_progress_time = 0
         console._cursor_hidden = False
+        console._region_height = 0
         self._real_stderr = sys.stderr
         self._real_stdout = sys.stdout
         self.stderr = io.StringIO()


### PR DESCRIPTION
> **Do not merge yet** — opening for CI + review; @chen3feng is testing it on macOS (flare) first.

Replaces ninja's leftover in-place status line with a Blade-rendered live panel.

### What it shows
- **Tri-state grayscale bar** from ninja's `%f`/`%r`/`%t`: done (bright) / running (mid) / remaining (dark). Segment widths use a cumulative floor so they always sum to the bar width. Falls back to block glyphs (`█`/`▒`/`░`) when color is off.
- **Sliding window** of the most recent completed steps (capped at 10 and by terminal height), redrawn in place at the bottom.
- **ETA + percent** on the header line (ETA computed from elapsed + completion rate).

### Why parse stdout (not the frontend protocol)
Stock ninja has no structured event channel — the protobuf "frontend" interface (PR #1210) was never merged upstream (confirmed against `ninja-build/ninja` HEAD). Piped/dumb-mode ninja emits **one line per finished edge**, so Blade parses `[%f/%t](%r) <desc>`:
- progress lines → drive the panel (transient);
- everything else (compiler warnings/errors, `ninja: ...`) → `console.output`, which **clears the panel first**, so those messages scroll above and are never overwritten.

This resolves the "the last line might be an error" hazard structurally: only Blade's own panel is ever erased.

### Behavior
- `ninja_runner` routes all **non-verbose** builds through the capture+render path; **verbose** (`-v`) still hands the terminal to ninja for full per-command output.
- On clean success a one-line `<N> build steps completed` summary replaces the panel (no leftover `[N/N]` line).
- Degrades to no panel on non-TTY / redirected output.

### Tests
`build_panel_test` (bar segment math, ETA/truncate, panel-line assembly, in-place redraw/clear escape sequences, status-line parse) + `console_test` state-mixin resets the new `_region_height`. Full unit suite: no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)