### PR TITLE
fix(progress): suppress ninja's "no work to do." line

### DIFF
--- a/src/blade/ninja_runner.py
+++ b/src/blade/ninja_runner.py
@@ -114,6 +114,8 @@ def _show_progress(process, file_reader):
                     eta = (total - finished) * elapsed / finished if finished else None
                     window = () if quiet else recent
                     console.render_build_panel(finished, running, total, window, eta)
+                elif line == 'ninja: no work to do.':
+                    pass
                 elif line:
                     console.output(line)
             elif process.returncode is not None:


### PR DESCRIPTION
## What
When everything is up to date, ninja prints `ninja: no work to do.` on stdout, which the progress reader forwards via `console.output`. blade already prints its own `Build success.` status, so this line is redundant noise on every no-op build. Swallow it in the progress loop.

```python
elif line == 'ninja: no work to do.':
    pass
elif line:
    console.output(line)
```

## Verification
A second (no-op) `blade build` of an already-built target now ends cleanly at `Build success.` with no `ninja: no work to do.` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)