### PR TITLE
config: add vcpkg_config rule (#1236, PR1)

### DIFF
--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -419,6 +419,36 @@ _CONFIG_TEMPLATE = {
         },
     },
 
+    # vcpkg package-manager integration (issue #1236). A single workspace-level
+    # section: vcpkg's manifest model allows one version and one feature set per
+    # package per workspace, so these map 1:1 onto vcpkg.json fields.
+    'vcpkg_config': {
+        '__help__': 'vcpkg C/C++ package manager configuration (issue #1236)',
+        # Pins the ports tree (git SHA or date) -> vcpkg.json "builtin-baseline".
+        # Empty means unpinned (not reproducible); a warning is emitted later.
+        'baseline': '',
+        # The allow-list of packages: the single source of truth for what a
+        # `vcpkg#<port>:<lib>` reference may resolve to. Each value is either a
+        # version string ('fmt': '10.2.1') or a dict with version/features
+        # ('curl': {'version': '8.5.0', 'features': ['ssl', 'http2']}).
+        'packages': {},
+        # Optional private registries -> vcpkg-configuration.json "registries".
+        'registries': [],
+        # vcpkg tool + ports tree. Empty = use $VCPKG_ROOT (a later phase may
+        # bootstrap one when unset).
+        'root': '',
+        # Target triplet; 'auto' derives it from the resolved cc_toolchain.
+        'triplet': 'auto',
+        # Per-workspace install root, relative to the build dir.
+        'install_dir': '.cache/vcpkg',
+        # Binary-cache backend (the cross-workspace time-saver). 'auto' uses a
+        # shared local dir; full vcpkg backend strings are accepted (later phase).
+        'binary_cache': 'auto',
+        # Governance: subtrees where bare `vcpkg#...` references are allowed.
+        # Empty = anywhere (enforcement lands in a later phase).
+        'direct_use_allowed': [],
+    },
+
 }
 
 
@@ -787,6 +817,37 @@ def _check_kwarg_enum_value(kwargs, name, valid_values):
         _blade_config.error(f'Invalid config item "{name}" value "{value}", can only be in {valid_values}')
 
 
+def _check_vcpkg_packages(packages):
+    """Validate the shape of vcpkg_config.packages entries (issue #1236).
+
+    Each value is either a version string or a dict with the keys ``version``
+    and/or ``features`` (a list). The top-level dict type is enforced by the
+    normal config machinery; this catches malformed per-port specs early.
+    """
+    if packages is None or callable(packages):
+        return
+    if not isinstance(packages, dict):
+        _blade_config.error('vcpkg_config.packages must be a dict of {port: version|spec}')
+        return
+    for port, spec in packages.items():
+        if isinstance(spec, str):
+            continue
+        if isinstance(spec, dict):
+            unknown = set(spec) - {'version', 'features'}
+            if unknown:
+                _blade_config.error(
+                    'vcpkg_config.packages["%s"]: unknown key(s) %s; allowed: version, features'
+                    % (port, ', '.join(sorted(unknown))))
+            features = spec.get('features')
+            if features is not None and not isinstance(features, list):
+                _blade_config.error(
+                    'vcpkg_config.packages["%s"].features must be a list' % port)
+            continue
+        _blade_config.error(
+            'vcpkg_config.packages["%s"] must be a version string or a dict with '
+            'version/features, got "%s"' % (port, type(spec).__name__))
+
+
 def _check_test_related_envs(kwargs):
     value = kwargs.get('test_related_envs')
     if value is None or callable(value):
@@ -913,6 +974,25 @@ def cc_config(append=None, **kwargs):
 def link_config(append=None, **kwargs):
     """link_config."""
     _blade_config.update_config('link_config', append, kwargs)
+
+
+@config_rule
+def vcpkg_config(append=None, **kwargs):
+    """vcpkg package-manager configuration (issue #1236).
+
+    Workspace-level allow-list and infrastructure for ``vcpkg#<port>:<lib>``
+    dependencies. Example::
+
+        vcpkg_config(
+            baseline = '2024-12-15',
+            packages = {
+                'fmt': '10.2.1',
+                'curl': {'version': '8.5.0', 'features': ['ssl', 'http2']},
+            },
+        )
+    """
+    _check_vcpkg_packages(kwargs.get('packages'))
+    _blade_config.update_config('vcpkg_config', append, kwargs)
 
 
 @config_rule

