### PR TITLE
feat(cli): add `blade root` subcommand (#528)

### DIFF
--- a/src/blade/command_line.py
+++ b/src/blade/command_line.py
@@ -79,10 +79,16 @@ class CommandLineParser:
             'clean': self._check_clean_command,
             'dump': self._check_dump_command,
             'query': self._check_query_command,
+            'root': self._check_root_command,
             'run': self._check_run_command,
             'test': self._check_test_command,
         }
         actions[command](options, targets)
+
+    def _check_root_command(self, options, targets):
+        """check root options: it takes no targets."""
+        if targets:
+            console.fatal('blade root does not accept any targets')
 
     def _check_run_targets(self, options, targets):
         """check that run command should have only one target."""
@@ -488,8 +494,13 @@ class CommandLineParser:
             'dump',
             help='Dump specified internal information')
 
+        root_parser = sub_parser.add_parser(
+            'root',
+            help='Print the workspace root directory')
+
         self._add_common_arguments(build_parser, run_parser, test_parser,
-                                   clean_parser, query_parser, dump_parser)
+                                   clean_parser, query_parser, dump_parser,
+                                   root_parser)
         self._add_build_arguments(build_parser, run_parser, test_parser, dump_parser)
         self._add_run_arguments(run_parser)
         self._add_test_arguments(test_parser)

--- a/src/blade/main.py
+++ b/src/blade/main.py
@@ -14,6 +14,7 @@ import cProfile
 import os
 import pstats
 import signal
+import sys
 import time
 import traceback
 
@@ -125,6 +126,14 @@ def _main(blade_path, argv):
     setup_console(options)
 
     ws = workspace.initialize(options)
+
+    # 'root' just prints the workspace root and exits, before any chdir /
+    # config load / build setup. sys.exit short-circuits main() before the
+    # trailing "Cost time" line, so stdout stays clean: cd "$(blade root)".
+    if command == 'root':
+        print(ws.root_dir)
+        sys.exit(0)
+
     ws.switch_to_root_dir()
     load_config(options, ws.root_dir)
 

--- a/src/test/blade_main_test.py
+++ b/src/test/blade_main_test.py
@@ -39,6 +39,7 @@ from resource_library_test import TestResourceLibrary
 from target_pattern_test import TargetPatternTest
 from linker_scripts_test import LinkerScriptsTest
 from build_from_subdir_test import BuildFromSubdirTest
+from root_command_test import RootCommandTest
 
 from html_test_runner import HTMLTestRunner
 from test_target_test import TestTestRunner
@@ -72,6 +73,7 @@ def _main():
         unittest.defaultTestLoader.loadTestsFromTestCase(TestPrebuildCcLibrary),
         unittest.defaultTestLoader.loadTestsFromTestCase(LinkerScriptsTest),
         unittest.defaultTestLoader.loadTestsFromTestCase(BuildFromSubdirTest),
+        unittest.defaultTestLoader.loadTestsFromTestCase(RootCommandTest),
         ])
 
     generate_html = len(sys.argv) > 1 and sys.argv[1].startswith('html')

--- a/src/test/root_command_test.py
+++ b/src/test/root_command_test.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Author: CHEN Feng <chen3feng@gmail.com>
+
+"""Integration test for the ``blade root`` subcommand (#528).
+
+``blade root`` prints the absolute workspace root directory and exits,
+with clean stdout (so ``cd "$(blade root)"`` works) regardless of which
+subdirectory it is invoked from.
+"""
+
+
+import os
+import subprocess
+import unittest
+
+
+class RootCommandTest(unittest.TestCase):
+    """Verify ``blade root`` prints the workspace root from any directory."""
+
+    def setUp(self):
+        self.cur_dir = os.getcwd()
+        here = os.path.dirname(os.path.abspath(__file__))
+        self.blade = os.path.join(here, '..', '..', 'blade')
+        self.root = os.path.join(here, 'testdata')
+
+    def tearDown(self):
+        os.chdir(self.cur_dir)
+
+    def _blade_root(self, from_dir):
+        os.chdir(from_dir)
+        p = subprocess.run(
+            [self.blade, 'root'],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
+        self.assertEqual(p.returncode, 0, 'blade root failed:\n%s' % p.stderr)
+        return p.stdout
+
+    def testRootFromWorkspaceRoot(self):
+        out = self._blade_root(self.root)
+        self.assertEqual(out.strip(), os.path.abspath(self.root))
+
+    def testRootFromSubdir(self):
+        # Invoked from a package dir, stdout must still be exactly the root.
+        out = self._blade_root(os.path.join(self.root, 'cc'))
+        self.assertEqual(out.strip(), os.path.abspath(self.root))
+
+    def testRootRejectsTargets(self):
+        os.chdir(self.root)
+        p = subprocess.run(
+            [self.blade, 'root', '//cc:uppercase'],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
+        self.assertNotEqual(p.returncode, 0)
+
+
+if __name__ == '__main__':
+    import blade_test
+    blade_test.run(RootCommandTest)


### PR DESCRIPTION
Closes #528.

## What
Adds a `blade root` subcommand that prints the absolute workspace root directory:

```console
$ cd some/deep/package
$ blade root
/path/to/workspace
$ cd "$(blade root)"   # jump to the workspace root
```

## Details
- Registered as a subparser with the common arguments (so `--color`/`--verbose` etc. still apply).
- Handled early in `_main` — right after the workspace is located, before chdir / config load / build-dir setup / lock — so it's fast and side-effect-free.
- Short-circuits via `sys.exit(0)`, which `main()` catches **before** the trailing `Blade(info): Cost time ...` line, keeping **stdout clean** (just the path) for `cd "$(blade root)"`. Normal commands still print Cost time.
- Works from any subdirectory (blade walks up to `BLADE_ROOT`) and rejects targets.

The issue also mentioned `blade dump --root` as an alternative; this implements the titled `blade root` subcommand. Happy to add the `dump --root` alias too if wanted.

## Tests
New `root_command_test.py` (integration): invocation from the workspace root and from a subdirectory both print the root; passing a target fails. Registered in `blade_main_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)