### PR TITLE
vcpkg: pure triplet + pkg-config helpers (#1236, PR3)

### DIFF
--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Pure helpers for native vcpkg support (issue #1236).
+
+This module holds the provider-independent data extraction that the vcpkg
+dependency provider builds on: deriving the vcpkg triplet from blade's resolved
+toolchain, and parsing a port's pkg-config (`.pc`) file. Both are pure
+functions over plain inputs (strings / os+arch tokens), unit-tested in
+isolation; the `VcpkgLibrary` target and the `vcpkg#port:lib` handler that
+consume them are wired up separately.
+
+Phase 1 resolves artifacts from an install tree the user produced themselves
+(`vcpkg install ...`), so `triplet_for` returns the *vanilla* vcpkg triplet a
+host's default install uses. The `blade-`prefixed overlay triplets that
+chainload blade's compiler belong to the orchestration phase and are added
+later.
+"""
+
+import re
+
+# blade target_arch (canonical, from `cc -dumpmachine`) / MSVC arch -> vcpkg
+# architecture token.
+_VCPKG_ARCH = {
+    'x86_64': 'x64', 'amd64': 'x64', 'win64': 'x64', 'x64': 'x64',
+    'aarch64': 'arm64', 'arm64': 'arm64',
+    'i386': 'x86', 'x86': 'x86', 'win32': 'x86',
+    'arm': 'arm',
+}
+
+# blade target_os -> vcpkg OS token.
+_VCPKG_OS = {'linux': 'linux', 'darwin': 'osx', 'windows': 'windows'}
+
+
+def triplet_for(target_os, target_arch, vendor=None, dynamic=False):
+    """Derive the vcpkg triplet for blade's resolved toolchain.
+
+    Args:
+        target_os: blade `ToolChain.target_os` -- 'linux' | 'darwin' | 'windows'.
+        target_arch: blade `ToolChain.target_arch` (e.g. 'x86_64', 'aarch64')
+            or an MSVC arch token ('x64', 'arm64').
+        vendor: compiler vendor ('gcc' | 'clang' | 'msvc'); only consulted on
+            Windows to pick MinGW vs MSVC triplets.
+        dynamic: True selects the shared-library triplet variant.
+
+    Returns:
+        The triplet string (e.g. 'x64-linux', 'arm64-osx', 'x64-windows-static'),
+        or None if the os/arch is unsupported.
+
+    blade links vcpkg artifacts statically by default, so on Windows -- where
+    vcpkg's default triplet is dynamic -- 'auto' resolves to the `-static`
+    variant. On Linux/macOS the default vcpkg triplet is already static.
+    """
+    arch = _VCPKG_ARCH.get(target_arch)
+    os_tok = _VCPKG_OS.get(target_os)
+    if arch is None or os_tok is None:
+        return None
+    if os_tok == 'windows':
+        if vendor in ('gcc', 'clang'):
+            return '%s-mingw-%s' % (arch, 'dynamic' if dynamic else 'static')
+        return '%s-windows%s' % (arch, '' if dynamic else '-static')
+    # linux / osx: the vanilla triplet is static; '-dynamic' for shared.
+    return '%s-%s%s' % (arch, os_tok, '-dynamic' if dynamic else '')
+
+
+# pkg-config grammar bits.
+_PC_KEYWORDS = {
+    'name', 'description', 'version', 'requires', 'requires.private',
+    'libs', 'libs.private', 'cflags', 'cflags.private', 'conflicts',
+    'provides', 'url',
+}
+_PC_KEYWORD_RE = re.compile(r'^([A-Za-z][\w.]*)\s*:\s*(.*)$')
+_PC_VAR_RE = re.compile(r'^([A-Za-z_][\w.]*)\s*=\s*(.*)$')
+_PC_REF_RE = re.compile(r'\$\{([A-Za-z_][\w.]*)\}')
+_PC_VERSION_OPS = {'>=', '<=', '=', '==', '>', '<', '!='}
+
+
+def _expand(value, variables):
+    """Expand ${var} references using the variables seen so far."""
+    def repl(m):
+        return variables.get(m.group(1), '')
+    # A couple of passes resolve nested ${a}=${b} chains in practice.
+    for _ in range(8):
+        new = _PC_REF_RE.sub(repl, value)
+        if new == value:
+            break
+        value = new
+    return value
+
+
+def _parse_module_list(value):
+    """Extract module names from a Requires[.private] value.
+
+    Drops version constraints, e.g. 'libssl >= 3.0, libcrypto' -> ['libssl',
+    'libcrypto']. Handles comma- and/or space-separated forms.
+    """
+    mods = []
+    skip_version = False
+    for tok in re.split(r'[\s,]+', value.strip()):
+        if not tok:
+            continue
+        if tok in _PC_VERSION_OPS:
+            skip_version = True
+            continue
+        if skip_version:
+            skip_version = False
+            continue
+        mods.append(tok)
+    return mods
+
+
+def _extract_l_libs(tokens):
+    """Pull bare library names from `-lfoo` tokens (also `-l foo`)."""
+    libs = []
+    want_name = False
+    for tok in tokens:
+        if want_name:
+            libs.append(tok)
+            want_name = False
+        elif tok == '-l':
+            want_name = True
+        elif tok.startswith('-l'):
+            libs.append(tok[2:])
+    return libs
+
+
+def parse_pkgconfig(text):
+    """Parse pkg-config (`.pc`) content into a structured dict.
+
+    Returns a dict with:
+        name, version              -- strings ('' if absent)
+        requires, requires_private -- module-name lists (versions stripped)
+        libs, libs_private, cflags -- token lists (variables expanded)
+        l_libs, l_private          -- bare `-l` names from libs / libs_private
+
+    Variable definitions (`libdir=${prefix}/lib`) are expanded; a leading
+    keyword (`Libs:`) is distinguished from a variable by the fixed pkg-config
+    keyword set, so a value containing '=' is not mistaken for a definition.
+    """
+    variables = {}
+    fields = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith('#'):
+            continue
+        km = _PC_KEYWORD_RE.match(line)
+        if km and km.group(1).lower() in _PC_KEYWORDS:
+            fields[km.group(1).lower()] = _expand(km.group(2).strip(), variables)
+            continue
+        vm = _PC_VAR_RE.match(line)
+        if vm:
+            variables[vm.group(1)] = _expand(vm.group(2).strip(), variables)
+
+    def tokens(key):
+        v = fields.get(key, '')
+        return v.split() if v else []
+
+    libs = tokens('libs')
+    libs_private = tokens('libs.private')
+    return {
+        'name': fields.get('name', ''),
+        'version': fields.get('version', ''),
+        'requires': _parse_module_list(fields.get('requires', '')),
+        'requires_private': _parse_module_list(fields.get('requires.private', '')),
+        'libs': libs,
+        'libs_private': libs_private,
+        'cflags': tokens('cflags'),
+        'l_libs': _extract_l_libs(libs),
+        'l_private': _extract_l_libs(libs_private),
+    }

--- a/src/tests/unit/vcpkg_helpers_test.py
+++ b/src/tests/unit/vcpkg_helpers_test.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+#
+# Unit tests for the pure vcpkg helpers (issue #1236, PR3).
+
+"""Tests triplet derivation and pkg-config parsing in blade.vcpkg.
+
+These are the provider-independent pieces the vcpkg dependency handler builds
+on; the handler + VcpkgLibrary target (which need a mock install tree) land in
+the next PR.
+"""
+
+import os
+import sys
+import unittest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import vcpkg  # noqa: E402
+
+
+class TripletTest(unittest.TestCase):
+    """Phase 1 returns the vanilla triplet a host's `vcpkg install` uses."""
+
+    def test_linux_x64(self):
+        self.assertEqual(vcpkg.triplet_for('linux', 'x86_64'), 'x64-linux')
+
+    def test_linux_arm64(self):
+        self.assertEqual(vcpkg.triplet_for('linux', 'aarch64'), 'arm64-linux')
+
+    def test_darwin_arm64(self):
+        # Apple Silicon: cc -dumpmachine yields arm64 -> canonical aarch64.
+        self.assertEqual(vcpkg.triplet_for('darwin', 'aarch64'), 'arm64-osx')
+
+    def test_darwin_x64(self):
+        self.assertEqual(vcpkg.triplet_for('darwin', 'x86_64'), 'x64-osx')
+
+    def test_windows_msvc_defaults_static(self):
+        # blade links static; vcpkg's default windows triplet is dynamic, so
+        # 'auto' must resolve to the -static variant.
+        self.assertEqual(vcpkg.triplet_for('windows', 'x64', vendor='msvc'),
+                         'x64-windows-static')
+
+    def test_windows_mingw(self):
+        self.assertEqual(vcpkg.triplet_for('windows', 'x86_64', vendor='gcc'),
+                         'x64-mingw-static')
+
+    def test_dynamic_variants(self):
+        self.assertEqual(vcpkg.triplet_for('linux', 'x86_64', dynamic=True),
+                         'x64-linux-dynamic')
+        self.assertEqual(vcpkg.triplet_for('windows', 'x64', vendor='msvc', dynamic=True),
+                         'x64-windows')
+
+    def test_unsupported_returns_none(self):
+        self.assertIsNone(vcpkg.triplet_for('plan9', 'x86_64'))
+        self.assertIsNone(vcpkg.triplet_for('linux', 'sparc'))
+
+
+_OPENSSL_PC = """\
+prefix=/work/build64/.cache/vcpkg/installed/x64-linux
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: OpenSSL-libssl
+Description: Secure Sockets Layer and cryptography libraries
+Version: 3.2.1
+Requires.private: libcrypto >= 3.2.1
+Libs: -L${libdir} -lssl
+Libs.private: -ldl -pthread
+Cflags: -I${includedir}
+"""
+
+_HEADER_ONLY_PC = """\
+prefix=/x
+includedir=${prefix}/include
+Name: nlohmann_json
+Version: 3.11.3
+Cflags: -I${includedir}
+"""
+
+
+class ParsePkgConfigTest(unittest.TestCase):
+
+    def test_basic_fields_and_expansion(self):
+        pc = vcpkg.parse_pkgconfig(_OPENSSL_PC)
+        self.assertEqual(pc['name'], 'OpenSSL-libssl')
+        self.assertEqual(pc['version'], '3.2.1')
+        # ${libdir} -> ${prefix}/lib -> the absolute prefix; expansion is nested.
+        self.assertIn('-L/work/build64/.cache/vcpkg/installed/x64-linux/lib',
+                      pc['libs'])
+
+    def test_l_libs_extracted(self):
+        pc = vcpkg.parse_pkgconfig(_OPENSSL_PC)
+        self.assertEqual(pc['l_libs'], ['ssl'])
+
+    def test_requires_private_strips_version(self):
+        pc = vcpkg.parse_pkgconfig(_OPENSSL_PC)
+        self.assertEqual(pc['requires_private'], ['libcrypto'])
+        self.assertEqual(pc['requires'], [])
+
+    def test_libs_private_system_libs(self):
+        pc = vcpkg.parse_pkgconfig(_OPENSSL_PC)
+        # -ldl -> 'dl'; bare '-pthread' is not a -l form and is left in tokens.
+        self.assertEqual(pc['l_private'], ['dl'])
+        self.assertIn('-pthread', pc['libs_private'])
+
+    def test_header_only_has_no_libs(self):
+        pc = vcpkg.parse_pkgconfig(_HEADER_ONLY_PC)
+        self.assertEqual(pc['l_libs'], [])
+        self.assertEqual(pc['requires'], [])
+        self.assertIn('-I/x/include', pc['cflags'])
+
+    def test_comma_and_space_separated_requires(self):
+        pc = vcpkg.parse_pkgconfig(
+            'Name: x\nRequires: a >= 1.0, b, c\n')
+        self.assertEqual(pc['requires'], ['a', 'b', 'c'])
+
+    def test_value_with_equals_not_treated_as_var(self):
+        # A keyword value containing '=' must not be misread as a variable def.
+        pc = vcpkg.parse_pkgconfig('Name: x\nCflags: -DFOO=1 -I/i\n')
+        self.assertIn('-DFOO=1', pc['cflags'])
+        self.assertEqual(pc['name'], 'x')
+
+    def test_spaced_dash_l(self):
+        pc = vcpkg.parse_pkgconfig('Name: x\nLibs: -L/d -l ssl -lcrypto\n')
+        self.assertEqual(pc['l_libs'], ['ssl', 'crypto'])
+
+    def test_empty_input(self):
+        pc = vcpkg.parse_pkgconfig('')
+        self.assertEqual(pc['name'], '')
+        self.assertEqual(pc['l_libs'], [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**PR3 of native vcpkg support (#1236)** — targets the `vcpkg` integration branch.

The provider-independent data extraction the dependency handler builds on, as standalone pure functions in a new `blade/vcpkg.py` (imported by nothing yet, so inert).

- `triplet_for(os, arch, vendor, dynamic)` — blade `target_os`/`target_arch` → vcpkg triplet. Phase 1 returns the *vanilla* triplet a host's own `vcpkg install` uses (`x64-linux`, `arm64-osx`); Windows → `-static` by default (blade links static; vcpkg's default windows triplet is dynamic). `blade-` chainload overlay triplets arrive with orchestration.
- `parse_pkgconfig(text)` — parses a port `.pc`: `${var}` expansion, `Requires[.private]` → module names (version constraints stripped), `Libs[.private]` → tokens + extracted `-l` names, `Cflags`. Keyword/variable disambiguation uses the fixed pkg-config keyword set so `-DFOO=1` isn't misread as a var def.

`VcpkgLibrary` + the `vcpkg#port:lib` handler that consume these land in PR4.

> Note: the original PR3 (resolver) is split into PR3 (these pure helpers) + PR4 (target + handler + registration, needs a mock install tree) for reviewability.

Tests: `vcpkg_helpers_test.py` (17 — triplet matrix incl. dynamic/unsupported; `.pc` expansion, requires/libs extraction, header-only, edge cases). Full unit suite: 518 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)