--- a/src/tests/unit/vcpkg_config_test.py
+++ b/src/tests/unit/vcpkg_config_test.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+#
+# Unit tests for the vcpkg_config BLADE_ROOT rule (issue #1236).
+
+"""Tests the vcpkg_config surface added as PR1 of native vcpkg support.
+
+This PR only adds the config rule; nothing consumes it yet. Covered here:
+
+  * Template defaults so the documented contract stays pinned.
+  * `vcpkg_config()` accepts the two `packages` value shapes (a bare version
+    string, or a dict with version/features) and rejects malformed specs at
+    config-load time.
+  * Values round-trip through `config.get_section('vcpkg_config')`.
+"""
+
+import os
+import sys
+import unittest
+import unittest.mock as mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import config  # noqa: E402
+
+
+class VcpkgConfigDefaultsTest(unittest.TestCase):
+    """Pin the template defaults; vcpkg's manifest model is one version /
+    feature-set per package per workspace, so this is a single section."""
+
+    def setUp(self):
+        self._template = config._CONFIG_TEMPLATE['vcpkg_config']
+
+    def test_baseline_defaults_empty(self):
+        # Empty = unpinned (Tier 0); a later phase warns. Defaulting to a
+        # value would silently pin everyone to an arbitrary ports tree.
+        self.assertEqual(self._template['baseline'], '')
+
+    def test_packages_defaults_empty_dict(self):
+        self.assertEqual(self._template['packages'], {})
+
+    def test_registries_defaults_empty_list(self):
+        self.assertEqual(self._template['registries'], [])
+
+    def test_root_defaults_empty(self):
+        # Empty = use $VCPKG_ROOT.
+        self.assertEqual(self._template['root'], '')
+
+    def test_triplet_defaults_auto(self):
+        self.assertEqual(self._template['triplet'], 'auto')
+
+    def test_install_dir_default(self):
+        self.assertEqual(self._template['install_dir'], '.cache/vcpkg')
+
+    def test_binary_cache_defaults_auto(self):
+        self.assertEqual(self._template['binary_cache'], 'auto')
+
+    def test_direct_use_allowed_defaults_empty(self):
+        # Empty = anywhere (governance enforcement is a later phase).
+        self.assertEqual(self._template['direct_use_allowed'], [])
+
+    def test_help_text_present(self):
+        """`blade dump --config` needs the section help string."""
+        self.assertIn('__help__', self._template)
+
+
+class VcpkgConfigValidationTest(unittest.TestCase):
+    """`packages` accepts str or {version, features}; anything else errors."""
+
+    def setUp(self):
+        self._bc = config._blade_config
+        self._saved = dict(self._bc.config)
+
+    def tearDown(self):
+        self._bc.config = self._saved
+
+    def _call(self, **kwargs):
+        warnings, errors = [], []
+        with mock.patch.object(self._bc, 'warning', side_effect=warnings.append), \
+             mock.patch.object(self._bc, 'error', side_effect=errors.append):
+            config.vcpkg_config(**kwargs)
+        return warnings, errors
+
+    def test_string_version_accepted(self):
+        _, errors = self._call(packages={'fmt': '10.2.1'})
+        self.assertEqual(errors, [])
+
+    def test_dict_spec_accepted(self):
+        _, errors = self._call(
+            packages={'curl': {'version': '8.5.0', 'features': ['ssl', 'http2']}})
+        self.assertEqual(errors, [])
+
+    def test_dict_version_only_accepted(self):
+        _, errors = self._call(packages={'openssl': {'version': '3.2.1'}})
+        self.assertEqual(errors, [])
+
+    def test_unknown_spec_key_errors(self):
+        """A typo'd key (e.g. `versions`) must surface at config-load time
+        rather than silently dropping the intended version pin."""
+        _, errors = self._call(packages={'fmt': {'versions': '10.2.1'}})
+        self.assertEqual(len(errors), 1)
+        self.assertIn('fmt', errors[0])
+
+    def test_features_must_be_list(self):
+        _, errors = self._call(
+            packages={'curl': {'version': '8.5.0', 'features': 'ssl'}})
+        self.assertEqual(len(errors), 1)
+        self.assertIn('features', errors[0])
+
+    def test_scalar_spec_errors(self):
+        """`'fmt': 10` (a bare int) is neither a version string nor a spec."""
+        _, errors = self._call(packages={'fmt': 10})
+        self.assertEqual(len(errors), 1)
+        self.assertIn('fmt', errors[0])
+
+    def test_packages_must_be_dict(self):
+        """A list instead of a dict triggers at least the config type check."""
+        _, errors = self._call(packages=['fmt'])
+        self.assertGreaterEqual(len(errors), 1)
+
+
+class VcpkgConfigReadbackTest(unittest.TestCase):
+    """Values set by the rule round-trip through get_section."""
+
+    def setUp(self):
+        self._bc = config._blade_config
+        self._saved = dict(self._bc.config)
+
+    def tearDown(self):
+        self._bc.config = self._saved
+
+    def test_fields_round_trip(self):
+        with mock.patch.object(self._bc, 'warning'), \
+             mock.patch.object(self._bc, 'error'):
+            config.vcpkg_config(
+                baseline='2024-12-15',
+                packages={'fmt': '10.2.1'},
+                triplet='auto',
+            )
+        section = config.get_section('vcpkg_config')
+        self.assertEqual(section['baseline'], '2024-12-15')
+        self.assertEqual(section['packages'], {'fmt': '10.2.1'})
+        # Untouched fields keep their template defaults.
+        self.assertEqual(section['install_dir'], '.cache/vcpkg')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**PR1 of native vcpkg support (#1236)** — targets the `vcpkg` integration branch, not `master`.

Adds only the `BLADE_ROOT` config surface; nothing consumes it yet, so existing builds are unaffected.

- `vcpkg_config` section in `_CONFIG_TEMPLATE` — single workspace-level section mirroring vcpkg's manifest model (one version / feature-set per package per workspace): `baseline`, `packages`, `registries`, `root`, `triplet='auto'`, `install_dir='.cache/vcpkg'`, `binary_cache='auto'`, `direct_use_allowed`.
- `vcpkg_config()` `@config_rule` + `_check_vcpkg_packages` validator — `packages` accepts a bare version string (`'fmt': '10.2.1'`) or a dict (`{'version': ..., 'features': [...]}`); malformed specs (unknown keys, non-list features, scalar specs) error at config-load time.

Value normalization (str → `{version}`) is deferred to the PR3 resolver so the stored config stays a faithful mirror of the user's input. `vcpkg#port:lib` parsing comes in PR2.

Tests: `vcpkg_config_test.py` (17 tests — defaults, validation, round-trip). Full unit suite: 492 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)