### PR TITLE
vcpkg: overlay triplet must set VCPKG_CMAKE_SYSTEM_NAME (#1236)

### DIFF
--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -231,17 +231,23 @@ def chainload_cmake(cc, cxx, c_flags='', cxx_flags=''):
         'set(CMAKE_CXX_FLAGS_INIT "%s")\n' % (cc, cxx, c_flags, cxx_flags))
 
 
+# Overlay triplet target-OS settings, mirroring vcpkg's stock triplets. Linux
+# and osx set VCPKG_CMAKE_SYSTEM_NAME (which is how vcpkg derives
+# VCPKG_TARGET_IS_LINUX / _OSX -- ports branch on it; openssl uses the Windows
+# portfile without it). On macOS that name is the *native* system, not a cross
+# build. Windows omits it (it is vcpkg's default host). osx also pins
+# VCPKG_OSX_ARCHITECTURES to the Apple arch name.
+_VCPKG_SYSTEM_NAME = {'linux': 'Linux', 'darwin': 'Darwin'}
+_VCPKG_OSX_ARCH = {'x64': 'x86_64', 'arm64': 'arm64', 'x86': 'i386'}
+
+
 def overlay_triplet_cmake(target_os, target_arch, library_linkage='static',
                           chainload_rel='../blade-chainload.cmake'):
     """The overlay triplet `.cmake` that chainloads blade's compiler.
 
-    Returns None if os/arch is unsupported. `library_linkage` is 'static'
-    (default, blade links static) or 'dynamic'.
-
-    Deliberately omits VCPKG_CMAKE_SYSTEM_NAME: blade's overlay triplets are
-    always native (host == target), and setting the system name would flip
-    CMake into cross-compile mode and break a native `vcpkg install`. Stock
-    native triplets omit it too.
+    Mirrors vcpkg's stock triplet for the OS (so ports detect the target
+    correctly) and adds the chainload toolchain. Returns None if os/arch is
+    unsupported. `library_linkage` is 'static' (default) or 'dynamic'.
     """
     arch = _VCPKG_ARCH.get(target_arch)
     if arch is None or target_os not in _VCPKG_OS:
@@ -250,9 +256,15 @@ def overlay_triplet_cmake(target_os, target_arch, library_linkage='static',
         'set(VCPKG_TARGET_ARCHITECTURE %s)' % arch,
         'set(VCPKG_CRT_LINKAGE dynamic)',
         'set(VCPKG_LIBRARY_LINKAGE %s)' % library_linkage,
-        'set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE '
-        '${CMAKE_CURRENT_LIST_DIR}/%s)' % chainload_rel,
     ]
+    system = _VCPKG_SYSTEM_NAME.get(target_os)
+    if system:
+        lines.append('set(VCPKG_CMAKE_SYSTEM_NAME %s)' % system)
+    if target_os == 'darwin':
+        lines.append('set(VCPKG_OSX_ARCHITECTURES %s)'
+                     % _VCPKG_OSX_ARCH.get(arch, arch))
+    lines.append('set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE '
+                 '${CMAKE_CURRENT_LIST_DIR}/%s)' % chainload_rel)
     return '\n'.join(lines) + '\n'
 
 

--- a/src/tests/unit/vcpkg_manifest_test.py
+++ b/src/tests/unit/vcpkg_manifest_test.py
@@ -71,23 +71,27 @@ class OverlayTripletTest(unittest.TestCase):
         self.assertEqual(vcpkg.overlay_triplet_name('x64-linux'), 'blade-x64-linux')
 
     def test_linux(self):
+        # Mirrors vcpkg's stock x64-linux triplet (+ chainload). The system
+        # name is how vcpkg sets VCPKG_TARGET_IS_LINUX, which ports branch on.
         t = vcpkg.overlay_triplet_cmake('linux', 'x86_64')
         self.assertIn('set(VCPKG_TARGET_ARCHITECTURE x64)', t)
         self.assertIn('set(VCPKG_LIBRARY_LINKAGE static)', t)
+        self.assertIn('set(VCPKG_CMAKE_SYSTEM_NAME Linux)', t)
         self.assertIn('VCPKG_CHAINLOAD_TOOLCHAIN_FILE', t)
         self.assertIn('../blade-chainload.cmake', t)
 
     def test_darwin_arm(self):
+        # Mirrors stock arm64-osx: Darwin (native, not cross) + OSX arch.
         t = vcpkg.overlay_triplet_cmake('darwin', 'aarch64')
         self.assertIn('set(VCPKG_TARGET_ARCHITECTURE arm64)', t)
+        self.assertIn('set(VCPKG_CMAKE_SYSTEM_NAME Darwin)', t)
+        self.assertIn('set(VCPKG_OSX_ARCHITECTURES arm64)', t)
 
-    def test_native_omits_system_name(self):
-        # blade overlays are always native; a CMAKE_SYSTEM_NAME would flip CMake
-        # into cross-compile mode and break a native `vcpkg install`.
-        for os_name, arch in (('linux', 'x86_64'), ('darwin', 'aarch64'),
-                              ('windows', 'x64')):
-            self.assertNotIn('VCPKG_CMAKE_SYSTEM_NAME',
-                             vcpkg.overlay_triplet_cmake(os_name, arch))
+    def test_windows_omits_system_name(self):
+        # Windows is vcpkg's default host; its stock triplets set no system name.
+        t = vcpkg.overlay_triplet_cmake('windows', 'x64')
+        self.assertNotIn('VCPKG_CMAKE_SYSTEM_NAME', t)
+        self.assertIn('set(VCPKG_TARGET_ARCHITECTURE x64)', t)
 
     def test_dynamic_linkage(self):
         t = vcpkg.overlay_triplet_cmake('linux', 'x86_64', library_linkage='dynamic')


### PR DESCRIPTION
Fixes a correctness bug in the merged Phase 2 (#1302). `overlay_triplet_cmake` dropped `VCPKG_CMAKE_SYSTEM_NAME`, but vcpkg derives `VCPKG_TARGET_IS_LINUX`/`_OSX` from it and ports branch on those — openssl took the Windows portfile on macOS and failed. On the native host that name is the real system, not a cross build; vcpkg's own stock linux/osx triplets set it. Mirror them (Linux/Darwin + `VCPKG_OSX_ARCHITECTURES` on macOS; omit on Windows).

Caught by `blade test` on openssl (multi-lib); fmt didn't branch on OS so it slipped through the earlier e2e. Re-validated: fmt + openssl(ssl/crypto) + nlohmann-json(:hdrs) all pass under `blade test`. Unit tests updated; suite 560 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)