### PR TITLE
doc: user guide for vcpkg support (#1236)

### DIFF
--- a/doc/en/README.md
+++ b/doc/en/README.md
@@ -14,6 +14,8 @@
 
 [Write a BUILD file](build_file.md)
 
+[Using vcpkg packages](vcpkg.md)
+
 [Command Line](command_line.md)
 
 [Testing Support](test.md)

--- a/doc/en/config.md
+++ b/doc/en/config.md
@@ -863,3 +863,71 @@ cc_toolchain_config(
 ```
 
 This skips Visual Studio auto-detection and uses clang-cl with MSVC-style flags.
+
+### vcpkg_config
+
+Configuration for consuming [vcpkg](https://github.com/microsoft/vcpkg)
+packages as `vcpkg#<port>:<lib>` dependencies. See [Using vcpkg
+packages](vcpkg.md) for the full guide. A single workspace-level section:
+vcpkg allows one version and one feature set per package per workspace.
+
+#### `manage`: bool = True
+
+**Purpose:** When `True` (default), Blade runs `vcpkg install` itself into a
+hermetic tree under the build directory, using an overlay triplet that
+chainloads Blade's compiler. When `False`, Blade only resolves artifacts that
+you installed yourself under `<root>/installed/<triplet>`.
+
+#### `packages`: dict = {}
+
+**Purpose:** The whitelist of allowed ports — the single source of truth for
+what a `vcpkg#<port>:<lib>` reference may resolve to. Referencing a port that
+is not listed is a hard error. Each value is a version string or a dict with
+`version` and/or `features`:
+
+```python
+vcpkg_config(
+    packages = {
+        'fmt': '10.2.1',
+        'curl': {'version': '8.5.0', 'features': ['ssl', 'http2']},
+    },
+)
+```
+
+#### `baseline`: str = ""
+
+**Purpose:** Pins the ports tree to a date or git SHA
+(vcpkg.json `builtin-baseline`). Leaving it empty is not reproducible; pin it
+for consistent versions.
+
+#### `registries`: list = []
+
+**Purpose:** Optional private vcpkg registries
+(vcpkg-configuration.json `registries`).
+
+#### `root`: str = ""
+
+**Purpose:** The vcpkg installation (tool + ports tree). Empty means
+`$VCPKG_ROOT`. In managed mode this locates the `vcpkg` tool; in unmanaged mode
+it is also the root of the install tree that is read.
+
+#### `triplet`: str = "auto"
+
+**Purpose:** The vcpkg triplet. `auto` derives it from the resolved
+`cc_toolchain` (e.g. `x64-linux`, `arm64-osx`, `x64-windows-static`); set an
+explicit triplet to override.
+
+#### `install_dir`: str = ".cache/vcpkg"
+
+**Purpose:** The per-workspace install root for managed mode, relative to the
+build directory. Cleared by `blade clean`.
+
+#### `binary_cache`: str = "auto"
+
+**Purpose:** The vcpkg binary-cache backend used to reuse compiled packages
+across workspaces.
+
+#### `direct_use_allowed`: list = []
+
+**Purpose:** Governance — subtrees where bare `vcpkg#...` references are
+allowed. Empty means anywhere.

--- a/doc/en/vcpkg.md
+++ b/doc/en/vcpkg.md
@@ -1,0 +1,249 @@
+# Using vcpkg packages
+
+Blade can consume C/C++ libraries from [vcpkg](https://github.com/microsoft/vcpkg)
+— Microsoft's cross-platform package manager (~2500 ports) — as first-class
+dependencies, alongside your source targets and system libraries. You reference
+a vcpkg library as `vcpkg#<port>:<lib>` in a target's `deps`, declare the
+allowed packages once in `BLADE_ROOT`, and Blade takes care of installing and
+linking them.
+
+This unifies third-party dependencies across Linux, macOS and Windows and
+removes most of the per-package `cmake_build` boilerplate.
+
+## Quick start
+
+1. **Get vcpkg.** Clone and bootstrap it, then either set `VCPKG_ROOT` to that
+   directory or put the `vcpkg` executable on your `PATH`:
+
+   ```bash
+   git clone https://github.com/microsoft/vcpkg.git ~/vcpkg
+   ~/vcpkg/bootstrap-vcpkg.sh        # bootstrap-vcpkg.bat on Windows
+   export VCPKG_ROOT=~/vcpkg
+   ```
+
+2. **Declare the allowed packages** in `BLADE_ROOT`:
+
+   ```python
+   vcpkg_config(
+       baseline = '2024-12-15',          # pins the ports tree (recommended)
+       packages = {
+           'fmt': '10.2.1',
+           'openssl': '3.2.1',
+       },
+   )
+   ```
+
+3. **Depend on a library** with `vcpkg#<port>:<lib>`:
+
+   ```python
+   cc_binary(
+       name = 'app',
+       srcs = ['app.cc'],
+       deps = [
+           'vcpkg#fmt:fmt',
+           'vcpkg#openssl:ssl',
+       ],
+   )
+   ```
+
+4. **Build.** By default Blade installs the declared packages and links them:
+
+   ```bash
+   blade build //:app
+   ```
+
+## Reference syntax: `vcpkg#<port>:<lib>`
+
+A vcpkg dependency extends Blade's `#name` system-library family. The `#`
+already means "a library not built from source in this workspace" (`#pthread`,
+`#dl`); a scheme in front of it says where the library comes from — here,
+`vcpkg`. The part after `#` is the package manager's own coordinate.
+
+| Reference | Meaning |
+|---|---|
+| `vcpkg#<port>:<lib>` | A specific static library — `lib<lib>.a` (the `lib` prefix is implied). |
+| `vcpkg#<port>:hdrs` | A header-only port — only its include directory, no archive. |
+| `vcpkg#<port>` | **Rejected** — you must name a library after the port. |
+
+References are always fully explicit: there is no "all libraries of a port"
+shortcut, so a multi-library port can never be over-linked by accident.
+
+The library basename can differ from the port name — the vcpkg port
+`boost-filesystem` produces `libboost_filesystem.a`, so it is referenced as
+`vcpkg#boost-filesystem:boost_filesystem`.
+
+## The package whitelist
+
+`vcpkg_config(packages=...)` is the single source of truth for which ports may
+be referenced. Referencing a port that is not listed is a **hard error** — this
+keeps every external dependency declared and versioned in one place. Each value
+is either a version string or a dict with `version` and/or `features`:
+
+```python
+vcpkg_config(
+    packages = {
+        'fmt': '10.2.1',                                   # short form
+        'curl': {'version': '8.5.0', 'features': ['ssl', 'http2']},
+    },
+)
+```
+
+## Managed vs. unmanaged installs
+
+`vcpkg_config(manage=...)` selects who runs `vcpkg install`.
+
+### Managed (`manage=True`, the default)
+
+Blade drives vcpkg for you. Before loading BUILD files it generates a manifest
+from your whitelist and runs `vcpkg install` into a hermetic tree under the
+build directory (`<build>/.cache/vcpkg/`), using an *overlay triplet*
+(`blade-<triplet>`) that chainloads Blade's resolved compiler so the artifacts
+stay ABI-compatible with the rest of your build. The result is reproducible and
+needs no manual steps — just `blade build`. An install is skipped when nothing
+relevant changed.
+
+The `vcpkg` **tool** is still located via `vcpkg_config.root`, `$VCPKG_ROOT`, or
+`PATH`; only the installed artifacts live under the build directory.
+
+### Unmanaged (`manage=False`)
+
+You run `vcpkg install` yourself, and Blade only resolves paths from the
+existing install tree at `<root>/installed/<triplet>/`, where `<root>` is
+`vcpkg_config.root` or `$VCPKG_ROOT`:
+
+```bash
+vcpkg install fmt openssl          # you install
+```
+```python
+vcpkg_config(manage = False, packages = {'fmt': '10.2.1', 'openssl': '3.2.1'})
+```
+
+## Multi-library ports
+
+Ports such as `openssl`, `protobuf` or `icu` produce several archives. Each is
+its own target, and you declare the ones you use:
+
+```python
+deps = [
+    'vcpkg#openssl:ssl',         # libssl.a
+    'vcpkg#openssl:crypto',      # libcrypto.a
+]
+```
+
+A bare `vcpkg#openssl` is rejected, so you never accidentally pull in libraries
+you do not use.
+
+## Header-only ports
+
+For a header-only port, use the `:hdrs` sentinel — Blade exposes the include
+directory and links no archive:
+
+```python
+deps = ['vcpkg#nlohmann-json:hdrs']
+```
+
+## Discovering ports and their libraries
+
+### Which ports and versions are available
+
+The available ports and their default versions are fixed by your `baseline`
+(the ports tree at that commit). To explore them:
+
+```bash
+vcpkg search            # every port and its version in the ports tree
+vcpkg search fmt        # ports whose name/description matches "fmt"
+```
+
+`vcpkg search` reflects the ports tree at its current checkout. To inspect a
+specific `baseline`, check the vcpkg repo out at that commit first
+(`git -C $VCPKG_ROOT checkout <baseline>`), or read the version database
+directly:
+
+- `$VCPKG_ROOT/versions/baseline.json` — the baseline version of every port.
+- `$VCPKG_ROOT/versions/<x->/<port>.json` — every published version of a port.
+- `$VCPKG_ROOT/ports/<port>/vcpkg.json` — the port's version, available
+  `features`, and its own dependencies.
+
+### Which libraries a port produces
+
+A `vcpkg#<port>:<lib>` reference names the archive `lib<lib>.a`, and the
+basename can differ from the port name (`boost-filesystem` →
+`libboost_filesystem.a`; `openssl` → `libssl.a` + `libcrypto.a`). Read the
+exact names off the installed tree:
+
+```bash
+# managed mode (manage=True): under the build dir, with the blade- overlay triplet
+ls build64_release/.cache/vcpkg/installed/blade-<triplet>/lib/lib*.a
+
+# unmanaged mode (manage=False): under the vcpkg root
+ls $VCPKG_ROOT/installed/<triplet>/lib/lib*.a
+```
+
+Each `lib<name>.a` is referenced as `vcpkg#<port>:<name>`. Two more sources:
+
+- `…/installed/<triplet>/lib/pkgconfig/<pkg>.pc` — the `Libs:` line lists the
+  `-l<name>` entries the port exports.
+- `…/installed/<triplet>/share/<port>/usage` — vcpkg's human-readable hint,
+  which usually names the libraries / CMake targets a port provides.
+
+The full list of files a port installed (including every `lib/*.a`) is in
+`…/installed/vcpkg/info/<port>_<version>_<triplet>.list`. A header-only port
+installs no `lib*.a` — reference it as `vcpkg#<port>:hdrs`.
+
+## Version management and reproducibility
+
+vcpkg's version model is per-workspace (one version and one feature set per
+package), which `vcpkg_config` maps onto directly:
+
+| `vcpkg_config` field | vcpkg manifest field |
+|---|---|
+| `baseline` | `builtin-baseline` |
+| `packages[pkg]` version | `overrides[].version` |
+| `packages[pkg]['features']` | `dependencies[].features` |
+| `registries` | `registries[]` (private registries) |
+
+For reproducible builds, pin `baseline` to a ports-tree commit (a date or git
+SHA); add every declared package to a version for the strongest guarantee.
+Blade installs the whole whitelist together, so the set stays consistent.
+
+## Triplets
+
+The triplet is derived automatically from Blade's toolchain
+(`x64-linux`, `arm64-osx`, `x64-windows-static`, …). In managed mode Blade uses
+a `blade-<triplet>` overlay that chainloads your compiler. Override the base
+triplet with `vcpkg_config(triplet='...')` when you need a specific one.
+
+## Wrapping for large repositories
+
+If your repository already routes third-party code through a `//third_party/`
+layer, hide the `vcpkg#` references behind ordinary `cc_library` wrappers so
+business code never sees them:
+
+```python
+# //third_party/openssl/BUILD
+cc_library(name='ssl',    deps=['vcpkg#openssl:ssl'],    visibility='PUBLIC')
+cc_library(name='crypto', deps=['vcpkg#openssl:crypto'], visibility='PUBLIC')
+
+# //services/payment/BUILD
+cc_library(name='payment', srcs=['payment.cc'], deps=['//third_party/openssl:ssl'])
+```
+
+## Configuration reference
+
+All settings live in `vcpkg_config(...)` in `BLADE_ROOT`. See the
+[`vcpkg_config`](config.md#vcpkg_config) section of the configuration manual for
+the full list of fields (`manage`, `baseline`, `packages`, `registries`, `root`,
+`triplet`, `install_dir`, `binary_cache`, `direct_use_allowed`).
+
+## Troubleshooting
+
+- **`vcpkg port "X" is not in the vcpkg_config.packages whitelist`** — add the
+  port to `vcpkg_config(packages=...)`.
+- **`the vcpkg tool was not found`** (managed mode) — set `vcpkg_config(root=...)`,
+  `$VCPKG_ROOT`, or put `vcpkg` on `PATH`.
+- **`static library not found at ...`** — the archive for that library is not in
+  the install tree. Check the library basename (it may differ from the port
+  name), and in unmanaged mode make sure you ran `vcpkg install` for the same
+  triplet.
+- **`a port must name a library`** — a reference is missing its `:lib`; use
+  `vcpkg#<port>:<lib>` (or `vcpkg#<port>:hdrs`).

--- a/doc/zh_CN/README.md
+++ b/doc/zh_CN/README.md
@@ -15,6 +15,8 @@ Blade 用户手册
 
 [编写 BUILD 文件](build_file.md)
 
+[使用 vcpkg 包](vcpkg.md)
+
 [命令行参考](command_line.md)
 
 [测试支持](test.md)

--- a/doc/zh_CN/config.md
+++ b/doc/zh_CN/config.md
@@ -865,3 +865,61 @@ cc_toolchain_config(
 ```
 
 这会跳过 Visual Studio 自动检测，直接使用 clang-cl 并采用 MSVC 风格的编译选项。
+
+### vcpkg_config
+
+用于把 [vcpkg](https://github.com/microsoft/vcpkg) 包作为 `vcpkg#<port>:<lib>`
+依赖使用的配置。完整说明见[使用 vcpkg 包](vcpkg.md)。这是一个工作区级别的单一
+节：vcpkg 每个包每个工作区只允许一个版本、一组 features。
+
+#### `manage`: bool = True
+
+**作用：** 为 `True`（默认）时，Blade 自己把 `vcpkg install` 安装到构建目录下的
+隔离目录，并使用 chainload 编译器的 overlay triplet。为 `False` 时，Blade 只解析
+你自己安装在 `<root>/installed/<triplet>` 下的产物。
+
+#### `packages`: dict = {}
+
+**作用：** 允许的 port 白名单——`vcpkg#<port>:<lib>` 可解析到什么的唯一事实来源。
+引用未列出的 port 是硬错误。每个值是版本字符串，或带 `version` 和/或 `features`
+的字典：
+
+```python
+vcpkg_config(
+    packages = {
+        'fmt': '10.2.1',
+        'curl': {'version': '8.5.0', 'features': ['ssl', 'http2']},
+    },
+)
+```
+
+#### `baseline`: str = ""
+
+**作用：** 把 ports 树固定到某个日期或 git SHA（vcpkg.json `builtin-baseline`）。
+留空则不可复现；固定它以获得一致的版本。
+
+#### `registries`: list = []
+
+**作用：** 可选的私有 vcpkg registry（vcpkg-configuration.json `registries`）。
+
+#### `root`: str = ""
+
+**作用：** vcpkg 安装位置（工具 + ports 树）。留空表示 `$VCPKG_ROOT`。托管模式下
+用于定位 `vcpkg` 工具；非托管模式下同时是被读取的安装树根目录。
+
+#### `triplet`: str = "auto"
+
+**作用：** vcpkg triplet。`auto` 根据解析出的 `cc_toolchain` 推导（如
+`x64-linux`、`arm64-osx`、`x64-windows-static`）；指定具体 triplet 可覆盖。
+
+#### `install_dir`: str = ".cache/vcpkg"
+
+**作用：** 托管模式下按工作区的安装根目录，相对于构建目录。`blade clean` 会清除。
+
+#### `binary_cache`: str = "auto"
+
+**作用：** vcpkg 二进制缓存后端，用于跨工作区复用已编译的包。
+
+#### `direct_use_allowed`: list = []
+
+**作用：** 治理项——允许裸写 `vcpkg#...` 引用的子树。留空表示任意位置。

--- a/doc/zh_CN/vcpkg.md
+++ b/doc/zh_CN/vcpkg.md
@@ -1,0 +1,232 @@
+# 使用 vcpkg 包
+
+Blade 可以把 [vcpkg](https://github.com/microsoft/vcpkg)（微软的跨平台 C/C++
+包管理器，约 2500 个 port）中的库作为一等依赖直接使用，与源码目标、系统库并列。
+在目标的 `deps` 中用 `vcpkg#<port>:<lib>` 引用，在 `BLADE_ROOT` 中一次性声明允许
+的包，其余的安装与链接交给 Blade。
+
+这样可以在 Linux、macOS、Windows 上统一管理第三方依赖，省去大量逐包编写
+`cmake_build` 的样板代码。
+
+## 快速上手
+
+1. **准备 vcpkg。** 克隆并 bootstrap，然后设置 `VCPKG_ROOT` 或把 `vcpkg`
+   可执行文件放进 `PATH`：
+
+   ```bash
+   git clone https://github.com/microsoft/vcpkg.git ~/vcpkg
+   ~/vcpkg/bootstrap-vcpkg.sh        # Windows 上是 bootstrap-vcpkg.bat
+   export VCPKG_ROOT=~/vcpkg
+   ```
+
+2. **在 `BLADE_ROOT` 中声明允许的包**：
+
+   ```python
+   vcpkg_config(
+       baseline = '2024-12-15',          # 固定 ports 树（推荐）
+       packages = {
+           'fmt': '10.2.1',
+           'openssl': '3.2.1',
+       },
+   )
+   ```
+
+3. **用 `vcpkg#<port>:<lib>` 声明依赖**：
+
+   ```python
+   cc_binary(
+       name = 'app',
+       srcs = ['app.cc'],
+       deps = [
+           'vcpkg#fmt:fmt',
+           'vcpkg#openssl:ssl',
+       ],
+   )
+   ```
+
+4. **构建。** 默认情况下 Blade 会安装所声明的包并完成链接：
+
+   ```bash
+   blade build //:app
+   ```
+
+## 引用语法：`vcpkg#<port>:<lib>`
+
+vcpkg 依赖是 Blade `#name` 系统库家族的扩展。`#` 本就表示“不在本工作区从源码
+构建的库”（`#pthread`、`#dl`）；在 `#` 前加一个 scheme 表示这个库来自哪里——这里
+是 `vcpkg`。`#` 之后是包管理器自身的坐标。
+
+| 引用形式 | 含义 |
+|---|---|
+| `vcpkg#<port>:<lib>` | 某个具体静态库——`lib<lib>.a`（`lib` 前缀隐含）。 |
+| `vcpkg#<port>:hdrs` | 仅头文件的 port——只暴露 include 目录，不链接归档。 |
+| `vcpkg#<port>` | **报错**——port 之后必须指明库名。 |
+
+引用始终是完全显式的：没有“一个 port 的全部库”的简写，因此多库 port 不会被
+意外过度链接。
+
+库的 basename 可能与 port 名不同——vcpkg 的 `boost-filesystem` port 产出
+`libboost_filesystem.a`，因此引用为 `vcpkg#boost-filesystem:boost_filesystem`。
+
+## 包白名单
+
+`vcpkg_config(packages=...)` 是“哪些 port 可被引用”的唯一事实来源。引用未列出的
+port 是**硬错误**——这样所有外部依赖都集中声明、统一管理版本。每个值是版本字符串，
+或带 `version` 和/或 `features` 的字典：
+
+```python
+vcpkg_config(
+    packages = {
+        'fmt': '10.2.1',                                   # 简写
+        'curl': {'version': '8.5.0', 'features': ['ssl', 'http2']},
+    },
+)
+```
+
+## 托管与非托管安装
+
+`vcpkg_config(manage=...)` 决定由谁来执行 `vcpkg install`。
+
+### 托管（`manage=True`，默认）
+
+由 Blade 替你驱动 vcpkg。在加载 BUILD 文件之前，Blade 会根据白名单生成 manifest，
+并用一个 *overlay triplet*（`blade-<triplet>`）把 `vcpkg install` 安装到构建目录下
+的隔离目录（`<build>/.cache/vcpkg/`）中；该 overlay 会 chainload Blade 解析出的
+编译器，使产物与项目其余部分 ABI 兼容。结果可复现、无需手动步骤——直接
+`blade build` 即可。当相关输入没有变化时会跳过安装。
+
+注意 `vcpkg` **工具**仍通过 `vcpkg_config.root`、`$VCPKG_ROOT` 或 `PATH` 定位；
+只有安装产物落在构建目录下。
+
+### 非托管（`manage=False`）
+
+由你自己执行 `vcpkg install`，Blade 只从既有安装树
+`<root>/installed/<triplet>/` 解析路径，其中 `<root>` 为 `vcpkg_config.root` 或
+`$VCPKG_ROOT`：
+
+```bash
+vcpkg install fmt openssl          # 自己安装
+```
+```python
+vcpkg_config(manage = False, packages = {'fmt': '10.2.1', 'openssl': '3.2.1'})
+```
+
+## 多库 port
+
+`openssl`、`protobuf`、`icu` 等 port 会产出多个归档。每个都是独立目标，按需声明：
+
+```python
+deps = [
+    'vcpkg#openssl:ssl',         # libssl.a
+    'vcpkg#openssl:crypto',      # libcrypto.a
+]
+```
+
+裸写 `vcpkg#openssl` 会被拒绝，因此不会拉入用不到的库。
+
+## 仅头文件 port
+
+仅头文件的 port 用 `:hdrs` 哨兵——Blade 暴露 include 目录，不链接任何归档：
+
+```python
+deps = ['vcpkg#nlohmann-json:hdrs']
+```
+
+## 查看有哪些 port 及 port 提供哪些库
+
+### 某个 baseline 下有哪些 port、版本是什么
+
+可用的 port 及其默认版本由 `baseline`（对应 ports 树的某次提交）决定。查看方式：
+
+```bash
+vcpkg search            # ports 树中的所有 port 及其版本
+vcpkg search fmt        # 名称/描述匹配 "fmt" 的 port
+```
+
+`vcpkg search` 反映的是 ports 树当前检出的状态。要查看某个具体 `baseline`，先把
+vcpkg 仓库检出到该提交（`git -C $VCPKG_ROOT checkout <baseline>`），或直接读版本
+数据库：
+
+- `$VCPKG_ROOT/versions/baseline.json`——每个 port 在 baseline 下的版本。
+- `$VCPKG_ROOT/versions/<x->/<port>.json`——某个 port 发布过的所有版本。
+- `$VCPKG_ROOT/ports/<port>/vcpkg.json`——该 port 的版本、可用 `features` 及其
+  自身依赖。
+
+### 某个 port 提供哪些库
+
+`vcpkg#<port>:<lib>` 引用的是归档 `lib<lib>.a`，其 basename 可能与 port 名不同
+（`boost-filesystem` → `libboost_filesystem.a`；`openssl` → `libssl.a` +
+`libcrypto.a`）。从安装树里读取确切的库名：
+
+```bash
+# 托管模式（manage=True）：在构建目录下，使用 blade- overlay triplet
+ls build64_release/.cache/vcpkg/installed/blade-<triplet>/lib/lib*.a
+
+# 非托管模式（manage=False）：在 vcpkg 根目录下
+ls $VCPKG_ROOT/installed/<triplet>/lib/lib*.a
+```
+
+每个 `lib<name>.a` 都以 `vcpkg#<port>:<name>` 引用。另有两个来源：
+
+- `…/installed/<triplet>/lib/pkgconfig/<pkg>.pc`——`Libs:` 行列出该 port 导出的
+  `-l<name>`。
+- `…/installed/<triplet>/share/<port>/usage`——vcpkg 给出的可读用法提示，通常会
+  列出该 port 提供的库 / CMake target。
+
+某个 port 安装的完整文件清单（含每个 `lib/*.a`）在
+`…/installed/vcpkg/info/<port>_<version>_<triplet>.list`。仅头文件的 port 不会
+安装任何 `lib*.a`——用 `vcpkg#<port>:hdrs` 引用。
+
+## 版本管理与可复现性
+
+vcpkg 的版本模型是按工作区的（每个包一个版本、一组 features），`vcpkg_config`
+直接映射到它：
+
+| `vcpkg_config` 字段 | vcpkg manifest 字段 |
+|---|---|
+| `baseline` | `builtin-baseline` |
+| `packages[pkg]` 版本 | `overrides[].version` |
+| `packages[pkg]['features']` | `dependencies[].features` |
+| `registries` | `registries[]`（私有 registry） |
+
+为了可复现，把 `baseline` 固定到某个 ports 树提交（日期或 git SHA）；把每个声明的
+包都固定到版本可获得最强保证。Blade 会把整个白名单一起安装，保持集合一致。
+
+## Triplet
+
+triplet 默认根据 Blade 的工具链自动推导（`x64-linux`、`arm64-osx`、
+`x64-windows-static` 等）。托管模式下 Blade 使用 chainload 编译器的
+`blade-<triplet>` overlay。需要指定时用 `vcpkg_config(triplet='...')` 覆盖。
+
+## 大型仓库的封装
+
+如果你的仓库已经通过 `//third_party/` 层统一管理第三方代码，可以把 `vcpkg#`
+引用藏在普通 `cc_library` 封装之后，业务代码不直接接触：
+
+```python
+# //third_party/openssl/BUILD
+cc_library(name='ssl',    deps=['vcpkg#openssl:ssl'],    visibility='PUBLIC')
+cc_library(name='crypto', deps=['vcpkg#openssl:crypto'], visibility='PUBLIC')
+
+# //services/payment/BUILD
+cc_library(name='payment', srcs=['payment.cc'], deps=['//third_party/openssl:ssl'])
+```
+
+## 配置参考
+
+所有设置都在 `BLADE_ROOT` 的 `vcpkg_config(...)` 中。完整字段（`manage`、
+`baseline`、`packages`、`registries`、`root`、`triplet`、`install_dir`、
+`binary_cache`、`direct_use_allowed`）见配置手册的
+[`vcpkg_config`](config.md#vcpkg_config) 一节。
+
+## 排错
+
+- **`vcpkg port "X" is not in the vcpkg_config.packages whitelist`**——把该 port
+  加入 `vcpkg_config(packages=...)`。
+- **`the vcpkg tool was not found`**（托管模式）——设置
+  `vcpkg_config(root=...)`、`$VCPKG_ROOT`，或把 `vcpkg` 放进 `PATH`。
+- **`static library not found at ...`**——安装树里没有该库的归档。检查库
+  basename（可能与 port 名不同），非托管模式下确认对同一 triplet 跑过
+  `vcpkg install`。
+- **`a port must name a library`**——引用缺少 `:lib`；用 `vcpkg#<port>:<lib>`
+  （或 `vcpkg#<port>:hdrs`）。


### PR DESCRIPTION
User documentation for native vcpkg support (Phases 1-2), in English + 中文 per repo convention.

- `doc/{en,zh_CN}/vcpkg.md` — quick start, `vcpkg#port:lib` syntax, the package whitelist, managed vs. unmanaged installs, multi-library & header-only ports, **discovering which ports/versions a baseline offers and which libraries a port produces**, version/baseline reproducibility, triplets, the monorepo wrapper pattern, and troubleshooting.
- `config.md` (en + zh) — a `vcpkg_config` reference documenting all nine fields.
- `README.md` (en + zh) — nav links.

Docs-only; content matches the shipped behavior (validated end-to-end with `blade test` on fmt / openssl / nlohmann-json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)