### PR TITLE
vcpkg: implement binary_cache and direct_use_allowed config fields

### DIFF
--- a/doc/en/config.md
+++ b/doc/en/config.md
@@ -925,9 +925,37 @@ build directory. Cleared by `blade clean`.
 #### `binary_cache`: str = "auto"
 
 **Purpose:** The vcpkg binary-cache backend used to reuse compiled packages
-across workspaces.
+across runs and machines. `"auto"` keeps vcpkg's built-in default (a local
+cache under the user's cache directory); any other value is passed straight
+through to `vcpkg install --binarysource=<value>`, so it accepts the full
+[vcpkg binary-caching](https://learn.microsoft.com/vcpkg/users/binarycaching)
+source syntax, for example:
+
+```python
+vcpkg_config(
+    # A shared directory cache (read+write).
+    binary_cache = 'files,/path/to/cache,readwrite',
+    # ... or a NuGet feed, GitHub Actions cache, x-azblob, x-gcs, etc.
+)
+```
+
+Set it to `'clear'` to disable caching entirely. Only consulted in managed
+mode (`manage = True`).
 
 #### `direct_use_allowed`: list = []
 
-**Purpose:** Governance — subtrees where bare `vcpkg#...` references are
-allowed. Empty means anywhere.
+**Purpose:** Governance — the list of source subtrees (e.g. `'thirdparty'` or
+`'//thirdparty'`) where a target may depend on a bare `vcpkg#port:lib`
+reference directly. The default empty list imposes no restriction. When
+non-empty, a `vcpkg#...` dependency is only accepted if the **referring**
+target lives within one of the listed subtrees; anywhere else Blade reports an
+error. This lets a team funnel all third-party usage through curated wrapper
+`cc_library` targets (kept under `thirdparty/`) while business code depends on
+those wrappers rather than on vcpkg ports directly.
+
+```python
+vcpkg_config(
+    # Only BUILD files under thirdparty/ may write `deps = ['vcpkg#fmt:fmt']`.
+    direct_use_allowed = ['thirdparty'],
+)
+```

--- a/doc/zh_CN/config.md
+++ b/doc/zh_CN/config.md
@@ -918,8 +918,32 @@ vcpkg_config(
 
 #### `binary_cache`: str = "auto"
 
-**作用：** vcpkg 二进制缓存后端，用于跨工作区复用已编译的包。
+**作用：** vcpkg 二进制缓存后端，用于跨运行、跨机器复用已编译的包。`"auto"`
+保留 vcpkg 内置默认（用户缓存目录下的本地缓存）；其他任何值都会原样传给
+`vcpkg install --binarysource=<value>`，因此支持完整的
+[vcpkg 二进制缓存](https://learn.microsoft.com/vcpkg/users/binarycaching)源语法，例如：
+
+```python
+vcpkg_config(
+    # 共享目录缓存（读写）。
+    binary_cache = 'files,/path/to/cache,readwrite',
+    # ……也可以是 NuGet feed、GitHub Actions 缓存、x-azblob、x-gcs 等。
+)
+```
+
+设为 `'clear'` 可完全禁用缓存。仅在托管模式（`manage = True`）下生效。
 
 #### `direct_use_allowed`: list = []
 
-**作用：** 治理项——允许裸写 `vcpkg#...` 引用的子树。留空表示任意位置。
+**作用：** 治理项——允许直接依赖裸 `vcpkg#port:lib` 引用的源码子树列表（如
+`'thirdparty'` 或 `'//thirdparty'`）。默认空列表不施加任何限制。非空时，只有当
+**发起依赖的**目标位于列表中某个子树内，`vcpkg#...` 依赖才被接受；否则 Blade 报错。
+借此可将所有第三方用法收敛到 `thirdparty/` 下精心维护的包装 `cc_library` 目标，
+业务代码只依赖这些包装而非直接依赖 vcpkg port。
+
+```python
+vcpkg_config(
+    # 仅 thirdparty/ 下的 BUILD 可以写 `deps = ['vcpkg#fmt:fmt']`。
+    direct_use_allowed = ['thirdparty'],
+)
+```

--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -386,6 +386,16 @@ def triplet_for_toolchain(toolchain, dynamic=False):
     return triplet_for(toolchain.target_os, toolchain.target_arch, vendor, dynamic)
 
 
+def _path_under(path, prefixes):
+    """True if workspace-relative `path` is within one of `prefixes` (each may
+    be written `dir` or `//dir`)."""
+    for prefix in prefixes:
+        prefix = prefix.strip('/')
+        if path == prefix or path.startswith(prefix + '/'):
+            return True
+    return False
+
+
 def _vcpkg_dep_handler(referrer, coordinate):
     """`<scheme>#...` provider for vcpkg (registered below).
 
@@ -395,6 +405,14 @@ def _vcpkg_dep_handler(referrer, coordinate):
     """
     from blade import config
     cfg = config.get_section('vcpkg_config')
+    allowed = cfg.get('direct_use_allowed') or []
+    if allowed and not _path_under(referrer.path, allowed):
+        referrer.error(
+            'vcpkg#%s: direct vcpkg# references are restricted to %s '
+            '(vcpkg_config.direct_use_allowed); route this dependency through a '
+            'wrapper cc_library there' % (
+                coordinate, ', '.join('//%s' % a.strip('/') for a in allowed)))
+        return None
     toolchain = referrer.blade.get_build_toolchain()
     vanilla = cfg.get('triplet')
     if not vanilla or vanilla == 'auto':
@@ -506,6 +524,12 @@ def setup(builder):
            '--x-manifest-root', base,
            '--x-install-root', installed_root,
            '--overlay-triplets', triplets_dir]
+    # Binary cache: 'auto' leaves vcpkg's default local cache on; any other
+    # value is a vcpkg binarysource string (files / nuget / GitHub / x-azblob /
+    # x-gcs / ...), passed through so identical builds are reused across runs.
+    binary_cache = cfg.get('binary_cache') or 'auto'
+    if binary_cache != 'auto':
+        cmd.append('--binarysource=' + binary_cache)
     console.info('vcpkg: installing %d package(s) for %s ...'
                  % (len(packages), overlay))
     if not _run_install_with_progress(cmd):

--- a/src/tests/unit/vcpkg_resolve_test.py
+++ b/src/tests/unit/vcpkg_resolve_test.py
@@ -105,8 +105,9 @@ class TripletForToolchainTest(unittest.TestCase):
 
 
 class _Referrer:
-    def __init__(self, db=None):
+    def __init__(self, db=None, path='app/foo'):
         self.target_database = db if db is not None else {}
+        self.path = path
         self.errors = []
         self.blade = mock.Mock()
         self.blade.get_build_toolchain.return_value = mock.Mock()
@@ -160,6 +161,44 @@ class HandlerTest(unittest.TestCase):
         self.assertEqual(key, 'vcpkg#fmt:fmt')
         MockVL.assert_not_called()
         r.blade.register_target.assert_not_called()
+
+    def test_direct_use_allowed_blocks_outside_referrer(self):
+        # With an allowlist set, a referrer outside it cannot use vcpkg# directly.
+        r = _Referrer(path='app/foo')
+        with mock.patch('blade.config.get_section',
+                        return_value=self._cfg(direct_use_allowed=['thirdparty'])), \
+             mock.patch('blade.cc_targets.VcpkgLibrary') as MockVL:
+            key = vcpkg._vcpkg_dep_handler(r, 'fmt:fmt')
+        self.assertIsNone(key)
+        self.assertEqual(len(r.errors), 1)
+        self.assertIn('direct_use_allowed', r.errors[0])
+        MockVL.assert_not_called()
+
+    def test_direct_use_allowed_permits_inside_referrer(self):
+        # A referrer under an allowed subtree (here '//thirdparty/...') is fine.
+        r = _Referrer(path='thirdparty/fmt')
+        with mock.patch('blade.config.get_section',
+                        return_value=self._cfg(direct_use_allowed=['//thirdparty'])), \
+             mock.patch('blade.cc_targets.VcpkgLibrary') as MockVL:
+            key = vcpkg._vcpkg_dep_handler(r, 'fmt:fmt')
+        self.assertEqual(key, 'vcpkg#fmt:fmt')
+        MockVL.assert_called_once()
+
+    def test_direct_use_allowed_empty_permits_anywhere(self):
+        # The default empty allowlist imposes no restriction.
+        r = _Referrer(path='app/foo')
+        with mock.patch('blade.config.get_section',
+                        return_value=self._cfg(direct_use_allowed=[])), \
+             mock.patch('blade.cc_targets.VcpkgLibrary') as MockVL:
+            key = vcpkg._vcpkg_dep_handler(r, 'fmt:fmt')
+        self.assertEqual(key, 'vcpkg#fmt:fmt')
+
+    def test_path_under(self):
+        self.assertTrue(vcpkg._path_under('thirdparty/fmt', ['thirdparty']))
+        self.assertTrue(vcpkg._path_under('thirdparty', ['//thirdparty']))
+        self.assertTrue(vcpkg._path_under('a/b/c', ['x', 'a/b']))
+        self.assertFalse(vcpkg._path_under('thirdpartyx/fmt', ['thirdparty']))
+        self.assertFalse(vcpkg._path_under('app/foo', ['thirdparty']))
 
     def test_auto_triplet_derived_from_toolchain(self):
         r = _Referrer()

--- a/src/tests/unit/vcpkg_setup_test.py
+++ b/src/tests/unit/vcpkg_setup_test.py
@@ -103,6 +103,19 @@ class SetupTest(unittest.TestCase):
         self.assertIn('blade-x64-linux', cmd)
         self.assertIn('--x-install-root', cmd)
 
+    def test_binary_cache_auto_omits_binarysource(self):
+        with tempfile.TemporaryDirectory() as d:
+            _, rc = self._run(d, cfg=dict(_CFG, binary_cache='auto'))
+        cmd = rc.call_args[0][0]
+        self.assertFalse(any(c.startswith('--binarysource') for c in cmd))
+
+    def test_binary_cache_custom_passes_binarysource(self):
+        source = 'files,/tmp/vcpkg-cache,readwrite'
+        with tempfile.TemporaryDirectory() as d:
+            _, rc = self._run(d, cfg=dict(_CFG, binary_cache=source))
+        cmd = rc.call_args[0][0]
+        self.assertIn('--binarysource=' + source, cmd)
+
     def test_install_failure_returns_false(self):
         with tempfile.TemporaryDirectory() as d:
             ok, _ = self._run(d, run_result=(1, '', 'boom'))


### PR DESCRIPTION
## Why

`vcpkg_config.binary_cache` and `vcpkg_config.direct_use_allowed` were both declared in the config template **and documented**, but neither was ever read by `setup()` or the dep handler — the docs described behavior that didn't exist. This closes that gap.

## What

- **`binary_cache`** (managed mode): a non-`'auto'` value is passed straight through to `vcpkg install --binarysource=<value>`, so the full [vcpkg binary-caching](https://learn.microsoft.com/vcpkg/users/binarycaching) source syntax works (`files,/path,readwrite`, NuGet, GitHub Actions, `x-azblob`, `x-gcs`, `clear`, …). `'auto'` keeps vcpkg's built-in local cache (no flag emitted).
- **`direct_use_allowed`** (governance): when non-empty, a `vcpkg#port:lib` dependency is only accepted if the **referring** target lives under one of the listed subtrees (`'thirdparty'` / `'//thirdparty'`); otherwise Blade reports an error. Lets teams funnel all third-party usage through curated wrapper `cc_library` targets while business code depends on the wrappers. Empty (default) imposes no restriction.

## Implementation

- New pure helper `_path_under(path, prefixes)`.
- Governance check at the top of `_vcpkg_dep_handler` (short-circuits before resolution).
- `--binarysource` append in `setup()` next to the `vcpkg install` command build.

## Docs

Rewrote the `binary_cache` / `direct_use_allowed` entries in `doc/en/config.md` and `doc/zh_CN/config.md` to describe the actual semantics, with examples.

## Tests

- `vcpkg_resolve_test.py`: `_path_under` table, and direct_use_allowed blocking outside / permitting inside / empty-permits-anywhere.
- `vcpkg_setup_test.py`: `binary_cache='auto'` omits `--binarysource`; a custom value passes it through.

101 vcpkg/dep-scheme unit tests pass; pyright clean (0/0/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)