### PR TITLE
vcpkg: blade-managed vcpkg install orchestration (#1236, PR6)

### DIFF
--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -424,6 +424,11 @@ _CONFIG_TEMPLATE = {
     # package per workspace, so these map 1:1 onto vcpkg.json fields.
     'vcpkg_config': {
         '__help__': 'vcpkg C/C++ package manager configuration (issue #1236)',
+        # True (default): blade orchestrates `vcpkg install` into a hermetic
+        # tree under the build dir, using an overlay triplet that chainloads
+        # blade's compiler. False: read artifacts the user installed themselves
+        # under <root>/installed/<triplet> (root = vcpkg_config.root/$VCPKG_ROOT).
+        'manage': True,
         # Pins the ports tree (git SHA or date) -> vcpkg.json "builtin-baseline".
         # Empty means unpinned (not reproducible); a warning is emitted later.
         'baseline': '',

--- a/src/blade/main.py
+++ b/src/blade/main.py
@@ -73,6 +73,14 @@ def run_subcommand(blade_path, command, options, ws, targets):
         config.dump(output_file_name)
         return _check_error_log('dump')
 
+    # vcpkg orchestration (issue #1236): blade-managed `vcpkg install` runs once
+    # here -- config is loaded and the build dir exists, but BUILD files are not
+    # parsed yet, so installed artifacts are present before any VcpkgLibrary
+    # resolves them. A no-op unless vcpkg_config(manage=True) with packages.
+    from blade import vcpkg
+    if not vcpkg.setup(builder):
+        return 1
+
     # Prepare the targets
     stages = [
         ('load', builder.load_targets),

--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -181,11 +181,6 @@ def parse_pkgconfig(text):
 # These are pure generators over plain inputs; writing the files + invoking
 # vcpkg is wired separately.
 
-# blade target_os -> CMAKE_SYSTEM_NAME for the overlay triplet ('' = native,
-# i.e. Windows, where vcpkg omits the cross-compile system name).
-_VCPKG_SYSTEM_NAME = {'linux': 'Linux', 'darwin': 'Darwin', 'windows': ''}
-
-
 def overlay_triplet_name(triplet):
     """The blade overlay triplet name for a vanilla vcpkg triplet."""
     return 'blade-' + triplet
@@ -242,21 +237,46 @@ def overlay_triplet_cmake(target_os, target_arch, library_linkage='static',
 
     Returns None if os/arch is unsupported. `library_linkage` is 'static'
     (default, blade links static) or 'dynamic'.
+
+    Deliberately omits VCPKG_CMAKE_SYSTEM_NAME: blade's overlay triplets are
+    always native (host == target), and setting the system name would flip
+    CMake into cross-compile mode and break a native `vcpkg install`. Stock
+    native triplets omit it too.
     """
     arch = _VCPKG_ARCH.get(target_arch)
-    if arch is None or target_os not in _VCPKG_SYSTEM_NAME:
+    if arch is None or target_os not in _VCPKG_OS:
         return None
     lines = [
         'set(VCPKG_TARGET_ARCHITECTURE %s)' % arch,
         'set(VCPKG_CRT_LINKAGE dynamic)',
         'set(VCPKG_LIBRARY_LINKAGE %s)' % library_linkage,
+        'set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE '
+        '${CMAKE_CURRENT_LIST_DIR}/%s)' % chainload_rel,
     ]
-    system = _VCPKG_SYSTEM_NAME[target_os]
-    if system:
-        lines.append('set(VCPKG_CMAKE_SYSTEM_NAME %s)' % system)
-    lines.append('set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE '
-                 '${CMAKE_CURRENT_LIST_DIR}/%s)' % chainload_rel)
     return '\n'.join(lines) + '\n'
+
+
+def install_location(cfg, vanilla_triplet, build_dir):
+    """Return (artifacts_root, triplet) for resolving a `vcpkg#...` reference.
+
+    manage=True (default): the blade-managed hermetic tree under the build dir,
+    with the overlay triplet `blade-<vanilla>`. manage=False: the tree the user
+    installed themselves (vcpkg_config.root or $VCPKG_ROOT) with the vanilla
+    triplet. `installed/<triplet>/` is appended by resolve_reference.
+    """
+    if cfg.get('manage', True):
+        root = os.path.join(build_dir, cfg.get('install_dir') or '.cache/vcpkg')
+        triplet = overlay_triplet_name(vanilla_triplet)
+    else:
+        root = cfg.get('root') or os.environ.get('VCPKG_ROOT', '')
+        triplet = vanilla_triplet
+    # Absolute so the resolved include dir survives _incs_to_fullpath (which
+    # would otherwise prepend the target's path sentinel to a relative dir) and
+    # so the .a path is independent of the compiler's working directory. blade
+    # has chdir'd to the workspace root, so abspath resolves against it.
+    if root:
+        root = os.path.abspath(root)
+    return root, triplet
 
 
 class VcpkgError(Exception):
@@ -323,10 +343,10 @@ def _vcpkg_dep_handler(referrer, coordinate):
     from blade import config
     cfg = config.get_section('vcpkg_config')
     toolchain = referrer.blade.get_build_toolchain()
-    triplet = cfg.get('triplet') or 'auto'
-    if triplet == 'auto':
-        triplet = triplet_for_toolchain(toolchain)
-    root = cfg.get('root') or os.environ.get('VCPKG_ROOT', '')
+    vanilla = cfg.get('triplet')
+    if not vanilla or vanilla == 'auto':
+        vanilla = triplet_for_toolchain(toolchain)
+    root, triplet = install_location(cfg, vanilla, referrer.blade.get_build_dir())
     try:
         info = resolve_reference(coordinate, cfg.get('packages', {}), root, triplet)
     except VcpkgError as e:
@@ -342,6 +362,99 @@ def _vcpkg_dep_handler(referrer, coordinate):
                           info['lib_dir'], info['include_dir'], info['header_only'])
     referrer.blade.register_target(target)
     return key
+
+
+def _find_vcpkg_tool(cfg):
+    """Locate the vcpkg executable: vcpkg_config.root / $VCPKG_ROOT / PATH."""
+    import shutil
+    tool_root = cfg.get('root') or os.environ.get('VCPKG_ROOT', '')
+    if tool_root:
+        candidate = os.path.join(tool_root, 'vcpkg')
+        if os.path.exists(candidate):
+            return candidate
+    return shutil.which('vcpkg')
+
+
+def setup(builder):
+    """Phase 2: blade-managed `vcpkg install` (issue #1236).
+
+    Runs once, after config load and before BUILD files are parsed, so the
+    installed artifacts exist on disk by the time VcpkgLibrary targets resolve.
+    A no-op unless vcpkg_config(manage=True) (the default) with a non-empty
+    packages whitelist. Returns True on success or no-op, False on failure
+    (after reporting). An MD5 stamp over the generated inputs skips the install
+    when nothing relevant changed.
+    """
+    import hashlib
+    import json
+    from blade import config, console, util
+    cfg = config.get_section('vcpkg_config')
+    packages = cfg.get('packages') or {}
+    if not cfg.get('manage', True) or not packages:
+        return True
+
+    toolchain = builder.get_build_toolchain()
+    vanilla = cfg.get('triplet')
+    if not vanilla or vanilla == 'auto':
+        vanilla = triplet_for_toolchain(toolchain)
+    triplet_cmake = (overlay_triplet_cmake(toolchain.target_os, toolchain.target_arch)
+                     if vanilla else None)
+    if not vanilla or triplet_cmake is None:
+        console.error('vcpkg: cannot derive a triplet for os=%s arch=%s; set '
+                      'vcpkg_config(triplet=...)'
+                      % (toolchain.target_os, toolchain.target_arch))
+        return False
+    overlay = overlay_triplet_name(vanilla)
+
+    base = os.path.join(builder.get_build_dir(), cfg.get('install_dir') or '.cache/vcpkg')
+    triplets_dir = os.path.join(base, 'triplets')
+    installed_root = os.path.join(base, 'installed')
+    os.makedirs(triplets_dir, exist_ok=True)
+
+    manifest = json.dumps(manifest_json(packages, cfg.get('baseline', '')),
+                          indent=2, sort_keys=True)
+    chainload = chainload_cmake(toolchain.tool('cc') or 'cc',
+                                toolchain.tool('cxx') or 'c++')
+    files = {
+        os.path.join(base, 'vcpkg.json'): manifest,
+        os.path.join(base, 'blade-chainload.cmake'): chainload,
+        os.path.join(triplets_dir, overlay + '.cmake'): triplet_cmake,
+    }
+    configuration = configuration_json(cfg.get('registries') or [])
+    if configuration is not None:
+        files[os.path.join(base, 'vcpkg-configuration.json')] = json.dumps(
+            configuration, indent=2, sort_keys=True)
+    for path, content in files.items():
+        util.write_if_changed(path, content)
+
+    stamp = hashlib.md5(
+        (manifest + chainload + triplet_cmake + overlay).encode()).hexdigest()
+    stamp_file = os.path.join(base, '.blade-vcpkg-stamp')
+    if os.path.isdir(installed_root) and os.path.exists(stamp_file):
+        with open(stamp_file) as f:
+            if f.read().strip() == stamp:
+                return True
+
+    vcpkg_bin = _find_vcpkg_tool(cfg)
+    if vcpkg_bin is None:
+        console.error('vcpkg: the vcpkg tool was not found; set '
+                      'vcpkg_config(root=...), $VCPKG_ROOT, or put vcpkg on PATH')
+        return False
+
+    cmd = [vcpkg_bin, 'install',
+           '--triplet', overlay,
+           '--x-manifest-root', base,
+           '--x-install-root', installed_root,
+           '--overlay-triplets', triplets_dir]
+    console.info('vcpkg: installing %d package(s) for %s ...'
+                 % (len(packages), overlay))
+    returncode, stdout, stderr = util.run_command(cmd)
+    if returncode != 0:
+        console.error('vcpkg install failed:\n%s' % (stderr or stdout))
+        return False
+    with open(stamp_file, 'w') as f:
+        f.write(stamp)
+    return True
 
 
 _blade_target.register_dep_scheme('vcpkg', _vcpkg_dep_handler)

--- a/src/tests/unit/vcpkg_manifest_test.py
+++ b/src/tests/unit/vcpkg_manifest_test.py
@@ -74,20 +74,20 @@ class OverlayTripletTest(unittest.TestCase):
         t = vcpkg.overlay_triplet_cmake('linux', 'x86_64')
         self.assertIn('set(VCPKG_TARGET_ARCHITECTURE x64)', t)
         self.assertIn('set(VCPKG_LIBRARY_LINKAGE static)', t)
-        self.assertIn('set(VCPKG_CMAKE_SYSTEM_NAME Linux)', t)
         self.assertIn('VCPKG_CHAINLOAD_TOOLCHAIN_FILE', t)
         self.assertIn('../blade-chainload.cmake', t)
 
     def test_darwin_arm(self):
         t = vcpkg.overlay_triplet_cmake('darwin', 'aarch64')
         self.assertIn('set(VCPKG_TARGET_ARCHITECTURE arm64)', t)
-        self.assertIn('set(VCPKG_CMAKE_SYSTEM_NAME Darwin)', t)
 
-    def test_windows_omits_system_name(self):
-        # Native Windows build: vcpkg doesn't want a cross CMAKE_SYSTEM_NAME.
-        t = vcpkg.overlay_triplet_cmake('windows', 'x64')
-        self.assertNotIn('VCPKG_CMAKE_SYSTEM_NAME', t)
-        self.assertIn('set(VCPKG_TARGET_ARCHITECTURE x64)', t)
+    def test_native_omits_system_name(self):
+        # blade overlays are always native; a CMAKE_SYSTEM_NAME would flip CMake
+        # into cross-compile mode and break a native `vcpkg install`.
+        for os_name, arch in (('linux', 'x86_64'), ('darwin', 'aarch64'),
+                              ('windows', 'x64')):
+            self.assertNotIn('VCPKG_CMAKE_SYSTEM_NAME',
+                             vcpkg.overlay_triplet_cmake(os_name, arch))
 
     def test_dynamic_linkage(self):
         t = vcpkg.overlay_triplet_cmake('linux', 'x86_64', library_linkage='dynamic')

--- a/src/tests/unit/vcpkg_resolve_test.py
+++ b/src/tests/unit/vcpkg_resolve_test.py
@@ -110,6 +110,7 @@ class _Referrer:
         self.errors = []
         self.blade = mock.Mock()
         self.blade.get_build_toolchain.return_value = mock.Mock()
+        self.blade.get_build_dir.return_value = 'build64'
 
     def error(self, msg):
         self.errors.append(msg)
@@ -118,7 +119,11 @@ class _Referrer:
 class HandlerTest(unittest.TestCase):
 
     def _cfg(self, **over):
-        cfg = {'packages': _WHITELIST, 'triplet': 'x64-linux', 'root': '/vc'}
+        # manage=False here pins the install location to root='/vc' so the
+        # handler-logic assertions stay deterministic; install_location's
+        # manage=True path is covered in vcpkg_setup_test + the case below.
+        cfg = {'packages': _WHITELIST, 'triplet': 'x64-linux', 'root': '/vc',
+               'manage': False, 'install_dir': '.cache/vcpkg'}
         cfg.update(over)
         return cfg
 
@@ -167,6 +172,18 @@ class HandlerTest(unittest.TestCase):
             vcpkg._vcpkg_dep_handler(r, 'fmt:fmt')
         # lib_dir reflects the auto-derived x64-linux triplet.
         self.assertEqual(MockVL.call_args[0][3], '/vc/installed/x64-linux/lib')
+
+    def test_manage_true_uses_hermetic_tree(self):
+        r = _Referrer()
+        with mock.patch('blade.config.get_section',
+                        return_value=self._cfg(manage=True, triplet='x64-linux')), \
+             mock.patch('blade.cc_targets.VcpkgLibrary') as MockVL:
+            vcpkg._vcpkg_dep_handler(r, 'fmt:fmt')
+        lib_dir = MockVL.call_args[0][3]
+        # Hermetic tree under the build dir, with the blade- overlay triplet.
+        self.assertTrue(lib_dir.endswith(
+            os.path.join('build64', '.cache/vcpkg', 'installed',
+                         'blade-x64-linux', 'lib')))
 
     def test_registered_as_vcpkg_scheme(self):
         # Importing blade.vcpkg wires the provider into target's registry.

--- a/src/tests/unit/vcpkg_setup_test.py
+++ b/src/tests/unit/vcpkg_setup_test.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+#
+# Unit tests for vcpkg orchestration: install_location + setup() (#1236, PR6).
+
+"""Tests the Phase-2 orchestration logic with the vcpkg subprocess mocked.
+
+install_location is pure. setup() writes the manifest / overlay triplet /
+chainload into a tmpdir and invokes `vcpkg install`; the subprocess and the
+tool lookup are patched, so these tests don't need a real vcpkg.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+import unittest.mock as mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import vcpkg  # noqa: E402
+
+
+class InstallLocationTest(unittest.TestCase):
+
+    def test_manage_uses_hermetic_tree_and_overlay(self):
+        root, triplet = vcpkg.install_location(
+            {'manage': True, 'install_dir': '.cache/vcpkg'}, 'x64-linux', 'build64')
+        # Absolute (needed so the include dir survives _incs_to_fullpath).
+        self.assertTrue(os.path.isabs(root))
+        self.assertEqual(root, os.path.abspath(os.path.join('build64', '.cache/vcpkg')))
+        self.assertEqual(triplet, 'blade-x64-linux')
+
+    def test_unmanaged_uses_root_and_vanilla(self):
+        root, triplet = vcpkg.install_location(
+            {'manage': False, 'root': '/vc'}, 'x64-linux', 'build64')
+        self.assertEqual(root, '/vc')
+        self.assertEqual(triplet, 'x64-linux')
+
+    def test_unmanaged_falls_back_to_env(self):
+        with mock.patch.dict(os.environ, {'VCPKG_ROOT': '/envroot'}):
+            root, _ = vcpkg.install_location(
+                {'manage': False, 'root': ''}, 'x64-linux', 'b')
+        self.assertEqual(root, '/envroot')
+
+
+def _builder(build_dir):
+    b = mock.Mock()
+    b.get_build_dir.return_value = build_dir
+    tc = b.get_build_toolchain.return_value
+    tc.target_os, tc.target_arch = 'linux', 'x86_64'
+    tc.cc_is = lambda v: v == 'gcc'
+    tc.tool = lambda k: {'cc': '/usr/bin/gcc', 'cxx': '/usr/bin/g++'}.get(k)
+    return b
+
+
+_CFG = {
+    'manage': True, 'packages': {'fmt': '10.2.1'}, 'install_dir': '.cache/vcpkg',
+    'triplet': 'auto', 'baseline': '', 'registries': [], 'root': '',
+}
+
+
+class SetupTest(unittest.TestCase):
+
+    def _run(self, build_dir, cfg=None, run_result=(0, 'ok', ''), tool='/vc/vcpkg'):
+        cfg = dict(_CFG if cfg is None else cfg)
+        with mock.patch('blade.config.get_section', return_value=cfg), \
+             mock.patch('blade.vcpkg._find_vcpkg_tool', return_value=tool), \
+             mock.patch('blade.console.info'), \
+             mock.patch('blade.console.error'), \
+             mock.patch('blade.util.run_command', return_value=run_result) as rc:
+            ok = vcpkg.setup(_builder(build_dir))
+        return ok, rc
+
+    def test_manage_false_is_noop(self):
+        with tempfile.TemporaryDirectory() as d:
+            ok, rc = self._run(d, cfg=dict(_CFG, manage=False))
+        self.assertTrue(ok)
+        rc.assert_not_called()
+
+    def test_no_packages_is_noop(self):
+        with tempfile.TemporaryDirectory() as d:
+            ok, rc = self._run(d, cfg=dict(_CFG, packages={}))
+        self.assertTrue(ok)
+        rc.assert_not_called()
+
+    def test_generates_files_and_invokes_install(self):
+        with tempfile.TemporaryDirectory() as d:
+            ok, rc = self._run(d)
+            self.assertTrue(ok)
+            base = os.path.join(d, '.cache/vcpkg')
+            self.assertTrue(os.path.exists(os.path.join(base, 'vcpkg.json')))
+            self.assertTrue(os.path.exists(os.path.join(base, 'blade-chainload.cmake')))
+            self.assertTrue(os.path.exists(
+                os.path.join(base, 'triplets', 'blade-x64-linux.cmake')))
+            self.assertTrue(os.path.exists(os.path.join(base, '.blade-vcpkg-stamp')))
+        cmd = rc.call_args[0][0]
+        self.assertIn('install', cmd)
+        self.assertIn('blade-x64-linux', cmd)
+        self.assertIn('--x-install-root', cmd)
+
+    def test_install_failure_returns_false(self):
+        with tempfile.TemporaryDirectory() as d:
+            ok, _ = self._run(d, run_result=(1, '', 'boom'))
+        self.assertFalse(ok)
+
+    def test_tool_not_found_returns_false(self):
+        with tempfile.TemporaryDirectory() as d:
+            ok, rc = self._run(d, tool=None)
+        self.assertFalse(ok)
+        rc.assert_not_called()
+
+    def test_stamp_skips_reinstall(self):
+        with tempfile.TemporaryDirectory() as d:
+            # First run installs and writes the stamp.
+            ok1, rc1 = self._run(d)
+            self.assertTrue(ok1)
+            rc1.assert_called_once()
+            # Simulate vcpkg having created the install root.
+            os.makedirs(os.path.join(d, '.cache/vcpkg', 'installed'), exist_ok=True)
+            # Second run with identical inputs must skip the subprocess.
+            ok2, rc2 = self._run(d)
+            self.assertTrue(ok2)
+            rc2.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**PR6 of native vcpkg support (#1236)** — completes **Phase 2** (orchestration). Default `vcpkg_config(manage=True)`: blade drives `vcpkg install` itself.

- **`main.py`** — at the `run_subcommand` seam (config loaded, build dir ready, BUILD files not yet parsed) call `vcpkg.setup(builder)` once, aborting on failure. Installing the whole whitelist upfront means artifacts exist before any `VcpkgLibrary` resolves them.
- **`vcpkg.setup()`** — generate `vcpkg.json` + `triplets/blade-<triplet>.cmake` + `blade-chainload.cmake` under `<build>/.cache/vcpkg`, then run `vcpkg install` (manifest mode, hermetic `--x-install-root`, overlay triplet chainloading blade's compiler). MD5 stamp skips re-install when unchanged. Tool found via `vcpkg_config.root` / `$VCPKG_ROOT` / PATH.
- **`install_location()`** — resolver mode switch: managed hermetic tree + overlay triplet (`manage=True`) vs the user's `$VCPKG_ROOT` tree + vanilla triplet (`manage=False`). Absolute root (so the include dir survives `_incs_to_fullpath`).
- **config** — `vcpkg_config(manage=True)` default.
- **`overlay_triplet_cmake`** — drop `VCPKG_CMAKE_SYSTEM_NAME` (blade overlays are native; emitting it flips CMake into cross-compile mode).

**Validation:** end to end against a real vcpkg — blade ran `vcpkg install fmt` for `blade-arm64-osx`, linked `libfmt.a`, `fmt::format` works, incremental rebuild stamp-skips. Unit tests (`vcpkg_setup_test.py`, +9) mock the subprocess. Full suite: 560 passed.

**Follow-ups:** `setup` runs for all build-ish commands (a `clean` reinstalls once then stamp-skips); chainload pins `cc`/`cxx` only (not full `cc_config` flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)