### PR TITLE
cc: silence macOS "table of contents is empty" warning for symbol-less archives

### DIFF
--- a/src/blade/cc_rule_support.py
+++ b/src/blade/cc_rule_support.py
@@ -208,6 +208,29 @@ sys.exit(p.wait())
 '''
 
 
+# A tiny shell wrapper for the macOS archive step. Apple's libtool/ranlib warns
+# "... the table of contents is empty (no object file members in the library
+# define global symbols)" for a symbol-less static library (an all-inline/
+# template lib whose stub `.cc` compiles to no global symbols). Such an `.a`
+# links fine as a header carrier, the warning is pure noise, and unlike "has no
+# symbols" it has no suppression flag (`-no_warning_for_no_symbols` does not
+# cover it). So drop just that one line from stderr while preserving stdout,
+# every other diagnostic, and the archive command's exit code.
+#
+# Process substitution streams stderr through `grep` live (no temp file), and
+# `exec` replaces the shell with the archive command so the only process beyond
+# the unavoidable `grep` is gone -- and the exit code is naturally the command's.
+# This needs bash, not `/bin/sh`: macOS's `/bin/sh` is bash in POSIX mode, which
+# rejects `>( )` as a syntax error. A shell wrapper (not a `builtin_tools` Python
+# helper) keeps the per-archive cost to a `/bin/bash` spawn instead of a Python
+# interpreter + `blade` package import on every `cc_library`. darwin-only --
+# Linux `ar` never emits this warning, so the rule wraps the command on macOS
+# alone.
+_DARWIN_AR_WRAPPER_SH = r'''#!/bin/bash
+exec "$@" 2> >(grep -v 'table of contents is empty' >&2)
+'''
+
+
 class CcRuleGenerator:
     """Generate cc/cuda ninja rules from a RuleContext (see module docstring)."""
 
@@ -222,6 +245,7 @@ class CcRuleGenerator:
         self.__inclusion_wrapper_path = None
         self.__msvc_wrapper_py_path = None
         self.__msvc_link_wrapper_py_path = None
+        self.__darwin_ar_wrapper_path = None
 
     def _add_line(self, line):
         self._ctx.add_line(line)
@@ -266,6 +290,14 @@ class CcRuleGenerator:
             util.write_if_changed(path, _MSVC_LINK_WRAPPER_PY)
             self.__msvc_link_wrapper_py_path = path
         return self.__msvc_link_wrapper_py_path
+
+    def _darwin_ar_wrapper_sh(self):
+        """Path to the macOS archive-output filter wrapper, written on first use."""
+        if self.__darwin_ar_wrapper_path is None:
+            path = os.path.join(self.build_dir, 'ar_wrapper.sh')
+            util.write_if_changed(path, _DARWIN_AR_WRAPPER_SH)
+            self.__darwin_ar_wrapper_path = path
+        return self.__darwin_ar_wrapper_path
 
     def _get_intrinsic_cc_flags(self):
         """Get the common c/c++ flags."""
@@ -742,11 +774,16 @@ class CcRuleGenerator:
             if thin:
                 console.error('cc_library_config.thin=True is not supported on macOS '
                               '(Apple ar does not support thin archives)')
+            # Route the archive through a shell wrapper that drops Apple's benign
+            # "table of contents is empty" warning for symbol-less libraries
+            # (no suppression flag exists for it). See _DARWIN_AR_WRAPPER_SH.
+            wrap = f'/bin/bash {self._darwin_ar_wrapper_sh()}'
             if deterministic:
-                command = 'rm -f $out; libtool -static -no_warning_for_no_symbols -o $out $in'
+                command = (f'rm -f $out; {wrap} libtool -static '
+                           '-no_warning_for_no_symbols -o $out $in')
             else:
                 ar = self.build_accelerator.get_ar_command()
-                command = f'rm -f $out; {ar} rcs $out $in'
+                command = f'rm -f $out; {wrap} {ar} rcs $out $in'
         elif target_os == 'linux':
             ar = self.build_accelerator.get_ar_command()
             extra = ''

--- a/src/tests/unit/cc_library_config_test.py
+++ b/src/tests/unit/cc_library_config_test.py
@@ -112,6 +112,10 @@ class CcArchiveRulesTest(unittest.TestCase):
         gen.build_toolchain.target_os = target_os
         gen.build_accelerator = mock.Mock()
         gen.build_accelerator.get_ar_command.return_value = 'ar'
+        # The darwin ar path wraps the command via a generated shell script;
+        # stub it to a fixed path so the test asserts the wiring without
+        # touching the filesystem.
+        gen._darwin_ar_wrapper_sh = mock.Mock(return_value='BUILD/ar_wrapper.sh')
         return gen
 
     def _capture_ar_command(self, gen, deterministic=False, thin=False):
@@ -145,6 +149,8 @@ class CcArchiveRulesTest(unittest.TestCase):
         gen = self._make_gen('linux')
         cmd = self._capture_ar_command(gen, deterministic=False, thin=False)
         self.assertIn('ar rcs ', cmd)
+        # The warning-filter wrapper is macOS-only; Linux ar never emits it.
+        self.assertNotIn('ar_wrapper.sh', cmd)
 
     def test_linux_deterministic(self):
         gen = self._make_gen('linux')
@@ -166,12 +172,14 @@ class CcArchiveRulesTest(unittest.TestCase):
     def test_darwin_default(self):
         gen = self._make_gen('darwin')
         cmd = self._capture_ar_command(gen, deterministic=False, thin=False)
-        self.assertIn('ar rcs ', cmd)
+        # Archive routed through the warning-filter wrapper (see #1295).
+        self.assertIn('/bin/bash BUILD/ar_wrapper.sh ar rcs ', cmd)
 
     def test_darwin_deterministic_uses_libtool(self):
         gen = self._make_gen('darwin')
         cmd = self._capture_ar_command(gen, deterministic=True, thin=False)
-        self.assertIn('libtool -static -no_warning_for_no_symbols -o $out $in', cmd)
+        self.assertIn('/bin/bash BUILD/ar_wrapper.sh libtool -static '
+                      '-no_warning_for_no_symbols -o $out $in', cmd)
 
     def test_darwin_thin_logs_error(self):
         gen = self._make_gen('darwin')


### PR DESCRIPTION
Fixes #1295.

## Problem

On macOS, archiving a `cc_library` whose objects export **no global symbols** (an all-inline/template lib with a stub `.cc`) prints:

```
warning: ... libtool: archive library: libfoo.a the table of contents is empty (no object file members in the library define global symbols)
```

Seen in flare for e.g. `flare/base/experimental:byte_set` and `flare/base:erased_ptr`. The `.a` links fine as a header carrier — the warning is pure noise on every build. Unlike the per-object `has no symbols` warning, this **whole-archive** one has no suppression flag (`-no_warning_for_no_symbols` does not cover it).

## Fix

Route the macOS archive step (both the `libtool -static` deterministic path and `ar rcs`) through a generated `/bin/bash` wrapper that drops just that one stderr line:

```bash
#!/bin/bash
exec "$@" 2> >(grep -v 'table of contents is empty' >&2)
```

- **No temp file** — process substitution streams stderr through `grep` live; `exec` leaves only the unavoidable `grep` process; the exit code is naturally the command's.
- **Shell, not a `builtin_tools` Python helper** — keeps the per-archive cost to a `bash` spawn instead of a Python interpreter + `blade` import on every `cc_library`. Mirrors the existing `link_wrapper.py` precedent (written to the build dir on first use).
- **darwin-only** — Linux `ar` never emits this warning, so the Linux/other branches are untouched. (bash, not `/bin/sh`, because macOS `/bin/sh` is bash in POSIX mode and rejects `>( )`.)

## Verification

- Raw `libtool` emits the warning; through the wrapper: 0 warnings, exit 0, valid archive.
- Real archive errors still surface with a nonzero exit; 100× stress: 0 leaks, 0 bad exits (no flush race).
- Source-blade rebuild of `erased_ptr` + `byte_set`: warning gone; `//flare/base/...` builds clean; normal symbol-bearing archives unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)