### PR TITLE
vcpkg: defer install to the build phase + build-panel progress (#1236)

### DIFF
--- a/src/blade/build_manager.py
+++ b/src/blade/build_manager.py
@@ -353,6 +353,15 @@ class Blade:
 
     def build(self):
         """Implement the "build" subcommand."""
+        # vcpkg orchestration (issue #1236): blade-managed `vcpkg install` runs
+        # here -- deferred from the load seam to the build phase, so commands
+        # that don't build (query/dump/clean) never install, and the install's
+        # progress shows in the build panel. VcpkgLibrary resolves paths
+        # optimistically during load; the artifacts are produced just before
+        # ninja links them. A no-op unless vcpkg_config(manage=True) with packages.
+        from blade import vcpkg
+        if not vcpkg.setup(self):
+            return 1
         console.info('Building...')
         console.flush()
         start_time = time.time()

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1871,16 +1871,14 @@ class VcpkgLibrary(PrebuiltCcLibrary):
         else:
             self._setup_static(tc)
 
+    # Paths are resolved optimistically -- the blade-managed `vcpkg install` is
+    # deferred to the build phase, so the artifacts are produced just before
+    # ninja links them, not at parse time. (A genuinely missing lib surfaces as
+    # ninja's "file not found" on the install path.)
     def _setup_static(self, tc):
         archive = os.path.join(
             self._vcpkg_lib_dir,
             f'{tc.lib_prefix}{self.name}{tc.static_lib_suffix}')
-        if not os.path.exists(archive):
-            self.error(
-                'vcpkg#%s:%s: static library not found at %s; run '
-                '`vcpkg install %s` for this triplet' % (
-                    self._vcpkg_port, self.name, archive, self._vcpkg_port))
-            return
         self.attr['static_source'] = archive
         self._add_target_file(tc.STATIC_LIB_LABEL, archive)
         # No separate shared lib is resolved here; the static archive serves
@@ -1891,25 +1889,29 @@ class VcpkgLibrary(PrebuiltCcLibrary):
         shared = os.path.join(
             self._vcpkg_lib_dir,
             f'{tc.lib_prefix}{self.name}{tc.dynamic_lib_suffix}')
-        if not os.path.exists(shared):
-            self.error(
-                'vcpkg#%s:%s: shared library not found at %s. The port is marked '
-                'linkage="dynamic" in vcpkg_config but produced no shared lib '
-                '(it may not support dynamic linkage).' % (
-                    self._vcpkg_port, self.name, shared))
-            return
         # Reuse PrebuiltCcLibrary's shared-lib machinery: copy the vcpkg .dylib
-        # into this target's dir and resolve its soname so consumers link a
-        # single instance with correct rpath/soname.
+        # into this target's dir so consumers link a single instance. The soname
+        # is read from the file lazily (soname_and_full_path), since the install
+        # is deferred and the file isn't present yet at parse time.
         dynamic_target = self._target_file_path(os.path.basename(shared))
         self.attr['dynamic_source'] = shared
         self.attr['dynamic_target'] = dynamic_target
         self._add_target_file(tc.DYNAMIC_LIB_LABEL, dynamic_target)
         # Dynamic-only: the shared lib serves static linking too.
         self._add_target_file(tc.STATIC_LIB_LABEL, dynamic_target)
-        soname = self._soname_of(shared)
-        if soname:
-            self.data['soname_and_full_path'] = (soname, dynamic_target)
+
+    def soname_and_full_path(self):  # override PrebuiltCcLibrary
+        # Lazy: the run harness asks for this after the build (so after the
+        # deferred install), when the .dylib exists to read its install_name.
+        if 'soname_and_full_path' not in self.data:
+            self.data['soname_and_full_path'] = None
+            src = self.attr.get('dynamic_source')
+            target = self.attr.get('dynamic_target')
+            if src and target:
+                soname = self._soname_of(src)
+                if soname:
+                    self.data['soname_and_full_path'] = (soname, target)
+        return self.data['soname_and_full_path']
 
     def generate(self):  # override
         # The static archive + include dir are pure metadata resolved in

--- a/src/blade/main.py
+++ b/src/blade/main.py
@@ -73,14 +73,6 @@ def run_subcommand(blade_path, command, options, ws, targets):
         config.dump(output_file_name)
         return _check_error_log('dump')
 
-    # vcpkg orchestration (issue #1236): blade-managed `vcpkg install` runs once
-    # here -- config is loaded and the build dir exists, but BUILD files are not
-    # parsed yet, so installed artifacts are present before any VcpkgLibrary
-    # resolves them. A no-op unless vcpkg_config(manage=True) with packages.
-    from blade import vcpkg
-    if not vcpkg.setup(builder):
-        return 1
-
     # Prepare the targets
     stages = [
         ('load', builder.load_targets),

--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -508,12 +508,49 @@ def setup(builder):
            '--overlay-triplets', triplets_dir]
     console.info('vcpkg: installing %d package(s) for %s ...'
                  % (len(packages), overlay))
-    returncode, stdout, stderr = util.run_command(cmd)
-    if returncode != 0:
-        console.error('vcpkg install failed:\n%s' % (stderr or stdout))
+    if not _run_install_with_progress(cmd):
         return False
     with open(stamp_file, 'w') as f:
         f.write(stamp)
+    return True
+
+
+def _run_install_with_progress(cmd):
+    """Run `vcpkg install`, rendering its `Installing N/M ...` stream as blade's
+    live build panel. Returns True on success; on failure prints the captured
+    output and returns False. Off a TTY the panel is a no-op (CI logs show the
+    output only on failure)."""
+    import collections
+    import subprocess
+    import time
+    from blade import console
+    progress_re = re.compile(r'Installing (\d+)/(\d+)\s+(\S+)')
+    recent = collections.deque(maxlen=4)
+    captured = []
+    total = 0
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT, text=True,
+                            errors='replace', bufsize=1)
+    start = time.time()
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        line = line.rstrip('\r\n')
+        captured.append(line)
+        m = progress_re.search(line)
+        if m:
+            current, total = int(m.group(1)), int(m.group(2))
+            recent.append(m.group(3))
+            elapsed = time.time() - start
+            eta = (total - current) * elapsed / current if current else None
+            # `current` is the package now installing -> current-1 finished.
+            console.render_build_panel(current - 1, 1, total, list(recent), eta)
+    proc.wait()
+    if total:
+        console.render_build_panel(total, 0, total, list(recent))
+    console.clear_progress_bar()
+    if proc.returncode != 0:
+        console.error('vcpkg install failed:\n%s' % '\n'.join(captured))
+        return False
     return True
 
 

--- a/src/tests/unit/vcpkg_setup_test.py
+++ b/src/tests/unit/vcpkg_setup_test.py
@@ -71,7 +71,8 @@ class SetupTest(unittest.TestCase):
              mock.patch('blade.vcpkg._find_vcpkg_tool', return_value=tool), \
              mock.patch('blade.console.info'), \
              mock.patch('blade.console.error'), \
-             mock.patch('blade.util.run_command', return_value=run_result) as rc:
+             mock.patch('blade.vcpkg._run_install_with_progress',
+                        return_value=run_result[0] == 0) as rc:
             ok = vcpkg.setup(_builder(build_dir))
         return ok, rc
 


### PR DESCRIPTION
Defers blade-managed `vcpkg install` from the load seam to `BuildManager.build()`: it now runs only for build/test/run (query/dump/clean never install) and right before ninja links the artifacts. VcpkgLibrary resolves paths optimistically (lazy dynamic-lib soname; dangling include-prefix symlinks resolve post-install). `vcpkg install`'s `Installing N/M` output streams into the multi-line build panel instead of blocking silently. Validated on flare (query no-install/no-error; build installs in-phase; compression tests pass at runtime). Unit suite: 570 passed.