### PR TITLE
feat(cc): make warning='no' allowed paths configurable (#646, #805)

### DIFF
--- a/src/blade/build_manager.py
+++ b/src/blade/build_manager.py
@@ -717,17 +717,6 @@ class Blade:
         """Return build toolchain instance."""
         return self.__build_toolchain
 
-    def get_sources_keyword_list(self):
-        """This keywords list is used to check the source files path.
-
-        Ex, when users specifies warning=no, it could be used to check that
-        the source files is under thirdparty or not. If not, it will warn
-        users that this flag is used incorrectly.
-
-        """
-        keywords = ['thirdparty']
-        return keywords
-
     def _build_jobs_num(self):
         """Calculate build jobs num."""
         # User has the highest priority

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -485,7 +485,7 @@ class CcTarget(Target):
         if not srcs or warning != 'no':
             return
 
-        keywords_list = self.blade.get_sources_keyword_list()
+        keywords_list = config.get_item('cc_config', 'no_warning_allowed_paths')
         for keyword in keywords_list:
             if keyword in self.path:
                 return

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -86,6 +86,13 @@ _CONFIG_TEMPLATE = {
         'c_warnings': [],
         'cxx_warnings': [],
         'warnings': [],
+        'no_warning_allowed_paths': [
+            'thirdparty', 'third_party', 'third-party',
+            '3rdparty', '3rd_party', 'vendor',
+        ],
+        'no_warning_allowed_paths__help__':
+            "Path keywords under which \"warning='no'\" may be used without a "
+            'misuse warning (substring match against the target path and srcs)',
         'optimize': [],
         'benchmark_libs': [],
         'benchmark_main_libs': [],

--- a/src/tests/unit/cc_targets_test.py
+++ b/src/tests/unit/cc_targets_test.py
@@ -318,5 +318,57 @@ class CcLinkPlatformGuardTest(unittest.TestCase):
         self.assertEqual([], target.warnings)
 
 
+class CheckIncorrectNoWarningTest(unittest.TestCase):
+    """Cover ``CcTarget._check_incorrect_no_warning`` and its config knob.
+
+    ``warning='no'`` is legitimate only for third-party code; using it
+    elsewhere silences real warnings. The set of allowed path keywords is
+    configurable via ``cc_config.no_warning_allowed_paths`` (issues #646,
+    #805) -- these tests pin both the gate and the config plumbing.
+    """
+
+    def _target(self, srcs, path):
+        target = _bare_cc_target()
+        target.srcs = srcs
+        target.path = path
+        target.warning = mock.Mock()
+        return target
+
+    def _check(self, target, warning, allowed):
+        with mock.patch.object(cc_targets.config, 'get_item',
+                               return_value=allowed) as get_item:
+            target._check_incorrect_no_warning(warning)
+        return get_item
+
+    def test_no_warning_outside_allowed_paths_warns(self):
+        target = self._target(['src/foo.cc'], 'src')
+        self._check(target, 'no', ['thirdparty'])
+        target.warning.assert_called_once()
+
+    def test_no_warning_under_allowed_path_is_silent(self):
+        target = self._target(['thirdparty/zlib/z.c'], 'thirdparty/zlib')
+        self._check(target, 'no', ['thirdparty'])
+        target.warning.assert_not_called()
+
+    def test_custom_allowed_path_is_honoured(self):
+        # A path the default would reject is accepted once configured.
+        target = self._target(['vendor/lib/a.cc'], 'vendor/lib')
+        self._check(target, 'no', ['vendor'])
+        target.warning.assert_not_called()
+
+    def test_warning_other_than_no_short_circuits(self):
+        # Must return before consulting the config at all.
+        target = self._target(['src/foo.cc'], 'src')
+        get_item = self._check(target, 'yes', ['thirdparty'])
+        get_item.assert_not_called()
+        target.warning.assert_not_called()
+
+    def test_empty_srcs_short_circuits(self):
+        target = self._target([], 'src')
+        get_item = self._check(target, 'no', ['thirdparty'])
+        get_item.assert_not_called()
+        target.warning.assert_not_called()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #646. Closes #805.

## What
The check that flags incorrect use of `warning='no'` (it should only silence warnings for third-party code) hardcoded the allowed directory keyword as `['thirdparty']` via `Blade.get_sources_keyword_list()`.

- Add a `cc_config` key **`no_warning_allowed_paths`** (list, substring-matched against the target path/srcs — same semantics as before).
- Read it in `CcTarget._check_incorrect_no_warning` and **remove** the now-dead `get_sources_keyword_list()` method (#805).
- Expand the default beyond `thirdparty` to the common spellings: `thirdparty, third_party, third-party, 3rdparty, 3rd_party, vendor`. Projects with other layouts can configure their own.

## Why
`#646` (P0) asks to make the allowed dirs configurable; `#805` asks to remove the hardcoded helper and make it config-driven. They're the same code path, so this does both.

## Back-compat
Default still includes `thirdparty`, so existing projects are unaffected; the extra defaults only *reduce* false-positive warnings.

## Tests
New `CheckIncorrectNoWarningTest` in `cc_targets_test.py` covers: warn outside allowed paths, silent under an allowed path, custom config honoured, and both short-circuits (`warning != 'no'`, empty srcs). Full unit suite: 468 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)