### PR TITLE
cc: resolve prebuilt @rpath dylibs at run time on macOS (#1236)

### DIFF
--- a/src/blade/binary_runner.py
+++ b/src/blade/binary_runner.py
@@ -79,6 +79,11 @@ class BinaryRunner:
         # Prepare environments
         run_env = dict(os.environ)
         environ_add_path(run_env, 'LD_LIBRARY_PATH', runfiles_dir)
+        if sys.platform == 'darwin':
+            # dyld ignores LD_LIBRARY_PATH; it searches DYLD_LIBRARY_PATH by leaf
+            # name even for @rpath installs, so the runfiles soname symlinks
+            # resolve prebuilt dylibs (e.g. vcpkg shared libs) at run time.
+            environ_add_path(run_env, 'DYLD_LIBRARY_PATH', runfiles_dir)
         if os.name == 'nt':
             # Windows analog of LD_LIBRARY_PATH: the loader searches PATH for the
             # flattened dependency DLLs placed in runfiles (see

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1165,9 +1165,24 @@ class CcTarget(Target):
         self.data['windows_dll'] = dll
 
     def _soname_of(self, so_path):
-        """Get the `soname` of a shared library."""
+        """Get the `soname` of a shared library (its leaf lookup name).
+
+        On macOS a dylib has no ELF soname; use the leaf of its install_name
+        instead. A binary linking `@rpath/libfoo.N.dylib` resolves that leaf via
+        DYLD_LIBRARY_PATH (dyld consults it by leaf name even for @rpath
+        installs), which the run harness points at the runfiles dir -- the same
+        scheme as the ELF soname symlink.
+        """
         if os.name == 'nt':
             return None  # Windows DLLs don't have ELF-style soname
+        if sys.platform == 'darwin':
+            returncode, output, unused_stderr = run_command(['otool', '-D', so_path])
+            if returncode != 0:
+                return None
+            # `otool -D` prints "<path>:" then the install_name line(s).
+            names = [line.strip() for line in output.splitlines()
+                     if line.strip() and not line.strip().endswith(':')]
+            return os.path.basename(names[-1]) if names else None
         returncode, output, unused_stderr = run_command(['objdump', '-p', so_path])
         if returncode != 0:
             return None


### PR DESCRIPTION
macOS dynamic prebuilt libs with `@rpath` install_names (vcpkg's default) weren't found at run time. Mirror the ELF-soname scheme: `_soname_of` reads the install_name leaf via `otool -D` on darwin, and the run harness sets `DYLD_LIBRARY_PATH` (which dyld searches by leaf name even for @rpath). Validated: flare tests linking dynamic vcpkg gflags now load. Unit suite: 569 passed.