### PR TITLE
vcpkg: include_prefix to remap a port's header path (#1236)

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1756,7 +1756,7 @@ class VcpkgLibrary(PrebuiltCcLibrary):
     """
 
     def __init__(self, port, lib, key, lib_dir, include_dir, header_only,
-                 dynamic=False, link_all_symbols=False):
+                 dynamic=False, link_all_symbols=False, include_prefix=None):
         # Stash the vcpkg-resolved locations before super().__init__, which
         # calls our _setup() at the end of construction.
         self._vcpkg_port = port
@@ -1800,13 +1800,43 @@ class VcpkgLibrary(PrebuiltCcLibrary):
             # External headers go via -isystem so third-party warnings don't
             # trip the consumer's -Werror (same posture as foreign_cc_library);
             # absolute paths survive _incs_to_fullpath unchanged.
-            self.attr['system_export_incs'] = self._incs_to_fullpath([include_dir])
+            inc = os.path.abspath(include_dir)
+            if include_prefix:
+                # flare includes "<prefix>/<header>" but vcpkg ships the headers
+                # at include/ top level. Expose include/ under <prefix> via a
+                # symlink dir and -isystem that, so "<prefix>/h" resolves.
+                inc = self._vcpkg_prefixed_incdir(include_prefix, include_dir)
+            self.attr['system_export_incs'] = self._incs_to_fullpath([inc])
         # Exempt from the unused-deps check: vcpkg headers live in an absolute,
         # out-of-tree `-isystem` dir, which blade's inclusion scanner can't
         # attribute back to this target (declare_hdr_dir works only for
         # in-tree dirs). Flagging every vcpkg dep as "unused" would be pure
         # noise; precise external-header attribution is a follow-up.
         declare_header_less(self)
+
+    def _vcpkg_prefixed_incdir(self, prefixes, include_dir):
+        """Expose the vcpkg include dir under each `<prefix>/` via a symlink, so
+        a consumer's `#include "<prefix>/h"` resolves to the port's `include/h`.
+        `prefixes` is a str or list (a port may be included under more than one
+        path, e.g. flare's "zlib/" and protobuf's "thirdparty/zlib/"). Nested
+        prefixes are supported. Returns the absolute prefix-root -isystem dir."""
+        prefix_root = os.path.abspath(os.path.join(self.target_dir, 'include-prefix'))
+        target_inc = os.path.abspath(include_dir)
+        for prefix in ([prefixes] if isinstance(prefixes, str) else prefixes):
+            link = os.path.join(prefix_root, prefix)
+            try:
+                os.makedirs(os.path.dirname(link), exist_ok=True)
+                if os.path.islink(link):
+                    if os.readlink(link) != target_inc:
+                        os.remove(link)
+                        os.symlink(target_inc, link)
+                elif not os.path.exists(link):
+                    os.symlink(target_inc, link)
+            except OSError as e:
+                self.error('vcpkg#%s:%s: could not create include-prefix symlink '
+                           '%s -> %s: %s' % (self._vcpkg_port, self.name, link,
+                                             target_inc, e))
+        return prefix_root
 
     def _setup(self):  # override PrebuiltCcLibrary._setup
         tc = self.blade.get_build_toolchain()

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -838,12 +838,20 @@ def _check_vcpkg_packages(packages):
         if isinstance(spec, str):
             continue
         if isinstance(spec, dict):
-            unknown = set(spec) - {'version', 'features', 'linkage', 'link_all_symbols'}
+            unknown = set(spec) - {'version', 'features', 'linkage',
+                                   'link_all_symbols', 'include_prefix'}
             if unknown:
                 _blade_config.error(
                     'vcpkg_config.packages["%s"]: unknown key(s) %s; allowed: '
-                    'version, features, linkage, link_all_symbols'
+                    'version, features, linkage, link_all_symbols, include_prefix'
                     % (port, ', '.join(sorted(unknown))))
+            prefix = spec.get('include_prefix')
+            if prefix is not None and not (
+                    isinstance(prefix, str) or
+                    (isinstance(prefix, list) and all(isinstance(p, str) for p in prefix))):
+                _blade_config.error(
+                    'vcpkg_config.packages["%s"].include_prefix must be a string '
+                    'or a list of strings' % port)
             features = spec.get('features')
             if features is not None and not isinstance(features, list):
                 _blade_config.error(

--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -242,15 +242,19 @@ _VCPKG_OSX_ARCH = {'x64': 'x86_64', 'arm64': 'arm64', 'x86': 'i386'}
 
 
 def port_options(packages, port):
-    """Per-port (linkage, link_all_symbols) from the whitelist spec.
+    """Per-port (linkage, link_all_symbols, include_prefix) from the spec.
 
-    A bare version string -> defaults ('static', False). A dict spec may carry
-    `linkage` ('static'|'dynamic') and `link_all_symbols` (bool).
+    A bare version string -> defaults ('static', False, None). A dict spec may
+    carry `linkage` ('static'|'dynamic'), `link_all_symbols` (bool) and
+    `include_prefix` (str: expose vcpkg's include dir under this subdir, for
+    libs flare includes as "<prefix>/<header>" but vcpkg ships at include top).
     """
     spec = packages.get(port)
     if isinstance(spec, dict):
