### PR TITLE
vcpkg: VcpkgLibrary target + vcpkg#port:lib provider (#1236, PR4)

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1741,6 +1741,85 @@ class PrebuiltCcLibrary(CcTarget):
                                 order_only_deps=inclusion_check_result)
 
 
+class VcpkgLibrary(PrebuiltCcLibrary):
+    """A library resolved from a vcpkg install tree (issue #1236).
+
+    Auto-created by the vcpkg dependency provider (NOT declared in a BUILD
+    file) for a `vcpkg#<port>:<lib>` reference -- the same lifecycle as a
+    SystemLibrary. It wraps a pre-existing static archive under
+    `<root>/installed/<triplet>/lib/` plus the install tree's include dir;
+    `vcpkg#<port>:hdrs` is a header-only port (include dir only, no archive).
+
+    The backing `.a` lives outside the build tree, so `_setup` is overridden to
+    look at the resolved absolute path directly rather than the source-relative
+    path PrebuiltCcLibrary computes.
+    """
+
+    def __init__(self, port, lib, key, lib_dir, include_dir, header_only):
+        # Stash the vcpkg-resolved locations before super().__init__, which
+        # calls our _setup() at the end of construction.
+        self._vcpkg_port = port
+        self._vcpkg_lib_dir = lib_dir
+        self._vcpkg_header_only = header_only
+        super().__init__(
+                name=lib,
+                deps=[],
+                hdrs=[],
+                visibility=['PUBLIC'],
+                tags=['lang:cc', 'type:library', 'type:vcpkg'],
+                export_incs=[],
+                libpath_pattern=None,
+                link_all_symbols=False,
+                binary_link_only=False,
+                deprecated=False,
+                kwargs={})
+        # Re-key as the canonical provider reference. The path sentinel must not
+        # be '#' -- that marks a `-l` system lib in the link/incs resolution.
+        # Done before declare_hdr_dir below so the headers register under the
+        # final key.
+        self.type = 'vcpkg_library'
+        self.path = 'vcpkg#' + port
+        self.key = key
+        self.fullname = '//' + key
+        if include_dir:
+            # External headers go via -isystem so third-party warnings don't
+            # trip the consumer's -Werror (same posture as foreign_cc_library);
+            # absolute paths survive _incs_to_fullpath unchanged.
+            self.attr['system_export_incs'] = self._incs_to_fullpath([include_dir])
+        # Exempt from the unused-deps check: vcpkg headers live in an absolute,
+        # out-of-tree `-isystem` dir, which blade's inclusion scanner can't
+        # attribute back to this target (declare_hdr_dir works only for
+        # in-tree dirs). Flagging every vcpkg dep as "unused" would be pure
+        # noise; precise external-header attribution is a follow-up.
+        declare_header_less(self)
+
+    def _setup(self):  # override PrebuiltCcLibrary._setup
+        tc = self.blade.get_build_toolchain()
+        if self._vcpkg_header_only:
+            return
+        archive = os.path.join(
+            self._vcpkg_lib_dir,
+            f'{tc.lib_prefix}{self.name}{tc.static_lib_suffix}')
+        if not os.path.exists(archive):
+            self.error(
+                'vcpkg#%s:%s: static library not found at %s; run '
+                '`vcpkg install %s` for this triplet' % (
+                    self._vcpkg_port, self.name, archive, self._vcpkg_port))
+            return
+        self.attr['static_source'] = archive
+        self._add_target_file(tc.STATIC_LIB_LABEL, archive)
+        # No separate shared lib is resolved in this phase; the static archive
+        # serves both link modes (consumers that dynamic_link still get it).
+        self._add_target_file(tc.DYNAMIC_LIB_LABEL, archive)
+
+    def generate(self):  # override
+        # The static archive + include dir are pure metadata resolved in
+        # _setup(); there is nothing to build. (Emitting archive-syms for
+        # cc_check_undefined would write `<archive>.syms` into the shared vcpkg
+        # tree; redirecting that into the build dir is a follow-up.)
+        pass
+
+
 def prebuilt_cc_library(
         name: str,
         deps: 'StrOrListOpt' = None,

--- a/src/blade/load_build_files.py
+++ b/src/blade/load_build_files.py
@@ -39,6 +39,7 @@ import posixpath
 def _load_build_rules():
     # pylint: disable=import-outside-toplevel,unused-import
     import blade.cc_targets
+    import blade.vcpkg  # registers the `vcpkg#...` dep scheme (issue #1236)
     import blade.cu_targets
     import blade.custom_rule_target
     import blade.gen_rule_target
@@ -593,12 +594,15 @@ def _load_related_build_files(blade, command_targets, processed_dirs):
 
     while cited_targets:
         target_id = cited_targets.pop()
-        source_dir, target_name = target_id.split(':')
+        source_dir, target_name = target_id.split(':', 1)
 
         if target_id in related_targets:
             continue
 
-        if source_dir == '#':
+        # System libs ('#name') and provider-qualified external libs
+        # ('vcpkg#port:lib', ...) are pre-registered in the database and have no
+        # BUILD file to load. A normal workspace source dir never contains '#'.
+        if '#' in source_dir:
             related_targets[target_id] = target_database[target_id]
             continue
 

--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -17,7 +17,10 @@ chainload blade's compiler belong to the orchestration phase and are added
 later.
 """
 
+import os
 import re
+
+from blade import target as _blade_target
 
 # blade target_arch (canonical, from `cc -dumpmachine`) / MSVC arch -> vcpkg
 # architecture token.
@@ -168,3 +171,91 @@ def parse_pkgconfig(text):
         'l_libs': _extract_l_libs(libs),
         'l_private': _extract_l_libs(libs_private),
     }
+
+
+class VcpkgError(Exception):
+    """A `vcpkg#...` reference could not be resolved (issue #1236)."""
+
+
+def resolve_reference(coordinate, packages, root, triplet):
+    """Resolve a `vcpkg#<coordinate>` reference to install-tree locations.
+
+    Pure validation + path computation (no toolchain / Target / filesystem):
+    the handler derives `triplet`/`root` from the toolchain + config and passes
+    them in. Raises VcpkgError (with a user-facing message) on any problem.
+
+    Returns a dict: port, lib, key, header_only, lib_dir, include_dir.
+    """
+    if ':' not in coordinate:
+        raise VcpkgError(
+            'invalid dependency "vcpkg#%s": a port must name a library, e.g. '
+            '"vcpkg#%s:<lib>" (or "vcpkg#%s:hdrs" for a header-only port)'
+            % (coordinate, coordinate, coordinate))
+    port, lib = coordinate.split(':', 1)
+    if not port or not lib:
+        raise VcpkgError('invalid dependency "vcpkg#%s": expected "<port>:<lib>"'
+                         % coordinate)
+    # Strict by default: the workspace whitelist is the single source of truth
+    # for which ports may be referenced.
+    if port not in packages:
+        raise VcpkgError(
+            'vcpkg port "%s" is not in the vcpkg_config.packages whitelist; '
+            'declare it in BLADE_ROOT, e.g. '
+            'vcpkg_config(packages={"%s": "<version>"})' % (port, port))
+    if not root:
+        raise VcpkgError(
+            'vcpkg: no install root for "vcpkg#%s"; set vcpkg_config(root=...) '
+            'or the VCPKG_ROOT environment variable' % coordinate)
+    if not triplet:
+        raise VcpkgError(
+            'vcpkg: could not determine a triplet for "vcpkg#%s"; set '
+            'vcpkg_config(triplet=...)' % coordinate)
+    installed = os.path.join(root, 'installed', triplet)
+    return {
+        'port': port,
+        'lib': lib,
+        'key': 'vcpkg#%s:%s' % (port, lib),
+        'header_only': lib == 'hdrs',
+        'lib_dir': os.path.join(installed, 'lib'),
+        'include_dir': os.path.join(installed, 'include'),
+    }
+
+
+def triplet_for_toolchain(toolchain, dynamic=False):
+    """Derive the vcpkg triplet from a blade ToolChain instance."""
+    vendor = next((v for v in ('gcc', 'clang', 'msvc') if toolchain.cc_is(v)), None)
+    return triplet_for(toolchain.target_os, toolchain.target_arch, vendor, dynamic)
+
+
+def _vcpkg_dep_handler(referrer, coordinate):
+    """`<scheme>#...` provider for vcpkg (registered below).
+
+    Resolves the reference against the workspace whitelist + install tree and
+    auto-creates a VcpkgLibrary target (like _add_system_library), returning its
+    database key. Reports via referrer.error() and returns None on failure.
+    """
+    from blade import config
+    cfg = config.get_section('vcpkg_config')
+    toolchain = referrer.blade.get_build_toolchain()
+    triplet = cfg.get('triplet') or 'auto'
+    if triplet == 'auto':
+        triplet = triplet_for_toolchain(toolchain)
+    root = cfg.get('root') or os.environ.get('VCPKG_ROOT', '')
+    try:
+        info = resolve_reference(coordinate, cfg.get('packages', {}), root, triplet)
+    except VcpkgError as e:
+        referrer.error(str(e))
+        return None
+    key = info['key']
+    if key in referrer.target_database:
+        return key
+    # Lazy import: cc_targets is loaded before this module, but keeping the
+    # import local avoids a hard module-level cycle (cc_targets -> ... -> here).
+    from blade.cc_targets import VcpkgLibrary
+    target = VcpkgLibrary(info['port'], info['lib'], key,
+                          info['lib_dir'], info['include_dir'], info['header_only'])
+    referrer.blade.register_target(target)
+    return key
+
+
+_blade_target.register_dep_scheme('vcpkg', _vcpkg_dep_handler)

--- a/src/tests/unit/vcpkg_resolve_test.py
+++ b/src/tests/unit/vcpkg_resolve_test.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+#
+# Unit tests for vcpkg reference resolution + the dep-scheme handler (#1236, PR4).
+
+"""Tests resolve_reference (pure), triplet_for_toolchain, and the
+`vcpkg#...` provider handler.
+
+The handler's only side effects are constructing a VcpkgLibrary and calling
+referrer.blade.register_target(); VcpkgLibrary itself needs a live BuildManager,
+so it is patched out here -- its construction is exercised by the build-level
+tests. The resolution *logic* (whitelist, path computation, error messages) is
+fully covered by the pure resolve_reference tests.
+"""
+
+import os
+import sys
+import unittest
+import unittest.mock as mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import vcpkg  # noqa: E402
+
+
+_WHITELIST = {'fmt': '10.2.1', 'openssl': {'version': '3.2.1'}, 'nlohmann-json': '3.11.3'}
+
+
+class ResolveReferenceTest(unittest.TestCase):
+
+    def _resolve(self, coord, packages=None, root='/vc', triplet='x64-linux'):
+        return vcpkg.resolve_reference(
+            coord, _WHITELIST if packages is None else packages, root, triplet)
+
+    def test_valid_reference(self):
+        info = self._resolve('fmt:fmt')
+        self.assertEqual(info['port'], 'fmt')
+        self.assertEqual(info['lib'], 'fmt')
+        self.assertEqual(info['key'], 'vcpkg#fmt:fmt')
+        self.assertFalse(info['header_only'])
+        self.assertEqual(info['lib_dir'], '/vc/installed/x64-linux/lib')
+        self.assertEqual(info['include_dir'], '/vc/installed/x64-linux/include')
+
+    def test_lib_basename_differs_from_port(self):
+        info = self._resolve('openssl:ssl')
+        self.assertEqual(info['key'], 'vcpkg#openssl:ssl')
+        self.assertEqual(info['lib'], 'ssl')
+
+    def test_header_only_sentinel(self):
+        info = self._resolve('nlohmann-json:hdrs')
+        self.assertTrue(info['header_only'])
+
+    def test_missing_colon_rejected(self):
+        with self.assertRaises(vcpkg.VcpkgError) as cm:
+            self._resolve('fmt')
+        self.assertIn('must name a library', str(cm.exception))
+
+    def test_empty_lib_rejected(self):
+        with self.assertRaises(vcpkg.VcpkgError):
+            self._resolve('fmt:')
+
+    def test_non_whitelisted_port_is_hard_error(self):
+        with self.assertRaises(vcpkg.VcpkgError) as cm:
+            self._resolve('boost:boost')
+        msg = str(cm.exception)
+        self.assertIn('whitelist', msg)
+        self.assertIn('boost', msg)
+
+    def test_no_root_rejected(self):
+        with self.assertRaises(vcpkg.VcpkgError) as cm:
+            self._resolve('fmt:fmt', root='')
+        self.assertIn('install root', str(cm.exception))
+
+    def test_no_triplet_rejected(self):
+        with self.assertRaises(vcpkg.VcpkgError) as cm:
+            self._resolve('fmt:fmt', triplet='')
+        self.assertIn('triplet', str(cm.exception))
+
+
+class TripletForToolchainTest(unittest.TestCase):
+
+    def _tc(self, target_os, arch, vendor):
+        tc = mock.Mock()
+        tc.target_os = target_os
+        tc.target_arch = arch
+        tc.cc_is = lambda v: v == vendor
+        return tc
+
+    def test_gcc_linux(self):
+        self.assertEqual(
+            vcpkg.triplet_for_toolchain(self._tc('linux', 'x86_64', 'gcc')),
+            'x64-linux')
+
+    def test_apple_clang_arm(self):
+        self.assertEqual(
+            vcpkg.triplet_for_toolchain(self._tc('darwin', 'aarch64', 'clang')),
+            'arm64-osx')
+
+    def test_msvc(self):
+        self.assertEqual(
+            vcpkg.triplet_for_toolchain(self._tc('windows', 'x64', 'msvc')),
+            'x64-windows-static')
+
+
+class _Referrer:
+    def __init__(self, db=None):
+        self.target_database = db if db is not None else {}
+        self.errors = []
+        self.blade = mock.Mock()
+        self.blade.get_build_toolchain.return_value = mock.Mock()
+
+    def error(self, msg):
+        self.errors.append(msg)
+
+
+class HandlerTest(unittest.TestCase):
+
+    def _cfg(self, **over):
+        cfg = {'packages': _WHITELIST, 'triplet': 'x64-linux', 'root': '/vc'}
+        cfg.update(over)
+        return cfg
+
+    def test_whitelist_error_short_circuits(self):
+        r = _Referrer()
+        with mock.patch('blade.config.get_section', return_value=self._cfg()), \
+             mock.patch('blade.cc_targets.VcpkgLibrary') as MockVL:
+            key = vcpkg._vcpkg_dep_handler(r, 'boost:boost')
+        self.assertIsNone(key)
+        self.assertEqual(len(r.errors), 1)
+        MockVL.assert_not_called()
+        r.blade.register_target.assert_not_called()
+
+    def test_valid_creates_and_registers(self):
+        r = _Referrer()
+        with mock.patch('blade.config.get_section', return_value=self._cfg()), \
+             mock.patch('blade.cc_targets.VcpkgLibrary') as MockVL:
+            key = vcpkg._vcpkg_dep_handler(r, 'fmt:fmt')
+        self.assertEqual(key, 'vcpkg#fmt:fmt')
+        MockVL.assert_called_once()
+        # port, lib, key, lib_dir, include_dir, header_only
+        args = MockVL.call_args[0]
+        self.assertEqual(args[0], 'fmt')
+        self.assertEqual(args[1], 'fmt')
+        self.assertEqual(args[2], 'vcpkg#fmt:fmt')
+        self.assertFalse(args[5])
+        r.blade.register_target.assert_called_once()
+
+    def test_already_registered_is_reused(self):
+        r = _Referrer(db={'vcpkg#fmt:fmt': object()})
+        with mock.patch('blade.config.get_section', return_value=self._cfg()), \
+             mock.patch('blade.cc_targets.VcpkgLibrary') as MockVL:
+            key = vcpkg._vcpkg_dep_handler(r, 'fmt:fmt')
+        self.assertEqual(key, 'vcpkg#fmt:fmt')
+        MockVL.assert_not_called()
+        r.blade.register_target.assert_not_called()
+
+    def test_auto_triplet_derived_from_toolchain(self):
+        r = _Referrer()
+        tc = r.blade.get_build_toolchain.return_value
+        tc.target_os, tc.target_arch = 'linux', 'x86_64'
+        tc.cc_is = lambda v: v == 'gcc'
+        with mock.patch('blade.config.get_section',
+                        return_value=self._cfg(triplet='auto')), \
+             mock.patch('blade.cc_targets.VcpkgLibrary') as MockVL:
+            vcpkg._vcpkg_dep_handler(r, 'fmt:fmt')
+        # lib_dir reflects the auto-derived x64-linux triplet.
+        self.assertEqual(MockVL.call_args[0][3], '/vc/installed/x64-linux/lib')
+
+    def test_registered_as_vcpkg_scheme(self):
+        # Importing blade.vcpkg wires the provider into target's registry.
+        from blade import target as target_mod
+        self.assertIn('vcpkg', target_mod._dep_scheme_providers)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**PR4 of native vcpkg support (#1236)** — targets the `vcpkg` integration branch. Completes **Phase 1**: `vcpkg#port:lib` deps resolve from an install tree the user produced with `vcpkg install`.

- **`vcpkg._vcpkg_dep_handler` + `resolve_reference`** — parse `port:lib`, enforce the `vcpkg_config.packages` whitelist as a **hard error**, derive triplet (auto from toolchain) + install root (`$VCPKG_ROOT` or `vcpkg_config.root`), and auto-create + register a `VcpkgLibrary` keyed `vcpkg#port:lib`. Registered as the `vcpkg` dep scheme; `load_build_files` imports `blade.vcpkg` at startup.
- **`cc_targets.VcpkgLibrary(PrebuiltCcLibrary)`** — wraps the pre-existing static archive at the absolute install path (overridden `_setup`) + the install include dir via `-isystem`; `:hdrs` is header-only.
- **`load_build_files`** — skip BUILD-loading for any pre-registered provider target (`'#' in source_dir`), not just bare system libs. The `-l` system-lib link paths (`path == '#'`) stay narrow, so a `VcpkgLibrary` links as a real `.a`.

**Decisions (flagged):**
- Vcpkg libs are exempt from the unused-deps check — `declare_hdr_dir` attributes only in-tree dirs; out-of-tree `-isystem` headers can't be attributed yet (follow-up).
- No archive-syms for `cc_check_undefined` yet (would write into the shared vcpkg tree; redirecting to the build dir is a follow-up).

**Validation:** unit tests (16) cover the resolver + handler with `VcpkgLibrary` mocked. Manually validated end to end against a mock install tree: a consumer links the vcpkg `.a`, compiles with `-isystem`, and whitelist / bare-port / `:hdrs` paths behave. (A committed integration test is suggested for the orchestration phase's e2e.) Full unit suite: 534 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)