### PR TITLE
refactor(run): add Target.is_executable, drop hardcoded run_list (#647)

### DIFF
--- a/src/blade/binary_runner.py
+++ b/src/blade/binary_runner.py
@@ -32,14 +32,6 @@ class BinaryRunner:
         self._build_targets = build_targets
         self.build_dir = build_manager.instance.get_build_dir()
         self.options = options
-        self.run_list = ['cc_binary',
-                         'cc_test',
-                         'java_binary',
-                         'java_test',
-                         'py_binary',
-                         'py_test',
-                         'scala_test',
-                         'sh_test']
         self.target_database = target_database
 
     def _executable(self, target):
@@ -253,7 +245,7 @@ class BinaryRunner:
     def run_target(self, target_name):
         """Run one single target."""
         target = self._build_targets[target_name]
-        if target.type not in self.run_list:
+        if not target.is_executable:
             target.error('is not a executable target')
             return 126
         run_env = self._prepare_env(target)

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -2064,6 +2064,8 @@ class CcBinary(CcTarget):
     rules according to user options.
     """
 
+    is_executable = True  # also covers CcTest
+
     def __init__(self,
                  name: str | None,
                  srcs: StrOrListOpt,

--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -771,6 +771,8 @@ class JavaLibrary(JavaTarget):
 class JavaBinary(JavaTarget):
     """JavaBinary"""
 
+    is_executable = True  # also covers JavaTest
+
     def __init__(
             self,
             name: str | None,

--- a/src/blade/py_targets.py
+++ b/src/blade/py_targets.py
@@ -187,6 +187,8 @@ class PythonBinary(PythonLibrary):
     This class generates python binary package.
     """
 
+    is_executable = True  # also covers PythonTest
+
     def __init__(self,
                  name: str | None,
                  srcs: StrOrListOpt,

--- a/src/blade/scala_targets.py
+++ b/src/blade/scala_targets.py
@@ -203,6 +203,8 @@ class ScalaFatLibrary(ScalaTarget):
 class ScalaTest(ScalaFatLibrary):
     """ScalaTest"""
 
+    is_executable = True
+
     def __init__(
             self,
             name: str | None,

--- a/src/blade/sh_test_target.py
+++ b/src/blade/sh_test_target.py
@@ -33,6 +33,8 @@ class ShellTest(Target):
     syntax.
     """
 
+    is_executable = True
+
     def __init__(self,
                  name: str | None,
                  srcs: StrOrListOpt,

--- a/src/blade/target.py
+++ b/src/blade/target.py
@@ -105,6 +105,10 @@ class Target:
 
     """
 
+    # Whether ``blade run`` can execute this target. Overridden to True by
+    # the executable target classes (binaries and tests).
+    is_executable = False
+
     def __init__(self,
                  name: str | None,
                  type: str,

--- a/src/tests/unit/target_is_executable_test.py
+++ b/src/tests/unit/target_is_executable_test.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for the Target.is_executable class attribute (#647).
+
+`blade run` and run_target() gate on whether a target is executable. This
+used to be a hardcoded type-name list in BinaryRunner; it now lives on the
+target classes as the ``is_executable`` attribute. These tests pin which
+target types are executable (binaries and tests) and which are not
+(libraries), including the values inherited by subclasses.
+"""
+
+import os
+import sys
+import unittest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import cc_targets  # noqa: E402
+from blade import java_targets  # noqa: E402
+from blade import py_targets  # noqa: E402
+from blade import scala_targets  # noqa: E402
+from blade import sh_test_target  # noqa: E402
+from blade.target import Target  # noqa: E402
+
+
+class TargetIsExecutableTest(unittest.TestCase):
+    """Pin the executable/non-executable classification per target type."""
+
+    def test_base_target_is_not_executable(self):
+        self.assertFalse(Target.is_executable)
+
+    def test_executable_targets(self):
+        # Binaries and tests are runnable. Tests inherit the flag from their
+        # binary base class (CcTest<-CcBinary, JavaTest<-JavaBinary,
+        # PythonTest<-PythonBinary).
+        for cls in (cc_targets.CcBinary, cc_targets.CcTest,
+                    java_targets.JavaBinary, java_targets.JavaTest,
+                    py_targets.PythonBinary, py_targets.PythonTest,
+                    scala_targets.ScalaTest, sh_test_target.ShellTest):
+            self.assertTrue(cls.is_executable,
+                            '%s should be executable' % cls.__name__)
+
+    def test_non_executable_targets(self):
+        # Libraries are not runnable, including those that share a base with
+        # an executable type (e.g. PythonBinary<-PythonLibrary).
+        for cls in (cc_targets.CcLibrary,
+                    java_targets.JavaLibrary,
+                    py_targets.PythonLibrary,
+                    scala_targets.ScalaLibrary,
+                    scala_targets.ScalaFatLibrary):
+            self.assertFalse(cls.is_executable,
+                             '%s should not be executable' % cls.__name__)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #647.

## What
`BinaryRunner.run_target()` decided whether a target is runnable via a hardcoded list of type-name strings:

```python
self.run_list = ['cc_binary', 'cc_test', 'java_binary', 'java_test',
                 'py_binary', 'py_test', 'scala_test', 'sh_test']
...
if target.type not in self.run_list:
```

Move that knowledge onto the target classes as an **`is_executable`** class attribute:
- `Target.is_executable = False` (default)
- `True` on `CcBinary`, `JavaBinary`, `PythonBinary` (inherited by `CcTest` / `JavaTest` / `PythonTest`), plus `ScalaTest` and `ShellTest`.

The runner now checks `if not target.is_executable:`.

## Behavior
Unchanged — the flagged classes correspond **exactly** to the eight types the old `run_list` contained. It's a class attribute, so it doesn't appear in `dump()` output (which serializes `self.attr`).

## Tests
New `target_is_executable_test.py` pins which target classes are executable vs not (incl. inherited values). Full unit suite: 471 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)