### PR TITLE
vcpkg: per-port linkage (dynamic) + link_all_symbols (#1236)

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1755,12 +1755,18 @@ class VcpkgLibrary(PrebuiltCcLibrary):
     path PrebuiltCcLibrary computes.
     """
 
-    def __init__(self, port, lib, key, lib_dir, include_dir, header_only):
+    def __init__(self, port, lib, key, lib_dir, include_dir, header_only,
+                 dynamic=False, link_all_symbols=False):
         # Stash the vcpkg-resolved locations before super().__init__, which
         # calls our _setup() at the end of construction.
         self._vcpkg_port = port
         self._vcpkg_lib_dir = lib_dir
         self._vcpkg_header_only = header_only
+        # A dynamic port (vcpkg_config linkage='dynamic') installs a shared lib
+        # instead of a `.a` -- used for singleton libs (gflags/glog/protobuf/
+        # gtest) so there is a single instance across the build, not one copy
+        # per dylib (which would double-register flags / descriptors / tests).
+        self._vcpkg_dynamic = dynamic
         super().__init__(
                 name=lib,
                 deps=[],
@@ -1769,7 +1775,9 @@ class VcpkgLibrary(PrebuiltCcLibrary):
                 tags=['lang:cc', 'type:library', 'type:vcpkg'],
                 export_incs=[],
                 libpath_pattern=None,
-                link_all_symbols=False,
+                # whole-archive the static lib when requested, so all of its
+                # static initializers (registration) run even if unreferenced.
+                link_all_symbols=link_all_symbols,
                 binary_link_only=False,
                 deprecated=False,
                 kwargs={})
@@ -1804,6 +1812,12 @@ class VcpkgLibrary(PrebuiltCcLibrary):
         tc = self.blade.get_build_toolchain()
         if self._vcpkg_header_only:
             return
+        if self._vcpkg_dynamic:
+            self._setup_dynamic(tc)
+        else:
+            self._setup_static(tc)
+
+    def _setup_static(self, tc):
         archive = os.path.join(
             self._vcpkg_lib_dir,
             f'{tc.lib_prefix}{self.name}{tc.static_lib_suffix}')
@@ -1815,19 +1829,51 @@ class VcpkgLibrary(PrebuiltCcLibrary):
             return
         self.attr['static_source'] = archive
         self._add_target_file(tc.STATIC_LIB_LABEL, archive)
-        # No separate shared lib is resolved in this phase; the static archive
-        # serves both link modes (consumers that dynamic_link still get it).
+        # No separate shared lib is resolved here; the static archive serves
+        # both link modes (consumers that dynamic_link still get it).
         self._add_target_file(tc.DYNAMIC_LIB_LABEL, archive)
+
+    def _setup_dynamic(self, tc):
+        shared = os.path.join(
+            self._vcpkg_lib_dir,
+            f'{tc.lib_prefix}{self.name}{tc.dynamic_lib_suffix}')
+        if not os.path.exists(shared):
+            self.error(
+                'vcpkg#%s:%s: shared library not found at %s. The port is marked '
+                'linkage="dynamic" in vcpkg_config but produced no shared lib '
+                '(it may not support dynamic linkage).' % (
+                    self._vcpkg_port, self.name, shared))
+            return
+        # Reuse PrebuiltCcLibrary's shared-lib machinery: copy the vcpkg .dylib
+        # into this target's dir and resolve its soname so consumers link a
+        # single instance with correct rpath/soname.
+        dynamic_target = self._target_file_path(os.path.basename(shared))
+        self.attr['dynamic_source'] = shared
+        self.attr['dynamic_target'] = dynamic_target
+        self._add_target_file(tc.DYNAMIC_LIB_LABEL, dynamic_target)
+        # Dynamic-only: the shared lib serves static linking too.
+        self._add_target_file(tc.STATIC_LIB_LABEL, dynamic_target)
+        soname = self._soname_of(shared)
+        if soname:
+            self.data['soname_and_full_path'] = (soname, dynamic_target)
 
     def generate(self):  # override
         # The static archive + include dir are pure metadata resolved in
-        # _setup(); there is nothing to build. Emit archive-syms (for the
-        # cc_check_undefined static check) only when the archive lives under the
-        # build dir -- i.e. blade-managed installs. For an unmanaged tree the
-        # `.syms` would land in the user's shared $VCPKG_ROOT, so skip it there.
+        # _setup(). For a static lib, emit archive-syms (for cc_check_undefined)
+        # when the archive lives under the build dir (managed installs); an
+        # unmanaged tree's `.syms` would pollute the user's shared $VCPKG_ROOT.
         static = self.attr.get('static_source')
         if static and static.startswith(os.path.abspath(self.build_dir) + os.sep):
             self._emit_archive_syms(static)
+        # For a dynamic port, copy the vcpkg shared lib into the build tree and
+        # expose its exported symbols to cc_check_undefined (nm reads a .dylib
+        # the same as a .a).
+        dynamic_source = self.attr.get('dynamic_source')
+        dynamic_target = self.attr.get('dynamic_target')
+        if dynamic_source and dynamic_target:
+            self.generate_build('copy', dynamic_target, inputs=dynamic_source)
+            if dynamic_source.startswith(os.path.abspath(self.build_dir) + os.sep):
+                self._emit_archive_syms(dynamic_source)
 
 
 def prebuilt_cc_library(

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -838,15 +838,26 @@ def _check_vcpkg_packages(packages):
         if isinstance(spec, str):
             continue
         if isinstance(spec, dict):
-            unknown = set(spec) - {'version', 'features'}
+            unknown = set(spec) - {'version', 'features', 'linkage', 'link_all_symbols'}
             if unknown:
                 _blade_config.error(
-                    'vcpkg_config.packages["%s"]: unknown key(s) %s; allowed: version, features'
+                    'vcpkg_config.packages["%s"]: unknown key(s) %s; allowed: '
+                    'version, features, linkage, link_all_symbols'
                     % (port, ', '.join(sorted(unknown))))
             features = spec.get('features')
             if features is not None and not isinstance(features, list):
                 _blade_config.error(
                     'vcpkg_config.packages["%s"].features must be a list' % port)
+            linkage = spec.get('linkage')
+            if linkage is not None and linkage not in ('static', 'dynamic'):
+                _blade_config.error(
+                    'vcpkg_config.packages["%s"].linkage must be "static" or '
+                    '"dynamic"' % port)
+            las = spec.get('link_all_symbols')
+            if las is not None and not isinstance(las, bool):
+                _blade_config.error(
+                    'vcpkg_config.packages["%s"].link_all_symbols must be a bool'
+                    % port)
             continue
         _blade_config.error(
             'vcpkg_config.packages["%s"] must be a version string or a dict with '

--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -241,13 +241,33 @@ _VCPKG_SYSTEM_NAME = {'linux': 'Linux', 'darwin': 'Darwin'}
 _VCPKG_OSX_ARCH = {'x64': 'x86_64', 'arm64': 'arm64', 'x86': 'i386'}
 
 
+def port_options(packages, port):
+    """Per-port (linkage, link_all_symbols) from the whitelist spec.
+
+    A bare version string -> defaults ('static', False). A dict spec may carry
+    `linkage` ('static'|'dynamic') and `link_all_symbols` (bool).
+    """
+    spec = packages.get(port)
+    if isinstance(spec, dict):
+        return spec.get('linkage') or 'static', bool(spec.get('link_all_symbols'))
+    return 'static', False
+
+
+def dynamic_ports(packages):
+    """Ports whose spec requests linkage='dynamic' (sorted, deterministic)."""
+    return sorted(p for p, s in packages.items()
+                  if isinstance(s, dict) and s.get('linkage') == 'dynamic')
+
+
 def overlay_triplet_cmake(target_os, target_arch, library_linkage='static',
-                          chainload_rel='../blade-chainload.cmake'):
+                          dynamic_ports=(), chainload_rel='../blade-chainload.cmake'):
     """The overlay triplet `.cmake` that chainloads blade's compiler.
 
     Mirrors vcpkg's stock triplet for the OS (so ports detect the target
-    correctly) and adds the chainload toolchain. Returns None if os/arch is
-    unsupported. `library_linkage` is 'static' (default) or 'dynamic'.
+    correctly) and adds the chainload toolchain. `library_linkage` is the
+    default ('static'); ports in `dynamic_ports` are overridden to dynamic
+    (vcpkg re-evaluates the triplet per port, so an `if(PORT ...)` guard gives
+    per-port linkage). Returns None if os/arch is unsupported.
     """
     arch = _VCPKG_ARCH.get(target_arch)
     if arch is None or target_os not in _VCPKG_OS:
@@ -257,6 +277,10 @@ def overlay_triplet_cmake(target_os, target_arch, library_linkage='static',
         'set(VCPKG_CRT_LINKAGE dynamic)',
         'set(VCPKG_LIBRARY_LINKAGE %s)' % library_linkage,
     ]
+    for port in dynamic_ports:
+        lines.append('if(PORT STREQUAL "%s")' % port)
+        lines.append('    set(VCPKG_LIBRARY_LINKAGE dynamic)')
+        lines.append('endif()')
     system = _VCPKG_SYSTEM_NAME.get(target_os)
     if system:
         lines.append('set(VCPKG_CMAKE_SYSTEM_NAME %s)' % system)
@@ -359,19 +383,23 @@ def _vcpkg_dep_handler(referrer, coordinate):
     if not vanilla or vanilla == 'auto':
         vanilla = triplet_for_toolchain(toolchain)
     root, triplet = install_location(cfg, vanilla, referrer.blade.get_build_dir())
+    packages = cfg.get('packages', {})
     try:
-        info = resolve_reference(coordinate, cfg.get('packages', {}), root, triplet)
+        info = resolve_reference(coordinate, packages, root, triplet)
     except VcpkgError as e:
         referrer.error(str(e))
         return None
     key = info['key']
     if key in referrer.target_database:
         return key
+    linkage, link_all_symbols = port_options(packages, info['port'])
     # Lazy import: cc_targets is loaded before this module, but keeping the
     # import local avoids a hard module-level cycle (cc_targets -> ... -> here).
     from blade.cc_targets import VcpkgLibrary
     target = VcpkgLibrary(info['port'], info['lib'], key,
-                          info['lib_dir'], info['include_dir'], info['header_only'])
+                          info['lib_dir'], info['include_dir'], info['header_only'],
+                          dynamic=(linkage == 'dynamic'),
+                          link_all_symbols=link_all_symbols)
     referrer.blade.register_target(target)
     return key
 
@@ -409,8 +437,9 @@ def setup(builder):
     vanilla = cfg.get('triplet')
     if not vanilla or vanilla == 'auto':
         vanilla = triplet_for_toolchain(toolchain)
-    triplet_cmake = (overlay_triplet_cmake(toolchain.target_os, toolchain.target_arch)
-                     if vanilla else None)
+    triplet_cmake = (overlay_triplet_cmake(
+        toolchain.target_os, toolchain.target_arch,
+        dynamic_ports=dynamic_ports(packages)) if vanilla else None)
     if not vanilla or triplet_cmake is None:
         console.error('vcpkg: cannot derive a triplet for os=%s arch=%s; set '
                       'vcpkg_config(triplet=...)'

--- a/src/tests/unit/vcpkg_manifest_test.py
+++ b/src/tests/unit/vcpkg_manifest_test.py
@@ -102,6 +102,38 @@ class OverlayTripletTest(unittest.TestCase):
         self.assertIsNone(vcpkg.overlay_triplet_cmake('linux', 'sparc'))
 
 
+class PortOptionsTest(unittest.TestCase):
+
+    def test_bare_version_defaults(self):
+        self.assertEqual(vcpkg.port_options({'fmt': '7.1.3'}, 'fmt'), ('static', False))
+
+    def test_dynamic_linkage(self):
+        self.assertEqual(
+            vcpkg.port_options({'gflags': {'linkage': 'dynamic'}}, 'gflags'),
+            ('dynamic', False))
+
+    def test_link_all_symbols(self):
+        self.assertEqual(
+            vcpkg.port_options({'g': {'link_all_symbols': True}}, 'g'),
+            ('static', True))
+
+    def test_dynamic_ports_sorted(self):
+        pkgs = {'fmt': '7', 'gflags': {'linkage': 'dynamic'},
+                'glog': {'linkage': 'dynamic'}, 'z': {'linkage': 'static'}}
+        self.assertEqual(vcpkg.dynamic_ports(pkgs), ['gflags', 'glog'])
+
+    def test_overlay_per_port_dynamic_override(self):
+        t = vcpkg.overlay_triplet_cmake('darwin', 'aarch64', dynamic_ports=['gflags'])
+        self.assertIn('set(VCPKG_LIBRARY_LINKAGE static)', t)
+        self.assertIn('if(PORT STREQUAL "gflags")', t)
+        self.assertIn('    set(VCPKG_LIBRARY_LINKAGE dynamic)', t)
+        self.assertIn('endif()', t)
+
+    def test_overlay_no_dynamic_ports_has_no_guard(self):
+        self.assertNotIn('if(PORT STREQUAL',
+                         vcpkg.overlay_triplet_cmake('linux', 'x86_64'))
+
+
 class ChainloadTest(unittest.TestCase):
 
     def test_compiler_and_flags(self):


### PR DESCRIPTION
Per-port `linkage: static|dynamic` and `link_all_symbols` in the vcpkg_config package spec, for singleton libs (gflags/glog/protobuf/gtest) that need a single shared instance (or whole-archive) to avoid duplicate flag/descriptor/test registration. The overlay triplet sets per-port `VCPKG_LIBRARY_LINKAGE` via `if(PORT ...)`; VcpkgLibrary resolves+copies the `.dylib` and emits syms for cc_check_undefined. Validated on flare's gflags. Unit suite: 566 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)