### PR TITLE
test: build from a non-root directory (#857)

### DIFF
--- a/src/test/blade_main_test.py
+++ b/src/test/blade_main_test.py
@@ -38,6 +38,7 @@ from query_target_test import TestQuery
 from resource_library_test import TestResourceLibrary
 from target_pattern_test import TargetPatternTest
 from linker_scripts_test import LinkerScriptsTest
+from build_from_subdir_test import BuildFromSubdirTest
 
 from html_test_runner import HTMLTestRunner
 from test_target_test import TestTestRunner
@@ -70,6 +71,7 @@ def _main():
         unittest.defaultTestLoader.loadTestsFromTestCase(TestTestRunner),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestPrebuildCcLibrary),
         unittest.defaultTestLoader.loadTestsFromTestCase(LinkerScriptsTest),
+        unittest.defaultTestLoader.loadTestsFromTestCase(BuildFromSubdirTest),
         ])
 
     generate_html = len(sys.argv) > 1 and sys.argv[1].startswith('html')

--- a/src/test/build_from_subdir_test.py
+++ b/src/test/build_from_subdir_test.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Author: CHEN Feng <chen3feng@gmail.com>
+
+"""Integration test: build when blade is invoked from a non-root directory.
+
+blade must locate BLADE_ROOT by walking up from the current working
+directory, so ``blade build :target`` works from inside a package
+directory, not only from the workspace root. Regression guard for #857.
+"""
+
+
+import os
+import shutil
+import subprocess
+import unittest
+
+
+class BuildFromSubdirTest(unittest.TestCase):
+    """Build a target with blade invoked from a workspace subdirectory."""
+
+    def setUp(self):
+        self.cur_dir = os.getcwd()
+        here = os.path.dirname(os.path.abspath(__file__))
+        # The blade wrapper lives at the repo root; this file is in src/test.
+        self.blade = os.path.join(here, '..', '..', 'blade')
+        self.root = os.path.join(here, 'testdata')
+        self.build_dir = os.path.join(self.root, 'build64_release')
+        shutil.rmtree(self.build_dir, ignore_errors=True)
+
+    def tearDown(self):
+        os.chdir(self.cur_dir)
+        shutil.rmtree(self.build_dir, ignore_errors=True)
+
+    def testBuildFromPackageDir(self):
+        """Enter a package dir (not the workspace root) and build a target."""
+        os.chdir(os.path.join(self.root, 'cc'))
+        # ':uppercase' is the local-package shorthand; it only resolves if
+        # blade found the workspace root above the current directory.
+        p = subprocess.run(
+            [self.blade, 'build', ':uppercase', '--generate-dynamic'],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
+        self.assertEqual(
+            p.returncode, 0,
+            'blade build from a subdir failed:\n%s' % p.stdout)
+        # The artifact lands under the workspace-root build dir, proving blade
+        # resolved BLADE_ROOT upward instead of treating cwd as the root.
+        self.assertTrue(
+            os.path.exists(os.path.join(self.build_dir, 'cc', 'libuppercase.a')),
+            'expected artifact not produced; output:\n%s' % p.stdout)
+
+
+if __name__ == '__main__':
+    import blade_test
+    blade_test.run(BuildFromSubdirTest)


### PR DESCRIPTION
Closes #857.

## What
Adds `src/test/build_from_subdir_test.py`: an integration test that `cd`s into a package directory (`testdata/cc`) and runs `blade build :uppercase` with the local-package `:name` shorthand. It asserts:
- the build succeeds (returncode 0), and
- the artifact lands under the **workspace-root** build dir (`testdata/build64_release/cc/libuppercase.a`),

proving blade resolves `BLADE_ROOT` by walking up from the cwd rather than treating the cwd as the workspace root.

Registered in `blade_main_test.py` so it runs in the integration suite (`src/test/runall.sh`).

The test shells out to the `blade` wrapper by absolute path, so it still runs under the CI coverage wrapper (`BLADE_PYTHON_INTERPRETER`).

## Testing
Passes standalone and via the aggregator with a CI-like env (`PYTHONPATH=src`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)