### PR TITLE
docs(query): fix "depended by" grammar; align on "dependent(s)" (#615)

### DIFF
--- a/src/blade/build_manager.py
+++ b/src/blade/build_manager.py
@@ -471,9 +471,9 @@ class Blade:
         if self.__options.dependents:
             for key in query_list:
                 print(file=output_file)
-                depended_by = all_targets[key].expanded_dependents
-                print('//%s is depended by the following targets:' % key, file=output_file)
-                for d in depended_by:
+                dependents = all_targets[key].expanded_dependents
+                print('//%s is depended on by the following targets:' % key, file=output_file)
+                for d in dependents:
                     print('%s' % d, file=output_file)
 
     def print_dot_node(self, output_file, node):

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1693,8 +1693,8 @@ class PrebuiltCcLibrary(CcTarget):
         tc = self.blade.get_build_toolchain()
         return os.path.join(libpath, f'{tc.lib_prefix}{self.name}{suffix}')
 
-    def _is_depended(self):
-        """Does this library really be used"""
+    def _is_depended_on(self):
+        """Whether this library is actually depended on by any target."""
         build_targets = self.blade.get_build_targets()
         for key in self.expanded_dependents:
             t = build_targets[key]
@@ -1732,9 +1732,9 @@ class PrebuiltCcLibrary(CcTarget):
         """Generate build code for cc object/library."""
         self._check_deprecated_deps()
         # We allow a prebuilt cc_library doesn't exist if it is not used.
-        # So if this library is not depended by any target, don't generate any
+        # So if this library is not depended on by any target, don't generate any
         # rule to avoid runtime error and also avoid unnecessary runtime cost.
-        if not self._is_depended():
+        if not self._is_depended_on():
             return
         objs, inclusion_check_result = self._cc_objects([])
         # Emit ``ccsyms`` for the prebuilt static archive when present. Has to

--- a/src/blade/command_line.py
+++ b/src/blade/command_line.py
@@ -309,11 +309,11 @@ class CommandLineParser:
         parser.add_argument(
             '--deps', dest='deps',
             action='store_true', default=False,
-            help='Show all targets that depended by the target being queried')
+            help='Show all targets that the target being queried depends on')
         parser.add_argument(
             '--dependents', dest='dependents',
             action='store_true', default=False,
-            help='Show all targets that depends on the target being queried')
+            help='Show all targets that depend on the target being queried')
         parser.add_argument(
             '--path-to', dest='query_path_to', type=str, default='',
             help='The targets to be depended on, comma separated')

--- a/src/blade/dependency_analyzer.py
+++ b/src/blade/dependency_analyzer.py
@@ -77,7 +77,7 @@ def _unique_deps(new_deps_list):
 def _expand_target_deps(target_id, targets, root_targets=None):
     """_expand_target_deps.
 
-    Return all targets depended by target_id directly and/or indirectly.
+    Return all targets that target_id depends on, directly and/or indirectly.
     We need the parameter root_target_id to check loopy dependency.
 
     """

--- a/src/blade/target.py
+++ b/src/blade/target.py
@@ -609,7 +609,7 @@ class Target:
         """Expand the generation process and generated rules of dependencies.
 
         Such as, given a proto_library target, it should generate Java rules
-        in addition to C++ rules once it's depended by a java_library target.
+        in addition to C++ rules once it's depended on by a java_library target.
         """
 
     def _get_java_pack_deps(self):


### PR DESCRIPTION
Closes #615.

## What
The repo standardized on **dependent(s)** (`expanded_dependents`, the `--dependents` flag, `dest='dependents'`), but a few spots still had the grammatically wrong **"depended by"**. This fixes them to "depends on" / "depended on by" — **not** the issue's literal "dependant", which would introduce a third spelling that clashes with the established convention.

- `--deps` / `--dependents` query help text corrected
- query output: `is depended by the following targets` → `is depended on by ...`
- `CcTarget._is_depended` → `_is_depended_on` (+ call site + comment)
- docstrings in `dependency_analyzer` and `target`

## Left as-is
- The deprecated `--depended` alias (intentional, for back-compat).
- `--path-to` help "targets to be depended on" — already correct grammar.

No behavior change; pure naming/docs. Full unit suite: 468 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)