### PR TITLE
vcpkg: synthetic manifest + overlay-triplet generators (#1236, PR5)

### DIFF
--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -173,6 +173,92 @@ def parse_pkgconfig(text):
     }
 
 
+# --- Phase 2 orchestration inputs: synthetic manifest + overlay triplet ------
+#
+# When blade drives `vcpkg install` itself, it generates a manifest from the
+# vcpkg_config whitelist and an overlay triplet that chainloads blade's resolved
+# compiler, so vcpkg's artifacts stay ABI-compatible with the rest of the build.
+# These are pure generators over plain inputs; writing the files + invoking
+# vcpkg is wired separately.
+
+# blade target_os -> CMAKE_SYSTEM_NAME for the overlay triplet ('' = native,
+# i.e. Windows, where vcpkg omits the cross-compile system name).
+_VCPKG_SYSTEM_NAME = {'linux': 'Linux', 'darwin': 'Darwin', 'windows': ''}
+
+
+def overlay_triplet_name(triplet):
+    """The blade overlay triplet name for a vanilla vcpkg triplet."""
+    return 'blade-' + triplet
+
+
+def manifest_json(packages, baseline=''):
+    """Build the synthetic vcpkg.json manifest from vcpkg_config (issue #1236).
+
+    A bare version -> a dependency + an `overrides` pin; a dict with features ->
+    a dependency object carrying them. Maps vcpkg_config 1:1 onto vcpkg's
+    manifest model (one version / feature set per package per workspace).
+    """
+    dependencies = []
+    overrides = []
+    for port in sorted(packages):
+        spec = packages[port]
+        if isinstance(spec, str):
+            version, features = spec, None
+        else:
+            version, features = spec.get('version'), spec.get('features')
+        if features:
+            dependencies.append({'name': port, 'features': list(features)})
+        else:
+            dependencies.append(port)
+        if version:
+            overrides.append({'name': port, 'version': version})
+    manifest = {'dependencies': dependencies}
+    if baseline:
+        manifest['builtin-baseline'] = baseline
+    if overrides:
+        manifest['overrides'] = overrides
+    return manifest
+
+
+def configuration_json(registries):
+    """Build vcpkg-configuration.json for private registries, or None."""
+    if not registries:
+        return None
+    return {'registries': [dict(r) for r in registries]}
+
+
+def chainload_cmake(cc, cxx, c_flags='', cxx_flags=''):
+    """CMake toolchain file pinning vcpkg's compiler to blade's resolved one."""
+    return (
+        'set(CMAKE_C_COMPILER "%s")\n'
+        'set(CMAKE_CXX_COMPILER "%s")\n'
+        'set(CMAKE_C_FLAGS_INIT "%s")\n'
+        'set(CMAKE_CXX_FLAGS_INIT "%s")\n' % (cc, cxx, c_flags, cxx_flags))
+
+
+def overlay_triplet_cmake(target_os, target_arch, library_linkage='static',
+                          chainload_rel='../blade-chainload.cmake'):
+    """The overlay triplet `.cmake` that chainloads blade's compiler.
+
+    Returns None if os/arch is unsupported. `library_linkage` is 'static'
+    (default, blade links static) or 'dynamic'.
+    """
+    arch = _VCPKG_ARCH.get(target_arch)
+    if arch is None or target_os not in _VCPKG_SYSTEM_NAME:
+        return None
+    lines = [
+        'set(VCPKG_TARGET_ARCHITECTURE %s)' % arch,
+        'set(VCPKG_CRT_LINKAGE dynamic)',
+        'set(VCPKG_LIBRARY_LINKAGE %s)' % library_linkage,
+    ]
+    system = _VCPKG_SYSTEM_NAME[target_os]
+    if system:
+        lines.append('set(VCPKG_CMAKE_SYSTEM_NAME %s)' % system)
+    lines.append('set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE '
+                 '${CMAKE_CURRENT_LIST_DIR}/%s)' % chainload_rel)
+    return '\n'.join(lines) + '\n'
+
+
 class VcpkgError(Exception):
     """A `vcpkg#...` reference could not be resolved (issue #1236)."""
 

