### PR TITLE
vcpkg: linkage='auto' (static + on-demand shared) + bake rpath for shared deps

### DIFF
--- a/doc/en/vcpkg.md
+++ b/doc/en/vcpkg.md
@@ -96,23 +96,38 @@ The dict form of a package accepts these keys:
 | --- | --- | --- |
 | `version` | str | Pin the port version (a vcpkg `overrides` entry). |
 | `features` | list[str] | vcpkg features to enable. |
-| `linkage` | `'static'` (default) / `'dynamic'` | Build the port shared. |
+| `linkage` | `'static'` (default) / `'dynamic'` / `'auto'` | How the port is built (see below). |
 | `link_all_symbols` | bool | Whole-archive the static lib. |
 | `include_prefix` | str / list[str] / dict | Remap the header include path. |
 | `cmake_options` | list[str] | Extra CMake configure options for the port. |
 
-### `linkage: 'dynamic'` — singleton libraries
+### `linkage` — `static` / `dynamic` / `auto`
+
+- **`'static'`** (default) — only the static archive (`.a`) is built.
+- **`'dynamic'`** — only the shared library is built; *every* consumer links
+  that single instance.
+- **`'auto'`** — the static archive is always built, **and** the shared library
+  is built *on demand* — only when a `dynamic_link` binary actually depends on
+  the port (the same rule as `cc_library`'s `generate_dynamic`). A static-link
+  tool then gets a self-contained `.a`, while a `dynamic_link` binary still
+  shares one shared library. vcpkg builds one linkage per triplet, so the shared
+  build of an `'auto'` port lands in a separate `blade-<triplet>-shared` install
+  tree alongside the main static tree.
+
+### `linkage: 'dynamic'` / `'auto'` — singleton libraries
 
 Some libraries keep a process-wide registry behind static initializers — gflags
 (the flag registry), glog, protobuf (the descriptor pool), googletest (the test
 registry). Linked **statically** into several shared libs and the executable,
 each copy gets its own registry and they collide at startup (duplicate flag /
 descriptor / test registration). Build such ports **shared** so there is a
-single instance:
+single instance. Use `'auto'` when some binaries link them statically (e.g. a
+self-contained build-time tool / protoc plugin) while others link dynamically;
+use `'dynamic'` to force shared everywhere:
 
 ```python
-'gflags': {'version': '2.2.2', 'linkage': 'dynamic'},
-'glog':   {'version': '0.7.1', 'linkage': 'dynamic'},
+'gflags': {'version': '2.2.2', 'linkage': 'auto'},
+'glog':   {'version': '0.7.1', 'linkage': 'auto'},
 ```
 
 ### `link_all_symbols: True` — force static initializers

--- a/doc/zh_CN/vcpkg.md
+++ b/doc/zh_CN/vcpkg.md
@@ -91,21 +91,34 @@ vcpkg_config(
 | --- | --- | --- |
 | `version` | str | 固定 port 版本（一条 vcpkg `overrides`）。 |
 | `features` | list[str] | 启用的 vcpkg features。 |
-| `linkage` | `'static'`（默认）/ `'dynamic'` | 把该 port 编成共享库。 |
+| `linkage` | `'static'`（默认）/ `'dynamic'` / `'auto'` | 该 port 如何构建（见下）。 |
 | `link_all_symbols` | bool | 对静态库做 whole-archive。 |
 | `include_prefix` | str / list[str] / dict | 重映射头文件包含路径。 |
 | `cmake_options` | list[str] | 该 port 的额外 CMake 配置选项。 |
 
-### `linkage: 'dynamic'`——单例库
+### `linkage`——`static` / `dynamic` / `auto`
+
+- **`'static'`**（默认）——只构建静态库（`.a`）。
+- **`'dynamic'`**——只构建共享库；*所有*消费者都链接这唯一一份实例。
+- **`'auto'`**——静态库总是构建，**且**共享库**按需**构建——仅当某个
+  `dynamic_link` 二进制真正依赖该 port 时才构建（与 `cc_library` 的
+  `generate_dynamic` 同一规则）。这样静态链接的工具拿到自包含的 `.a`，而
+  `dynamic_link` 二进制仍共享同一份共享库。vcpkg 一个 triplet 只构建一种
+  linkage，所以 `'auto'` port 的共享构建落在独立的 `blade-<triplet>-shared`
+  安装树里，与主静态树并列。
+
+### `linkage: 'dynamic'` / `'auto'`——单例库
 
 有些库通过静态初始化维护进程级注册表——gflags（flag 注册表）、glog、protobuf
 （descriptor pool）、googletest（测试注册表）。当它们被**静态**链接进多个共享库
 和可执行文件时，每份拷贝各有一份注册表，启动时冲突（重复注册 flag / descriptor /
-测试）。把这类 port 编成**共享库**，全进程只有一份实例：
+测试）。把这类 port 编成**共享库**，全进程只有一份实例。当一部分二进制静态链接
+它们（如自包含的构建期工具 / protoc 插件）、另一部分动态链接时，用 `'auto'`；要
+全程强制共享，用 `'dynamic'`：
 
 ```python
-'gflags': {'version': '2.2.2', 'linkage': 'dynamic'},
-'glog':   {'version': '0.7.1', 'linkage': 'dynamic'},
+'gflags': {'version': '2.2.2', 'linkage': 'auto'},
+'glog':   {'version': '0.7.1', 'linkage': 'auto'},
 ```
 
 ### `link_all_symbols: True`——强制运行静态初始化

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1771,17 +1771,21 @@ class VcpkgLibrary(PrebuiltCcLibrary):
     """
 
     def __init__(self, port, lib, key, lib_dir, include_dir, header_only,
-                 dynamic=False, link_all_symbols=False, include_prefix=None):
+                 linkage='static', dynamic_lib_dir=None,
+                 link_all_symbols=False, include_prefix=None):
         # Stash the vcpkg-resolved locations before super().__init__, which
         # calls our _setup() at the end of construction.
         self._vcpkg_port = port
         self._vcpkg_lib_dir = lib_dir
         self._vcpkg_header_only = header_only
-        # A dynamic port (vcpkg_config linkage='dynamic') installs a shared lib
-        # instead of a `.a` -- used for singleton libs (gflags/glog/protobuf/
-        # gtest) so there is a single instance across the build, not one copy
-        # per dylib (which would double-register flags / descriptors / tests).
-        self._vcpkg_dynamic = dynamic
+        # linkage (vcpkg_config): 'static' (.a only), 'dynamic' (shared only --
+        # one instance across the build for singletons like gflags/glog/protobuf
+        # so flags/descriptors are not double-registered), or 'auto' (static .a
+        # always; shared lib built on demand when a dynamic_link binary depends
+        # on it). The shared lib of an 'auto' port lives in a separate `-shared`
+        # install tree; `dynamic_lib_dir` points there (else == lib_dir).
+        self._vcpkg_linkage = linkage
+        self._vcpkg_dynamic_lib_dir = dynamic_lib_dir or lib_dir
         super().__init__(
                 name=lib,
                 deps=[],
@@ -1866,8 +1870,10 @@ class VcpkgLibrary(PrebuiltCcLibrary):
         tc = self.blade.get_build_toolchain()
         if self._vcpkg_header_only:
             return
-        if self._vcpkg_dynamic:
+        if self._vcpkg_linkage == 'dynamic':
             self._setup_dynamic(tc)
+        elif self._vcpkg_linkage == 'auto':
+            self._setup_auto(tc)
         else:
             self._setup_static(tc)
 
@@ -1900,17 +1906,68 @@ class VcpkgLibrary(PrebuiltCcLibrary):
         # Dynamic-only: the shared lib serves static linking too.
         self._add_target_file(tc.STATIC_LIB_LABEL, dynamic_target)
 
+    def _setup_auto(self, tc):
+        # Both artifacts are exposed so the consumer's own link mode picks: a
+        # static_link binary takes the STATIC label (the always-built .a from the
+        # main tree), a dynamic_link binary takes the DYNAMIC label (the .dylib
+        # from the `-shared` tree). Whether that .dylib is actually built/copied
+        # is gated on generate_dynamic in generate() (set during analyze only
+        # when a dynamic_link binary depends on this port).
+        archive = os.path.join(
+            self._vcpkg_lib_dir,
+            f'{tc.lib_prefix}{self.name}{tc.static_lib_suffix}')
+        self.attr['static_source'] = archive
+        self._add_target_file(tc.STATIC_LIB_LABEL, archive)
+        shared = os.path.join(
+            self._vcpkg_dynamic_lib_dir,
+            f'{tc.lib_prefix}{self.name}{tc.dynamic_lib_suffix}')
+        dynamic_target = self._target_file_path(os.path.basename(shared))
+        self.attr['dynamic_source'] = shared
+        self.attr['dynamic_target'] = dynamic_target
+        self._add_target_file(tc.DYNAMIC_LIB_LABEL, dynamic_target)
+
+    def _vcpkg_wants_dynamic(self):
+        """Whether this port's shared library should actually be materialized.
+
+        Always for a 'dynamic' port; for an 'auto' port only when a dynamic_link
+        binary depends on it (generate_dynamic, set during analyze) -- mirrors
+        cc_library not emitting a .so nobody dynamically links."""
+        if self._vcpkg_linkage == 'dynamic':
+            return True
+        if self._vcpkg_linkage == 'auto':
+            return bool(self.attr.get('generate_dynamic'))
+        return False
+
+    def vcpkg_runtime_libdir(self, dynamic_link):
+        """Absolute dir of the shared library a consumer loads at runtime, for
+        baking an `-rpath`; None when this consumer links the port statically.
+
+        Points at the *install* lib dir (which also holds the port's vcpkg
+        sibling deps -- e.g. glog's libgflags) so the binary's `@rpath/<leaf>`
+        references resolve the whole closure with no DYLD_LIBRARY_PATH, including
+        when the binary is run as a build-time tool (a protoc plugin)."""
+        if self._vcpkg_header_only:
+            return None
+        if self._vcpkg_linkage == 'dynamic':
+            return os.path.abspath(self._vcpkg_lib_dir)
+        if self._vcpkg_linkage == 'auto' and dynamic_link:
+            return os.path.abspath(self._vcpkg_dynamic_lib_dir)
+        return None
+
     def soname_and_full_path(self):  # override PrebuiltCcLibrary
         # Lazy: the run harness asks for this after the build (so after the
         # deferred install), when the .dylib exists to read its install_name.
+        # Only meaningful when a shared lib was actually built (an 'auto' port
+        # that nothing dynamic-links has no .dylib to read).
         if 'soname_and_full_path' not in self.data:
             self.data['soname_and_full_path'] = None
-            src = self.attr.get('dynamic_source')
-            target = self.attr.get('dynamic_target')
-            if src and target:
-                soname = self._soname_of(src)
-                if soname:
-                    self.data['soname_and_full_path'] = (soname, target)
+            if self._vcpkg_wants_dynamic():
+                src = self.attr.get('dynamic_source')
+                target = self.attr.get('dynamic_target')
+                if src and target:
+                    soname = self._soname_of(src)
+                    if soname:
+                        self.data['soname_and_full_path'] = (soname, target)
         return self.data['soname_and_full_path']
 
     def generate(self):  # override
@@ -1921,12 +1978,13 @@ class VcpkgLibrary(PrebuiltCcLibrary):
         static = self.attr.get('static_source')
         if static and static.startswith(os.path.abspath(self.build_dir) + os.sep):
             self._emit_archive_syms(static)
-        # For a dynamic port, copy the vcpkg shared lib into the build tree and
-        # expose its exported symbols to cc_check_undefined (nm reads a .dylib
-        # the same as a .a).
+        # Copy the vcpkg shared lib into the build tree and expose its exported
+        # symbols to cc_check_undefined (nm reads a .dylib the same as a .a).
+        # Skipped for an 'auto' port that nothing dynamic-links (no .dylib was
+        # built in the `-shared` tree).
         dynamic_source = self.attr.get('dynamic_source')
         dynamic_target = self.attr.get('dynamic_target')
-        if dynamic_source and dynamic_target:
+        if dynamic_source and dynamic_target and self._vcpkg_wants_dynamic():
             self.generate_build('copy', dynamic_target, inputs=dynamic_source)
             if dynamic_source.startswith(os.path.abspath(self.build_dir) + os.sep):
                 self._emit_archive_syms(dynamic_source)
@@ -2374,7 +2432,45 @@ class CcBinary(CcTarget):
         linkflags += self._generate_link_flags()
         for rpath_link in self._get_rpath_links():
             linkflags.append('-Wl,--rpath-link=%s' % rpath_link)
+        linkflags += self._vcpkg_rpath_flags(dynamic_link, toolchain)
         return linkflags
+
+    def _vcpkg_rpath_flags(self, dynamic_link, toolchain):
+        """Bake an `LC_RPATH` (ELF DT_RPATH) so vcpkg shared libraries the binary
+        links resolve their `@rpath/<leaf>` (macOS) / soname (ELF) at runtime
+        with no DYLD/LD_LIBRARY_PATH -- which also covers a binary run as a
+        build-time tool (a protoc plugin), where blade's run-harness env is never
+        set. Windows has no rpath, so emit nothing there.
+
+        Two entries per binary: an absolute path to each install lib dir (fixes
+        in-place runs and build-time tools), and an `@executable_path`-relative
+        path to the binary's runfiles dir (so a relocated binary+runfiles also
+        resolves, replacing the DYLD_LIBRARY_PATH=runfiles hack)."""
+        if os.name == 'nt' or toolchain.cc_is('msvc'):
+            return []
+        build_targets = self.blade.get_build_targets()
+        assert self.expanded_deps is not None, 'expanded_deps not expanded'
+        libdirs = []
+        for lib in self.expanded_deps:
+            getter = getattr(build_targets[lib], 'vcpkg_runtime_libdir', None)
+            if getter is None:
+                continue
+            libdir = getter(dynamic_link)
+            if libdir and libdir not in libdirs:
+                libdirs.append(libdir)
+        if not libdirs:
+            return []
+        flags = ['-Wl,-rpath,%s' % d for d in libdirs]
+        # The runfiles dir sits next to the executable (see binary_runner), so
+        # `@executable_path/<exe>.runfiles` is where blade stages the dylibs --
+        # a relocatable rpath for shipping binary+runfiles. macOS only; ELF's
+        # equivalent is `$ORIGIN`, whose `$` would need ninja-escaping, and on
+        # Linux the absolute rpath above already covers build-time tools.
+        if sys.platform == 'darwin':
+            executable_name = self.attr.get('executable_name', self.name)
+            flags.append(
+                '-Wl,-rpath,@executable_path/%s.runfiles' % executable_name)
+        return flags
 
     def _cc_binary(self, objs, inclusion_check_result, dynamic_link):
         implicit_deps = None

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -867,10 +867,10 @@ def _check_vcpkg_packages(packages):
                 _blade_config.error(
                     'vcpkg_config.packages["%s"].features must be a list' % port)
             linkage = spec.get('linkage')
-            if linkage is not None and linkage not in ('static', 'dynamic'):
+            if linkage is not None and linkage not in ('static', 'dynamic', 'auto'):
                 _blade_config.error(
-                    'vcpkg_config.packages["%s"].linkage must be "static" or '
-                    '"dynamic"' % port)
+                    'vcpkg_config.packages["%s"].linkage must be "static", '
+                    '"dynamic" or "auto"' % port)
             las = spec.get('link_all_symbols')
             if las is not None and not isinstance(las, bool):
                 _blade_config.error(

--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -446,7 +446,7 @@ def _vcpkg_dep_handler(referrer, coordinate):
     # so deriving the shared sibling here keeps the path computation co-located.
     if linkage == 'auto' and cfg.get('manage', True):
         dynamic_lib_dir = os.path.join(
-            root, 'installed', shared_overlay_triplet_name(vanilla), 'lib')
+            shared_install_root(root), shared_overlay_triplet_name(vanilla), 'lib')
     else:
         dynamic_lib_dir = info['lib_dir']
     # Lazy import: cc_targets is loaded before this module, but keeping the
@@ -565,7 +565,7 @@ def setup(builder):
     # debug build).
     if demanded and not _install_shared(
             vcpkg_bin, cfg, vanilla, demanded, packages,
-            base, triplets_dir, installed_root, toolchain):
+            base, triplets_dir, toolchain):
         return False
     return True
 
@@ -598,11 +598,20 @@ def _auto_dynamic_ports(builder, packages):
     return sorted(demanded)
 
 
+def shared_install_root(base):
+    """Install root for the shared (`-shared` triplet) tree.
+
+    A SEPARATE root from the main install: vcpkg manifest mode "owns" its
+    install root and prunes anything not in the current manifest, so sharing one
+    root would make the second (subset) install wipe the first."""
+    return os.path.join(base, 'shared', 'installed')
+
+
 def _install_shared(vcpkg_bin, cfg, vanilla, ports, packages,
-                    base, triplets_dir, installed_root, toolchain):
+                    base, triplets_dir, toolchain):
     """Install `ports` as shared libraries into the `blade-<triplet>-shared`
-    tree (a separate manifest + overlay triplet, since vcpkg builds one linkage
-    per triplet). Returns True on success or a stamp-skip."""
+    tree (a separate manifest + overlay triplet + install root, since vcpkg
+    builds one linkage per triplet). Returns True on success or a stamp-skip."""
     import hashlib
     import json
     from blade import console, util
@@ -614,6 +623,7 @@ def _install_shared(vcpkg_bin, cfg, vanilla, ports, packages,
     if triplet_cmake is None:  # pragma: no cover - main triplet already validated
         return True
     shared_base = os.path.join(base, 'shared')
+    shared_installed = shared_install_root(base)
     os.makedirs(shared_base, exist_ok=True)
     subset = {p: packages[p] for p in ports}
     manifest = json.dumps(manifest_json(subset, cfg.get('baseline', '')),
@@ -632,7 +642,7 @@ def _install_shared(vcpkg_bin, cfg, vanilla, ports, packages,
     stamp = hashlib.md5(
         (manifest + triplet_cmake + shared_overlay).encode()).hexdigest()
     stamp_file = os.path.join(shared_base, '.blade-vcpkg-stamp')
-    if (os.path.isdir(os.path.join(installed_root, shared_overlay))
+    if (os.path.isdir(os.path.join(shared_installed, shared_overlay))
             and os.path.exists(stamp_file)
             and _read_text(stamp_file).strip() == stamp):
         return True
@@ -640,7 +650,7 @@ def _install_shared(vcpkg_bin, cfg, vanilla, ports, packages,
     cmd = [vcpkg_bin, 'install',
            '--triplet', shared_overlay,
            '--x-manifest-root', shared_base,
-           '--x-install-root', installed_root,
+           '--x-install-root', shared_installed,
            '--overlay-triplets', triplets_dir]
     console.info('vcpkg: installing %d shared package(s) for %s ...'
                  % (len(ports), shared_overlay))

--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -186,6 +186,15 @@ def overlay_triplet_name(triplet):
     return 'blade-' + triplet
 
 
+def shared_overlay_triplet_name(triplet):
+    """The overlay triplet that force-builds 'auto' ports as shared libraries.
+
+    A separate triplet (and install subtree) is needed because vcpkg builds a
+    single linkage per triplet: the main `blade-<triplet>` tree holds the
+    static .a, and `blade-<triplet>-shared` holds the on-demand .dylib/.so."""
+    return overlay_triplet_name(triplet) + '-shared'
+
+
 def manifest_json(packages, baseline=''):
     """Build the synthetic vcpkg.json manifest from vcpkg_config (issue #1236).
 
@@ -245,9 +254,20 @@ def port_options(packages, port):
     """Per-port (linkage, link_all_symbols, include_prefix) from the spec.
 
     A bare version string -> defaults ('static', False, None). A dict spec may
-    carry `linkage` ('static'|'dynamic'), `link_all_symbols` (bool) and
-    `include_prefix` (str: expose vcpkg's include dir under this subdir, for
-    libs flare includes as "<prefix>/<header>" but vcpkg ships at include top).
+    carry `linkage`, `link_all_symbols` (bool) and `include_prefix` (str: expose
+    vcpkg's include dir under this subdir, for libs flare includes as
+    "<prefix>/<header>" but vcpkg ships at include top).
+
+    `linkage` is one of:
+      'static'  (default) -- only the static archive (.a) is built.
+      'dynamic'           -- only the shared library (.dylib/.so) is built; both
+                             link modes share that single instance.
+      'auto'              -- the static archive is always built; the shared
+                             library is built *on demand*, only when a
+                             dynamic_link binary actually depends on the port
+                             (mirrors cc_library's generate_dynamic). This gives
+                             a static-link tool a self-contained .a while a
+                             dynamic-link binary still shares one .dylib.
     """
     spec = packages.get(port)
     if isinstance(spec, dict):
@@ -258,9 +278,19 @@ def port_options(packages, port):
 
 
 def dynamic_ports(packages):
-    """Ports whose spec requests linkage='dynamic' (sorted, deterministic)."""
+    """Ports whose spec requests linkage='dynamic' (sorted, deterministic).
+
+    These build their shared library in the *main* install tree. 'auto' ports
+    are excluded here: they build static in the main tree and their shared lib
+    lands in the separate `-shared` tree (see auto_ports / setup)."""
     return sorted(p for p, s in packages.items()
                   if isinstance(s, dict) and s.get('linkage') == 'dynamic')
+
+
+def auto_ports(packages):
+    """Ports whose spec requests linkage='auto' (sorted, deterministic)."""
+    return sorted(p for p, s in packages.items()
+                  if isinstance(s, dict) and s.get('linkage') == 'auto')
 
 
 def port_cmake_options(packages):
@@ -410,12 +440,21 @@ def _vcpkg_dep_handler(referrer, coordinate):
     if key in referrer.target_database:
         return key
     linkage, link_all_symbols, include_prefix = port_options(packages, info['port'])
+    # For an 'auto' port the shared library lives in the separate `-shared`
+    # install tree (managed mode); a 'dynamic' port's .dylib is in the main tree
+    # alongside its lib_dir. install_location built `triplet` from the same cfg,
+    # so deriving the shared sibling here keeps the path computation co-located.
+    if linkage == 'auto' and cfg.get('manage', True):
+        dynamic_lib_dir = os.path.join(
+            root, 'installed', shared_overlay_triplet_name(vanilla), 'lib')
+    else:
+        dynamic_lib_dir = info['lib_dir']
     # Lazy import: cc_targets is loaded before this module, but keeping the
     # import local avoids a hard module-level cycle (cc_targets -> ... -> here).
     from blade.cc_targets import VcpkgLibrary
     target = VcpkgLibrary(info['port'], info['lib'], key,
                           info['lib_dir'], info['include_dir'], info['header_only'],
-                          dynamic=(linkage == 'dynamic'),
+                          linkage=linkage, dynamic_lib_dir=dynamic_lib_dir,
                           link_all_symbols=link_all_symbols,
                           include_prefix=include_prefix)
     referrer.blade.register_target(target)
@@ -490,10 +529,17 @@ def setup(builder):
     stamp = hashlib.md5(
         (manifest + chainload + triplet_cmake + overlay).encode()).hexdigest()
     stamp_file = os.path.join(base, '.blade-vcpkg-stamp')
-    if os.path.isdir(installed_root) and os.path.exists(stamp_file):
-        with open(stamp_file) as f:
-            if f.read().strip() == stamp:
-                return True
+    main_fresh = (os.path.isdir(os.path.join(installed_root, overlay))
+                  and os.path.exists(stamp_file)
+                  and _read_text(stamp_file).strip() == stamp)
+
+    # The 'auto' ports a dynamic_link binary actually depends on (computed from
+    # the analyzed graph -- setup() runs in build(), after analyze) determine
+    # whether the second, shared install is needed at all.
+    demanded = _auto_dynamic_ports(builder, packages)
+
+    if main_fresh and not demanded:
+        return True
 
     vcpkg_bin = _find_vcpkg_tool(cfg)
     if vcpkg_bin is None:
@@ -501,13 +547,103 @@ def setup(builder):
                       'vcpkg_config(root=...), $VCPKG_ROOT, or put vcpkg on PATH')
         return False
 
+    if not main_fresh:
+        cmd = [vcpkg_bin, 'install',
+               '--triplet', overlay,
+               '--x-manifest-root', base,
+               '--x-install-root', installed_root,
+               '--overlay-triplets', triplets_dir]
+        console.info('vcpkg: installing %d package(s) for %s ...'
+                     % (len(packages), overlay))
+        if not _run_install_with_progress(cmd):
+            return False
+        with open(stamp_file, 'w') as f:
+            f.write(stamp)
+
+    # Second tree: build the demanded 'auto' ports as shared libraries. Skipped
+    # entirely when nothing dynamic-links an 'auto' port (e.g. an all-static
+    # debug build).
+    if demanded and not _install_shared(
+            vcpkg_bin, cfg, vanilla, demanded, packages,
+            base, triplets_dir, installed_root, toolchain):
+        return False
+    return True
+
+
+def _read_text(path):
+    with open(path) as f:
+        return f.read()
+
+
+def _auto_dynamic_ports(builder, packages):
+    """The 'auto' ports that a dynamic_link binary actually depends on.
+
+    Mirrors cc_library's generate_dynamic: a dynamic_link binary's
+    _expand_deps_generation sets attr['generate_dynamic']=True on each
+    VcpkgLibrary in its dependency closure during analyze (which runs before
+    setup()), so the flag now tells us exactly which 'auto' ports need a shared
+    library built. Returns a sorted, deduplicated port list."""
+    auto = set(auto_ports(packages))
+    if not auto:
+        return []
+    demanded = set()
+    for target in builder.get_build_targets().values():
+        if getattr(target, 'type', None) != 'vcpkg_library':
+            continue
+        if not target.attr.get('generate_dynamic'):
+            continue
+        port = getattr(target, '_vcpkg_port', None)
+        if port in auto:
+            demanded.add(port)
+    return sorted(demanded)
+
+
+def _install_shared(vcpkg_bin, cfg, vanilla, ports, packages,
+                    base, triplets_dir, installed_root, toolchain):
+    """Install `ports` as shared libraries into the `blade-<triplet>-shared`
+    tree (a separate manifest + overlay triplet, since vcpkg builds one linkage
+    per triplet). Returns True on success or a stamp-skip."""
+    import hashlib
+    import json
+    from blade import console, util
+    shared_overlay = shared_overlay_triplet_name(vanilla)
+    triplet_cmake = overlay_triplet_cmake(
+        toolchain.target_os, toolchain.target_arch,
+        library_linkage='dynamic',
+        cmake_options=port_cmake_options({p: packages[p] for p in ports}))
+    if triplet_cmake is None:  # pragma: no cover - main triplet already validated
+        return True
+    shared_base = os.path.join(base, 'shared')
+    os.makedirs(shared_base, exist_ok=True)
+    subset = {p: packages[p] for p in ports}
+    manifest = json.dumps(manifest_json(subset, cfg.get('baseline', '')),
+                          indent=2, sort_keys=True)
+    files = {
+        os.path.join(shared_base, 'vcpkg.json'): manifest,
+        os.path.join(triplets_dir, shared_overlay + '.cmake'): triplet_cmake,
+    }
+    configuration = configuration_json(cfg.get('registries') or [])
+    if configuration is not None:
+        files[os.path.join(shared_base, 'vcpkg-configuration.json')] = json.dumps(
+            configuration, indent=2, sort_keys=True)
+    for path, content in files.items():
+        util.write_if_changed(path, content)
+
+    stamp = hashlib.md5(
+        (manifest + triplet_cmake + shared_overlay).encode()).hexdigest()
+    stamp_file = os.path.join(shared_base, '.blade-vcpkg-stamp')
+    if (os.path.isdir(os.path.join(installed_root, shared_overlay))
+            and os.path.exists(stamp_file)
+            and _read_text(stamp_file).strip() == stamp):
+        return True
+
     cmd = [vcpkg_bin, 'install',
-           '--triplet', overlay,
-           '--x-manifest-root', base,
+           '--triplet', shared_overlay,
+           '--x-manifest-root', shared_base,
            '--x-install-root', installed_root,
            '--overlay-triplets', triplets_dir]
-    console.info('vcpkg: installing %d package(s) for %s ...'
-                 % (len(packages), overlay))
+    console.info('vcpkg: installing %d shared package(s) for %s ...'
+                 % (len(ports), shared_overlay))
     if not _run_install_with_progress(cmd):
         return False
     with open(stamp_file, 'w') as f:

--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -318,6 +318,10 @@ def overlay_triplet_cmake(target_os, target_arch, library_linkage='static',
         'set(VCPKG_TARGET_ARCHITECTURE %s)' % arch,
         'set(VCPKG_CRT_LINKAGE dynamic)',
         'set(VCPKG_LIBRARY_LINKAGE %s)' % library_linkage,
+        # vcpkg builds both release and debug by default; blade only ever links
+        # the release tree (installed/<triplet>/lib), so building debug doubles
+        # the install time and disk for nothing. Release-only.
+        'set(VCPKG_BUILD_TYPE release)',
     ]
     for port in dynamic_ports:
         lines.append('if(PORT STREQUAL "%s")' % port)

--- a/src/tests/unit/vcpkg_manifest_test.py
+++ b/src/tests/unit/vcpkg_manifest_test.py
@@ -137,10 +137,26 @@ class PortOptionsTest(unittest.TestCase):
                 {'glog': {'include_prefix': {'thirdparty/glog': 'glog'}}}, 'glog'),
             ('static', False, {'thirdparty/glog': 'glog'}))
 
+    def test_auto_linkage(self):
+        self.assertEqual(
+            vcpkg.port_options({'glog': {'linkage': 'auto'}}, 'glog'),
+            ('auto', False, None))
+
     def test_dynamic_ports_sorted(self):
         pkgs = {'fmt': '7', 'gflags': {'linkage': 'dynamic'},
                 'glog': {'linkage': 'dynamic'}, 'z': {'linkage': 'static'}}
         self.assertEqual(vcpkg.dynamic_ports(pkgs), ['gflags', 'glog'])
+
+    def test_auto_ports_sorted_and_excluded_from_dynamic(self):
+        pkgs = {'fmt': '7', 'glog': {'linkage': 'auto'},
+                'gflags': {'linkage': 'auto'}, 'z': {'linkage': 'dynamic'}}
+        # 'auto' ports build static in the main tree -> not in dynamic_ports.
+        self.assertEqual(vcpkg.auto_ports(pkgs), ['gflags', 'glog'])
+        self.assertEqual(vcpkg.dynamic_ports(pkgs), ['z'])
+
+    def test_shared_overlay_triplet_name(self):
+        self.assertEqual(vcpkg.shared_overlay_triplet_name('x64-linux'),
+                         'blade-x64-linux-shared')
 
     def test_overlay_per_port_dynamic_override(self):
         t = _overlay('darwin', 'aarch64', dynamic_ports=['gflags'])

--- a/src/tests/unit/vcpkg_manifest_test.py
+++ b/src/tests/unit/vcpkg_manifest_test.py
@@ -83,6 +83,8 @@ class OverlayTripletTest(unittest.TestCase):
         t = _overlay('linux', 'x86_64')
         self.assertIn('set(VCPKG_TARGET_ARCHITECTURE x64)', t)
         self.assertIn('set(VCPKG_LIBRARY_LINKAGE static)', t)
+        # Release-only: blade links the release tree, never debug/.
+        self.assertIn('set(VCPKG_BUILD_TYPE release)', t)
         self.assertIn('set(VCPKG_CMAKE_SYSTEM_NAME Linux)', t)
         self.assertIn('VCPKG_CHAINLOAD_TOOLCHAIN_FILE', t)
         self.assertIn('../blade-chainload.cmake', t)

--- a/src/tests/unit/vcpkg_resolve_test.py
+++ b/src/tests/unit/vcpkg_resolve_test.py
@@ -185,6 +185,31 @@ class HandlerTest(unittest.TestCase):
             os.path.join('build64', '.cache/vcpkg', 'installed',
                          'blade-x64-linux', 'lib')))
 
+    def test_auto_port_passes_shared_dynamic_lib_dir(self):
+        # An 'auto' port (managed mode) gets its shared lib from the separate
+        # `-shared` tree; the handler points dynamic_lib_dir there.
+        r = _Referrer()
+        with mock.patch('blade.config.get_section',
+                        return_value=self._cfg(manage=True, triplet='x64-linux',
+                                               packages={'glog': {'linkage': 'auto'}})), \
+             mock.patch('blade.cc_targets.VcpkgLibrary') as MockVL:
+            vcpkg._vcpkg_dep_handler(r, 'glog:glog')
+        kw = MockVL.call_args[1]
+        self.assertEqual(kw['linkage'], 'auto')
+        self.assertTrue(kw['dynamic_lib_dir'].endswith(
+            os.path.join('installed', 'blade-x64-linux-shared', 'lib')),
+            kw['dynamic_lib_dir'])
+
+    def test_static_port_dynamic_lib_dir_falls_back_to_main(self):
+        r = _Referrer()
+        with mock.patch('blade.config.get_section',
+                        return_value=self._cfg(packages={'fmt': '10.2.1'})), \
+             mock.patch('blade.cc_targets.VcpkgLibrary') as MockVL:
+            vcpkg._vcpkg_dep_handler(r, 'fmt:fmt')
+        kw = MockVL.call_args[1]
+        self.assertEqual(kw['linkage'], 'static')
+        self.assertEqual(kw['dynamic_lib_dir'], MockVL.call_args[0][3])
+
     def test_registered_as_vcpkg_scheme(self):
         # Importing blade.vcpkg wires the provider into target's registry.
         from blade import target as target_mod

--- a/src/tests/unit/vcpkg_resolve_test.py
+++ b/src/tests/unit/vcpkg_resolve_test.py
@@ -197,7 +197,7 @@ class HandlerTest(unittest.TestCase):
         kw = MockVL.call_args[1]
         self.assertEqual(kw['linkage'], 'auto')
         self.assertTrue(kw['dynamic_lib_dir'].endswith(
-            os.path.join('installed', 'blade-x64-linux-shared', 'lib')),
+            os.path.join('shared', 'installed', 'blade-x64-linux-shared', 'lib')),
             kw['dynamic_lib_dir'])
 
     def test_static_port_dynamic_lib_dir_falls_back_to_main(self):

--- a/src/tests/unit/vcpkg_setup_test.py
+++ b/src/tests/unit/vcpkg_setup_test.py
@@ -46,14 +46,24 @@ class InstallLocationTest(unittest.TestCase):
         self.assertEqual(root, '/envroot')
 
 
-def _builder(build_dir):
+def _builder(build_dir, targets=None):
     b = mock.Mock()
     b.get_build_dir.return_value = build_dir
+    b.get_build_targets.return_value = targets or {}
     tc = b.get_build_toolchain.return_value
     tc.target_os, tc.target_arch = 'linux', 'x86_64'
     tc.cc_is = lambda v: v == 'gcc'
     tc.tool = lambda k: {'cc': '/usr/bin/gcc', 'cxx': '/usr/bin/g++'}.get(k)
     return b
+
+
+def _vcpkg_lib(port, generate_dynamic):
+    """A stand-in VcpkgLibrary target as setup() sees it in the build graph."""
+    t = mock.Mock()
+    t.type = 'vcpkg_library'
+    t._vcpkg_port = port
+    t.attr = {'generate_dynamic': generate_dynamic}
+    return t
 
 
 _CFG = {
@@ -65,7 +75,7 @@ _CFG = {
 class SetupTest(unittest.TestCase):
 
     def _run(self, build_dir, cfg=None, run_result=(0, 'ok', ''),
-             tool: 'str | None' = '/vc/vcpkg'):
+             tool: 'str | None' = '/vc/vcpkg', targets=None):
         cfg = dict(_CFG if cfg is None else cfg)
         with mock.patch('blade.config.get_section', return_value=cfg), \
              mock.patch('blade.vcpkg._find_vcpkg_tool', return_value=tool), \
@@ -73,7 +83,7 @@ class SetupTest(unittest.TestCase):
              mock.patch('blade.console.error'), \
              mock.patch('blade.vcpkg._run_install_with_progress',
                         return_value=run_result[0] == 0) as rc:
-            ok = vcpkg.setup(_builder(build_dir))
+            ok = vcpkg.setup(_builder(build_dir, targets))
         return ok, rc
 
     def test_manage_false_is_noop(self):
@@ -120,12 +130,61 @@ class SetupTest(unittest.TestCase):
             ok1, rc1 = self._run(d)
             self.assertTrue(ok1)
             rc1.assert_called_once()
-            # Simulate vcpkg having created the install root.
-            os.makedirs(os.path.join(d, '.cache/vcpkg', 'installed'), exist_ok=True)
+            # Simulate vcpkg having created the per-triplet install tree.
+            os.makedirs(os.path.join(d, '.cache/vcpkg', 'installed',
+                                     'blade-x64-linux'), exist_ok=True)
             # Second run with identical inputs must skip the subprocess.
             ok2, rc2 = self._run(d)
             self.assertTrue(ok2)
             rc2.assert_not_called()
+
+
+_AUTO_CFG = dict(_CFG, packages={'glog': {'linkage': 'auto'}})
+
+
+class SharedInstallTest(unittest.TestCase):
+    """The on-demand second (`-shared`) install for 'auto' ports."""
+
+    def _run(self, build_dir, targets=None):
+        with mock.patch('blade.config.get_section', return_value=dict(_AUTO_CFG)), \
+             mock.patch('blade.vcpkg._find_vcpkg_tool', return_value='/vc/vcpkg'), \
+             mock.patch('blade.console.info'), \
+             mock.patch('blade.console.error'), \
+             mock.patch('blade.vcpkg._run_install_with_progress',
+                        return_value=True) as rc:
+            ok = vcpkg.setup(_builder(build_dir, targets))
+        return ok, rc
+
+    def test_no_dynamic_consumer_skips_shared(self):
+        # 'auto' port present but nothing dynamic-links it -> only the main
+        # (static) tree is installed.
+        with tempfile.TemporaryDirectory() as d:
+            ok, rc = self._run(d, targets={'k': _vcpkg_lib('glog', False)})
+        self.assertTrue(ok)
+        self.assertEqual(rc.call_count, 1)
+        self.assertNotIn('blade-x64-linux-shared', rc.call_args_list[0][0][0])
+
+    def test_dynamic_consumer_runs_shared(self):
+        # A dynamic_link binary set generate_dynamic on the VcpkgLibrary -> the
+        # shared tree is installed too.
+        with tempfile.TemporaryDirectory() as d:
+            ok, rc = self._run(d, targets={'k': _vcpkg_lib('glog', True)})
+            self.assertTrue(ok)
+            self.assertEqual(rc.call_count, 2)
+            shared_cmd = rc.call_args_list[1][0][0]
+            self.assertIn('blade-x64-linux-shared', shared_cmd)
+            base = os.path.join(d, '.cache/vcpkg', 'shared')
+            self.assertTrue(os.path.exists(os.path.join(base, 'vcpkg.json')))
+            self.assertTrue(os.path.exists(os.path.join(
+                d, '.cache/vcpkg', 'triplets', 'blade-x64-linux-shared.cmake')))
+
+    def test_shared_triplet_forces_dynamic_linkage(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._run(d, targets={'k': _vcpkg_lib('glog', True)})
+            cmake = os.path.join(d, '.cache/vcpkg', 'triplets',
+                                 'blade-x64-linux-shared.cmake')
+            with open(cmake) as f:
+                self.assertIn('set(VCPKG_LIBRARY_LINKAGE dynamic)', f.read())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Why

A vcpkg singleton library (gflags/glog/protobuf/...) had to be either `static` (each module gets its own registry → duplicate flag/descriptor registration) or `dynamic` (one shared instance, but a build-time tool like a protoc plugin then can't load the `@rpath/...` dylib — it runs before blade's run harness sets `DYLD_LIBRARY_PATH`). Neither works when *some* binaries want it static and others shared.

## What

**A. `linkage: 'auto'`** — the static `.a` is always built; the shared library is built **on demand**, only when a `dynamic_link` binary actually depends on the port (reusing the `generate_dynamic` flag `_expand_deps_generation` already sets on the `VcpkgLibrary` during analyze — `setup()` now runs in `build()`, after analyze). vcpkg builds one linkage per triplet, so the shared build goes to a **separate** `blade-<triplet>-shared` install tree (its own `--x-install-root`, since manifest mode prunes its root). `VcpkgLibrary` exposes `STATIC→.a` / `DYNAMIC→.dylib`, so the consumer's own link mode picks: a static tool gets a self-contained `.a`, a dynamic release binary shares one `.dylib`.

**B. Bake an `LC_RPATH` (ELF `DT_RPATH`)** on a `cc_binary` that links a vcpkg shared lib: an absolute path to the install lib dir (resolves `@rpath/<leaf>` for in-place runs **and** build-time tools, with no `DYLD/LD_LIBRARY_PATH`), plus — on macOS — an `@executable_path`-relative path to the binary's `.runfiles` dir for relocatable shipping.

## Validation (flare, arm64-osx)

- Full `flare/...` build green (2475 steps). The static protoc plugins (`dynamic_link=False`) build and run at build time — the original `@rpath/libglog ... no LC_RPATH` failure is gone.
- A dynamic-link release binary (`logging_test`) carries both rpath entries, links `@rpath/libglog`/`libgflags`, runs standalone with `DYLD_LIBRARY_PATH` unset, and passes.

## Tests / docs

578 unit tests pass; pyright clean (0 errors). New tests cover `auto_ports`/shared-overlay naming, the handler's shared `dynamic_lib_dir`, and `setup()`'s demand-driven shared install. `doc/{en,zh_CN}/vcpkg.md` document the three linkage modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)