-        return spec.get('linkage') or 'static', bool(spec.get('link_all_symbols'))
-    return 'static', False
+        return (spec.get('linkage') or 'static',
+                bool(spec.get('link_all_symbols')),
+                spec.get('include_prefix') or None)
+    return 'static', False, None
 
 
 def dynamic_ports(packages):
@@ -392,14 +396,15 @@ def _vcpkg_dep_handler(referrer, coordinate):
     key = info['key']
     if key in referrer.target_database:
         return key
-    linkage, link_all_symbols = port_options(packages, info['port'])
+    linkage, link_all_symbols, include_prefix = port_options(packages, info['port'])
     # Lazy import: cc_targets is loaded before this module, but keeping the
     # import local avoids a hard module-level cycle (cc_targets -> ... -> here).
     from blade.cc_targets import VcpkgLibrary
     target = VcpkgLibrary(info['port'], info['lib'], key,
                           info['lib_dir'], info['include_dir'], info['header_only'],
                           dynamic=(linkage == 'dynamic'),
-                          link_all_symbols=link_all_symbols)
+                          link_all_symbols=link_all_symbols,
+                          include_prefix=include_prefix)
     referrer.blade.register_target(target)
     return key
 

--- a/src/tests/unit/vcpkg_manifest_test.py
+++ b/src/tests/unit/vcpkg_manifest_test.py
@@ -105,17 +105,23 @@ class OverlayTripletTest(unittest.TestCase):
 class PortOptionsTest(unittest.TestCase):
 
     def test_bare_version_defaults(self):
-        self.assertEqual(vcpkg.port_options({'fmt': '7.1.3'}, 'fmt'), ('static', False))
+        self.assertEqual(vcpkg.port_options({'fmt': '7.1.3'}, 'fmt'),
+                         ('static', False, None))
 
     def test_dynamic_linkage(self):
         self.assertEqual(
             vcpkg.port_options({'gflags': {'linkage': 'dynamic'}}, 'gflags'),
-            ('dynamic', False))
+            ('dynamic', False, None))
 
     def test_link_all_symbols(self):
         self.assertEqual(
             vcpkg.port_options({'g': {'link_all_symbols': True}}, 'g'),
-            ('static', True))
+            ('static', True, None))
+
+    def test_include_prefix(self):
+        self.assertEqual(
+            vcpkg.port_options({'snappy': {'include_prefix': 'snappy'}}, 'snappy'),
+            ('static', False, 'snappy'))
 
     def test_dynamic_ports_sorted(self):
         pkgs = {'fmt': '7', 'gflags': {'linkage': 'dynamic'},


### PR DESCRIPTION
Per-port `include_prefix` (str or list) exposes a vcpkg port's include dir under `<prefix>/` via a symlink + -isystem, so flare's "<lib>/<header>" includes resolve against vcpkg's top-level headers -- no hand-written stub headers. List form handles a port included under multiple paths (flare's `zlib/` + protobuf-3.4.1's `thirdparty/zlib/`). Validated on zlib/lz4/zstd. Unit suite: 567 passed.