--- a/src/tests/unit/vcpkg_manifest_test.py
+++ b/src/tests/unit/vcpkg_manifest_test.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+#
+# Unit tests for vcpkg manifest + overlay-triplet generation (#1236, PR5).
+
+"""Tests the pure Phase-2 generators: synthetic vcpkg.json, the overlay triplet
+that chainloads blade's compiler, and the chainload toolchain file. Writing
+these files + invoking `vcpkg install` is wired separately (PR6)."""
+
+import os
+import sys
+import unittest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import vcpkg  # noqa: E402
+
+
+class ManifestTest(unittest.TestCase):
+
+    def test_string_version_becomes_dep_plus_override(self):
+        m = vcpkg.manifest_json({'fmt': '10.2.1'})
+        self.assertEqual(m['dependencies'], ['fmt'])
+        self.assertEqual(m['overrides'], [{'name': 'fmt', 'version': '10.2.1'}])
+
+    def test_features_dep_object(self):
+        m = vcpkg.manifest_json(
+            {'curl': {'version': '8.5.0', 'features': ['ssl', 'http2']}})
+        self.assertEqual(m['dependencies'],
+                         [{'name': 'curl', 'features': ['ssl', 'http2']}])
+        self.assertEqual(m['overrides'], [{'name': 'curl', 'version': '8.5.0'}])
+
+    def test_baseline_included_when_set(self):
+        m = vcpkg.manifest_json({'fmt': '10.2.1'}, baseline='2024-12-15')
+        self.assertEqual(m['builtin-baseline'], '2024-12-15')
+
+    def test_no_baseline_key_when_empty(self):
+        m = vcpkg.manifest_json({'fmt': '10.2.1'})
+        self.assertNotIn('builtin-baseline', m)
+
+    def test_deterministic_order(self):
+        # Sorted by port so the generated manifest is stable across runs.
+        m = vcpkg.manifest_json({'zlib': '1.3', 'fmt': '10.2.1'})
+        self.assertEqual(m['dependencies'], ['fmt', 'zlib'])
+
+    def test_version_optional(self):
+        # A featureful spec without a version -> dep object, no override.
+        m = vcpkg.manifest_json({'x': {'features': ['a']}})
+        self.assertEqual(m['dependencies'], [{'name': 'x', 'features': ['a']}])
+        self.assertNotIn('overrides', m)
+
+    def test_empty(self):
+        self.assertEqual(vcpkg.manifest_json({}), {'dependencies': []})
+
+
+class ConfigurationTest(unittest.TestCase):
+
+    def test_none_when_no_registries(self):
+        self.assertIsNone(vcpkg.configuration_json([]))
+
+    def test_registries_passed_through(self):
+        regs = [{'kind': 'git', 'repository': 'https://x', 'baseline': 'abc'}]
+        self.assertEqual(vcpkg.configuration_json(regs), {'registries': regs})
+
+
+class OverlayTripletTest(unittest.TestCase):
+
+    def test_name(self):
+        self.assertEqual(vcpkg.overlay_triplet_name('x64-linux'), 'blade-x64-linux')
+
+    def test_linux(self):
+        t = vcpkg.overlay_triplet_cmake('linux', 'x86_64')
+        self.assertIn('set(VCPKG_TARGET_ARCHITECTURE x64)', t)
+        self.assertIn('set(VCPKG_LIBRARY_LINKAGE static)', t)
+        self.assertIn('set(VCPKG_CMAKE_SYSTEM_NAME Linux)', t)
+        self.assertIn('VCPKG_CHAINLOAD_TOOLCHAIN_FILE', t)
+        self.assertIn('../blade-chainload.cmake', t)
+
+    def test_darwin_arm(self):
+        t = vcpkg.overlay_triplet_cmake('darwin', 'aarch64')
+        self.assertIn('set(VCPKG_TARGET_ARCHITECTURE arm64)', t)
+        self.assertIn('set(VCPKG_CMAKE_SYSTEM_NAME Darwin)', t)
+
+    def test_windows_omits_system_name(self):
+        # Native Windows build: vcpkg doesn't want a cross CMAKE_SYSTEM_NAME.
+        t = vcpkg.overlay_triplet_cmake('windows', 'x64')
+        self.assertNotIn('VCPKG_CMAKE_SYSTEM_NAME', t)
+        self.assertIn('set(VCPKG_TARGET_ARCHITECTURE x64)', t)
+
+    def test_dynamic_linkage(self):
+        t = vcpkg.overlay_triplet_cmake('linux', 'x86_64', library_linkage='dynamic')
+        self.assertIn('set(VCPKG_LIBRARY_LINKAGE dynamic)', t)
+
+    def test_unsupported_returns_none(self):
+        self.assertIsNone(vcpkg.overlay_triplet_cmake('plan9', 'x86_64'))
+        self.assertIsNone(vcpkg.overlay_triplet_cmake('linux', 'sparc'))
+
+
+class ChainloadTest(unittest.TestCase):
+
+    def test_compiler_and_flags(self):
+        c = vcpkg.chainload_cmake('/usr/bin/gcc', '/usr/bin/g++',
+                                  c_flags='-O2', cxx_flags='-O2 -std=c++17')
+        self.assertIn('set(CMAKE_C_COMPILER "/usr/bin/gcc")', c)
+        self.assertIn('set(CMAKE_CXX_COMPILER "/usr/bin/g++")', c)
+        self.assertIn('set(CMAKE_C_FLAGS_INIT "-O2")', c)
+        self.assertIn('set(CMAKE_CXX_FLAGS_INIT "-O2 -std=c++17")', c)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**PR5 of native vcpkg support (#1236)** — first half of Phase 2 (orchestration). Pure generators in `vcpkg.py`, called by nothing yet (PR6 writes the files + runs `vcpkg install`), so inert.

- `manifest_json(packages, baseline)` — synthetic `vcpkg.json` from the whitelist: bare version → dependency + `overrides` pin; dict with features → dependency object. Deterministic (ports sorted).
- `configuration_json(registries)` — `vcpkg-configuration.json` for private registries, or `None`.
- `overlay_triplet_cmake` / `overlay_triplet_name` — the `blade-<triplet>` overlay that chainloads blade's compiler (static linkage default; Windows omits the cross `CMAKE_SYSTEM_NAME`).
- `chainload_cmake(cc, cxx, flags)` — pins vcpkg's compiler/flags to blade's resolved toolchain so artifacts stay ABI-compatible.

Tests: `vcpkg_manifest_test.py` (16). Full unit suite: 550 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)