### PR TITLE
vcpkg: match debug libs for MSVC-ABI builds (#1315)

### DIFF
--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -233,6 +233,12 @@ def configuration_json(registries):
 
 def chainload_cmake(cc, cxx, c_flags='', cxx_flags=''):
     """CMake toolchain file pinning vcpkg's compiler to blade's resolved one."""
+    # CMake parses backslashes in a string as escapes, so a Windows compiler
+    # path (C:\...\cl.exe) must use forward slashes (CMake accepts them on
+    # Windows). Without this the chainload file is a CMake syntax error and every
+    # vcpkg port configure fails ("Invalid character escape").
+    cc = cc.replace('\\', '/')
+    cxx = cxx.replace('\\', '/')
     return (
         'set(CMAKE_C_COMPILER "%s")\n'
         'set(CMAKE_CXX_COMPILER "%s")\n'
@@ -299,8 +305,44 @@ def port_cmake_options(packages):
             if isinstance(s, dict) and s.get('cmake_options')}
 
 
+def is_msvc_abi_triplet(triplet: str | None) -> bool:
+    """True for vcpkg triplets that use the MSVC CRT + MSVC STL -- the
+    `*-windows*` family (cl.exe and clang-cl both target it). MinGW is
+    `*-mingw-*` (libstdc++, no debug/release ABI split) and is excluded.
+
+    Gate on the triplet, not the compiler name: blade classifies clang-cl as
+    'clang', so a `cc_is('msvc')` gate would miss it -- but its triplet is still
+    `*-windows*`."""
+    return '-windows' in (triplet or '')
+
+
+def vcpkg_build_type(triplet: str | None, profile: str) -> str | None:
+    """The `VCPKG_BUILD_TYPE` for an overlay triplet, or None to build both.
+
+    blade only links the release tree, so default to release-only (half the
+    install time/disk). The exception is an MSVC-ABI **debug** build: debug and
+    release are ABI-incompatible there -- the CRT differs (`/MDd` ucrtbased vs
+    `/MD` ucrtbase) and MSVC STL's `_ITERATOR_DEBUG_LEVEL` changes `std::`
+    container layout -- so a debug MSVC/clang-cl program must link debug libs.
+    For that case return None: build BOTH (the debug tree is needed, and headers
+    only ship with the release install, so a debug-only build would lose them).
+    clang/gcc/MinGW are unaffected (release libs work in debug)."""
+    if profile == 'debug' and is_msvc_abi_triplet(triplet):
+        return None
+    return 'release'
+
+
+def lib_subdir(triplet: str | None, profile: str) -> str:
+    """The install-tree lib subdir to link from: `debug/lib` for an MSVC-ABI
+    debug build (matching vcpkg_build_type building both), else `lib`."""
+    if profile == 'debug' and is_msvc_abi_triplet(triplet):
+        return os.path.join('debug', 'lib')
+    return 'lib'
+
+
 def overlay_triplet_cmake(target_os, target_arch, library_linkage='static',
                           dynamic_ports=(), cmake_options=None,
+                          build_type: str | None = 'release',
                           chainload_rel='../blade-chainload.cmake'):
     """The overlay triplet `.cmake` that chainloads blade's compiler.
 
@@ -318,11 +360,13 @@ def overlay_triplet_cmake(target_os, target_arch, library_linkage='static',
         'set(VCPKG_TARGET_ARCHITECTURE %s)' % arch,
         'set(VCPKG_CRT_LINKAGE dynamic)',
         'set(VCPKG_LIBRARY_LINKAGE %s)' % library_linkage,
-        # vcpkg builds both release and debug by default; blade only ever links
-        # the release tree (installed/<triplet>/lib), so building debug doubles
-        # the install time and disk for nothing. Release-only.
-        'set(VCPKG_BUILD_TYPE release)',
     ]
+    # vcpkg builds both release and debug by default; blade only links the
+    # release tree, so default to release-only (half the install time/disk).
+    # build_type=None means build both -- needed for an MSVC-ABI debug build,
+    # whose ABI-incompatible debug libs must be linked (see vcpkg_build_type).
+    if build_type:
+        lines.append('set(VCPKG_BUILD_TYPE %s)' % build_type)
     for port in dynamic_ports:
         lines.append('if(PORT STREQUAL "%s")' % port)
         lines.append('    set(VCPKG_LIBRARY_LINKAGE dynamic)')
@@ -370,12 +414,17 @@ class VcpkgError(Exception):
     """A `vcpkg#...` reference could not be resolved (issue #1236)."""
 
 
-def resolve_reference(coordinate, packages, root, triplet):
+def resolve_reference(coordinate, packages, root, triplet, profile: str = 'release'):
     """Resolve a `vcpkg#<coordinate>` reference to install-tree locations.
 
     Pure validation + path computation (no toolchain / Target / filesystem):
-    the handler derives `triplet`/`root` from the toolchain + config and passes
-    them in. Raises VcpkgError (with a user-facing message) on any problem.
+    the handler derives `triplet`/`root`/`profile` from the toolchain + config
+    and passes them in. Raises VcpkgError (with a user-facing message) on any
+    problem.
+
+    An MSVC-ABI debug build links the `debug/lib` subtree (its debug CRT/STL is
+    ABI-incompatible with release); every other case links `lib`. The include
+    dir is shared (vcpkg installs headers once, with the release build).
 
     Returns a dict: port, lib, key, header_only, lib_dir, include_dir.
     """
@@ -409,7 +458,7 @@ def resolve_reference(coordinate, packages, root, triplet):
         'lib': lib,
         'key': 'vcpkg#%s:%s' % (port, lib),
         'header_only': lib == 'hdrs',
-        'lib_dir': os.path.join(installed, 'lib'),
+        'lib_dir': os.path.join(installed, lib_subdir(triplet, profile)),
         'include_dir': os.path.join(installed, 'include'),
     }
 
@@ -452,9 +501,10 @@ def _vcpkg_dep_handler(referrer, coordinate):
     if not vanilla or vanilla == 'auto':
         vanilla = triplet_for_toolchain(toolchain)
     root, triplet = install_location(cfg, vanilla, referrer.blade.get_build_dir())
+    profile = referrer.blade.get_options().profile
     packages = cfg.get('packages', {})
     try:
-        info = resolve_reference(coordinate, packages, root, triplet)
+        info = resolve_reference(coordinate, packages, root, triplet, profile)
     except VcpkgError as e:
         referrer.error(str(e))
         return None
@@ -467,8 +517,10 @@ def _vcpkg_dep_handler(referrer, coordinate):
     # alongside its lib_dir. install_location built `triplet` from the same cfg,
     # so deriving the shared sibling here keeps the path computation co-located.
     if linkage == 'auto' and cfg.get('manage', True):
+        shared_triplet = shared_overlay_triplet_name(vanilla)
         dynamic_lib_dir = os.path.join(
-            shared_install_root(root), shared_overlay_triplet_name(vanilla), 'lib')
+            shared_install_root(root), shared_triplet,
+            lib_subdir(shared_triplet, profile))
     else:
         dynamic_lib_dir = info['lib_dir']
     # Lazy import: cc_targets is loaded before this module, but keeping the
@@ -488,9 +540,11 @@ def _find_vcpkg_tool(cfg):
     import shutil
     tool_root = cfg.get('root') or os.environ.get('VCPKG_ROOT', '')
     if tool_root:
-        candidate = os.path.join(tool_root, 'vcpkg')
-        if os.path.exists(candidate):
-            return candidate
+        # The executable is `vcpkg.exe` on Windows, `vcpkg` elsewhere.
+        for name in ('vcpkg.exe', 'vcpkg') if os.name == 'nt' else ('vcpkg',):
+            candidate = os.path.join(tool_root, name)
+            if os.path.exists(candidate):
+                return candidate
     return shutil.which('vcpkg')
 
 
@@ -516,10 +570,12 @@ def setup(builder):
     vanilla = cfg.get('triplet')
     if not vanilla or vanilla == 'auto':
         vanilla = triplet_for_toolchain(toolchain)
+    profile = builder.get_options().profile
     triplet_cmake = (overlay_triplet_cmake(
         toolchain.target_os, toolchain.target_arch,
         dynamic_ports=dynamic_ports(packages),
-        cmake_options=port_cmake_options(packages)) if vanilla else None)
+        cmake_options=port_cmake_options(packages),
+        build_type=vcpkg_build_type(vanilla, profile)) if vanilla else None)
     if not vanilla or triplet_cmake is None:
         console.error('vcpkg: cannot derive a triplet for os=%s arch=%s; set '
                       'vcpkg_config(triplet=...)'
@@ -583,7 +639,7 @@ def setup(builder):
             cmd.append('--binarysource=' + binary_cache)
         console.info('vcpkg: installing %d package(s) for %s ...'
                      % (len(packages), overlay))
-        if not _run_install_with_progress(cmd):
+        if not _run_install_with_progress(cmd, install_env(toolchain)):
             return False
         with open(stamp_file, 'w') as f:
             f.write(stamp)
@@ -593,7 +649,7 @@ def setup(builder):
     # debug build).
     if demanded and not _install_shared(
             vcpkg_bin, cfg, vanilla, demanded, packages,
-            base, triplets_dir, toolchain):
+            base, triplets_dir, toolchain, profile):
         return False
     return True
 
@@ -636,7 +692,7 @@ def shared_install_root(base):
 
 
 def _install_shared(vcpkg_bin, cfg, vanilla, ports, packages,
-                    base, triplets_dir, toolchain):
+                    base, triplets_dir, toolchain, profile):
     """Install `ports` as shared libraries into the `blade-<triplet>-shared`
     tree (a separate manifest + overlay triplet + install root, since vcpkg
     builds one linkage per triplet). Returns True on success or a stamp-skip."""
@@ -647,7 +703,8 @@ def _install_shared(vcpkg_bin, cfg, vanilla, ports, packages,
     triplet_cmake = overlay_triplet_cmake(
         toolchain.target_os, toolchain.target_arch,
         library_linkage='dynamic',
-        cmake_options=port_cmake_options({p: packages[p] for p in ports}))
+        cmake_options=port_cmake_options({p: packages[p] for p in ports}),
+        build_type=vcpkg_build_type(vanilla, profile))
     if triplet_cmake is None:  # pragma: no cover - main triplet already validated
         return True
     shared_base = os.path.join(base, 'shared')
@@ -685,14 +742,60 @@ def _install_shared(vcpkg_bin, cfg, vanilla, ports, packages,
         cmd.append('--binarysource=' + binary_cache)
     console.info('vcpkg: installing %d shared package(s) for %s ...'
                  % (len(ports), shared_overlay))
-    if not _run_install_with_progress(cmd):
+    if not _run_install_with_progress(cmd, install_env(toolchain)):
         return False
     with open(stamp_file, 'w') as f:
         f.write(stamp)
     return True
 
 
-def _run_install_with_progress(cmd):
+def install_env(toolchain) -> dict | None:
+    """Subprocess environment for `vcpkg install`, or None to inherit os.environ.
+
+    On MSVC, ports are built by vcpkg's own cmake invoking the chainloaded
+    cl.exe / link.exe / rc.exe -- which need the Developer-Command-Prompt
+    environment that blade is normally launched without. The chainload toolchain
+    only pins the compiler, not the environment, so we reconstruct the essential
+    bits from blade's resolved toolchain:
+
+      * `INCLUDE` / `LIB` -- CRT + Windows SDK headers and libraries. Without LIB
+        every port fails to link (`LNK1104: cannot open file 'LIBCMT.lib'`).
+      * `VCPKG_KEEP_ENV_VARS` -- vcpkg scrubs the build environment; INCLUDE/LIB
+        must be whitelisted or they never reach the compiler.
+      * `PATH` -- the SDK + compiler tool dirs, so `rc.exe` (invoked unqualified
+        by CMake's manifest step) and the compiler's own DLLs resolve. PATH is
+        always inherited by vcpkg builds, so it needs no keep entry.
+
+    Non-MSVC toolchains need nothing (gcc/clang locate their own runtime), so
+    return None there."""
+    if not toolchain.cc_is('msvc'):
+        return None
+    inc = toolchain.get_system_include_paths()
+    lib = toolchain.get_system_lib_paths()
+    if not inc and not lib:
+        return None
+    env = dict(os.environ)
+    if inc:
+        env['INCLUDE'] = os.pathsep.join(inc)
+    if lib:
+        env['LIB'] = os.pathsep.join(lib)
+    keep = [v for v in env.get('VCPKG_KEEP_ENV_VARS', '').split(';') if v]
+    for v in ('INCLUDE', 'LIB'):
+        if v not in keep:
+            keep.append(v)
+    env['VCPKG_KEEP_ENV_VARS'] = ';'.join(keep)
+    bindirs = []
+    for key in ('cc', 'rc'):
+        path = toolchain.tool(key)
+        d = os.path.dirname(path) if path else ''
+        if d and d not in bindirs:
+            bindirs.append(d)
+    if bindirs:
+        env['PATH'] = os.pathsep.join(bindirs + [env.get('PATH', '')])
+    return env
+
+
+def _run_install_with_progress(cmd, env=None):
     """Run `vcpkg install`, rendering its `Installing N/M ...` stream as blade's
     live build panel. Returns True on success; on failure prints the captured
     output and returns False. Off a TTY the panel is a no-op (CI logs show the
@@ -707,7 +810,7 @@ def _run_install_with_progress(cmd):
     total = 0
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT, text=True,
-                            errors='replace', bufsize=1)
+                            errors='replace', bufsize=1, env=env)
     start = time.time()
     assert proc.stdout is not None
     for line in proc.stdout:

--- a/src/tests/unit/vcpkg_manifest_test.py
+++ b/src/tests/unit/vcpkg_manifest_test.py
@@ -11,6 +11,7 @@ these files + invoking `vcpkg install` is wired separately (PR6)."""
 import os
 import sys
 import unittest
+import unittest.mock as mock
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
@@ -110,6 +111,45 @@ class OverlayTripletTest(unittest.TestCase):
         self.assertIsNone(vcpkg.overlay_triplet_cmake('plan9', 'x86_64'))
         self.assertIsNone(vcpkg.overlay_triplet_cmake('linux', 'sparc'))
 
+    def test_build_type_release_by_default(self):
+        self.assertIn('set(VCPKG_BUILD_TYPE release)', _overlay('windows', 'x64'))
+
+    def test_build_type_none_omits_the_line(self):
+        # An MSVC-ABI debug build needs both release + debug -> no VCPKG_BUILD_TYPE.
+        self.assertNotIn('VCPKG_BUILD_TYPE',
+                         _overlay('windows', 'x64', build_type=None))
+
+
+class MsvcDebugGateTest(unittest.TestCase):
+    """The MSVC-ABI debug gate (issue #1315): is_msvc_abi_triplet /
+    vcpkg_build_type / lib_subdir."""
+
+    def test_is_msvc_abi_triplet_true_for_windows_family(self):
+        for t in ('x64-windows', 'x64-windows-static', 'blade-x64-windows',
+                  'blade-x64-windows-shared'):
+            self.assertTrue(vcpkg.is_msvc_abi_triplet(t), t)
+
+    def test_is_msvc_abi_triplet_false_for_mingw_posix_none(self):
+        for t in ('x64-mingw-dynamic', 'x64-mingw-static', 'x64-linux',
+                  'arm64-osx', '', None):
+            self.assertFalse(vcpkg.is_msvc_abi_triplet(t), t)
+
+    def test_vcpkg_build_type_release_except_msvc_debug(self):
+        self.assertEqual(vcpkg.vcpkg_build_type('x64-windows', 'release'), 'release')
+        self.assertEqual(vcpkg.vcpkg_build_type('x64-linux', 'debug'), 'release')
+        self.assertEqual(vcpkg.vcpkg_build_type('x64-mingw-dynamic', 'debug'),
+                         'release')
+        # MSVC-ABI debug -> build both (None), so debug libs exist to link.
+        self.assertIsNone(vcpkg.vcpkg_build_type('x64-windows', 'debug'))
+        self.assertIsNone(vcpkg.vcpkg_build_type('blade-x64-windows', 'debug'))
+
+    def test_lib_subdir(self):
+        self.assertEqual(vcpkg.lib_subdir('x64-windows', 'release'), 'lib')
+        self.assertEqual(vcpkg.lib_subdir('x64-linux', 'debug'), 'lib')
+        self.assertEqual(vcpkg.lib_subdir('x64-mingw-dynamic', 'debug'), 'lib')
+        self.assertEqual(vcpkg.lib_subdir('x64-windows', 'debug'),
+                         os.path.join('debug', 'lib'))
+
 
 class PortOptionsTest(unittest.TestCase):
 
@@ -183,6 +223,48 @@ class PortOptionsTest(unittest.TestCase):
         self.assertIn('set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DSNAPPY_WITH_RTTI=ON")', t)
 
 
+class InstallEnvTest(unittest.TestCase):
+    """install_env: reconstruct the MSVC dev environment for `vcpkg install`."""
+
+    def _tc(self, vendor='msvc', inc=None, lib=None, tools=None):
+        tc = mock.Mock()
+        tc.cc_is = lambda v: v == vendor
+        tc.get_system_include_paths.return_value = inc or []
+        tc.get_system_lib_paths.return_value = lib or []
+        tc.tool = lambda k: (tools or {}).get(k)
+        return tc
+
+    def test_non_msvc_inherits_environment(self):
+        self.assertIsNone(vcpkg.install_env(self._tc(vendor='gcc')))
+
+    def test_msvc_without_discovered_paths_returns_none(self):
+        self.assertIsNone(vcpkg.install_env(self._tc()))
+
+    def test_msvc_sets_include_lib_keep_and_path(self):
+        tc = self._tc(inc=['I:/inc'], lib=['L:/lib'],
+                      tools={'cc': 'C:/vs/bin/cl.exe', 'rc': 'C:/sdk/bin/rc.exe'})
+        with mock.patch.dict(os.environ,
+                             {'PATH': 'P:/old', 'INCLUDE': '', 'LIB': '',
+                              'VCPKG_KEEP_ENV_VARS': ''}, clear=True):
+            env = vcpkg.install_env(tc)
+        self.assertEqual(env['INCLUDE'], 'I:/inc')
+        self.assertEqual(env['LIB'], 'L:/lib')
+        # vcpkg scrubs the build env -> INCLUDE/LIB must be whitelisted.
+        self.assertIn('INCLUDE', env['VCPKG_KEEP_ENV_VARS'].split(';'))
+        self.assertIn('LIB', env['VCPKG_KEEP_ENV_VARS'].split(';'))
+        # compiler + rc tool dirs prepended to PATH (so rc.exe etc. resolve).
+        self.assertIn('C:/vs/bin', env['PATH'])
+        self.assertIn('C:/sdk/bin', env['PATH'])
+        self.assertTrue(env['PATH'].endswith('P:/old'))
+
+    def test_keep_env_vars_preserves_existing(self):
+        tc = self._tc(inc=['I:/inc'], lib=['L:/lib'])
+        with mock.patch.dict(os.environ,
+                             {'VCPKG_KEEP_ENV_VARS': 'FOO'}, clear=True):
+            env = vcpkg.install_env(tc)
+        self.assertEqual(env['VCPKG_KEEP_ENV_VARS'].split(';'), ['FOO', 'INCLUDE', 'LIB'])
+
+
 class ChainloadTest(unittest.TestCase):
 
     def test_compiler_and_flags(self):
@@ -192,6 +274,14 @@ class ChainloadTest(unittest.TestCase):
         self.assertIn('set(CMAKE_CXX_COMPILER "/usr/bin/g++")', c)
         self.assertIn('set(CMAKE_C_FLAGS_INIT "-O2")', c)
         self.assertIn('set(CMAKE_CXX_FLAGS_INIT "-O2 -std=c++17")', c)
+
+    def test_windows_compiler_path_uses_forward_slashes(self):
+        # CMake parses '\' as an escape, so a Windows cl.exe path must be written
+        # with forward slashes or every port configure fails to parse the file.
+        c = vcpkg.chainload_cmake(r'C:\VS\bin\cl.exe', r'C:\VS\bin\cl.exe')
+        self.assertIn('set(CMAKE_C_COMPILER "C:/VS/bin/cl.exe")', c)
+        self.assertIn('set(CMAKE_CXX_COMPILER "C:/VS/bin/cl.exe")', c)
+        self.assertNotIn('\\', c)
 
 
 if __name__ == '__main__':

--- a/src/tests/unit/vcpkg_resolve_test.py
+++ b/src/tests/unit/vcpkg_resolve_test.py
@@ -43,6 +43,24 @@ class ResolveReferenceTest(unittest.TestCase):
         self.assertEqual(info['lib_dir'], '/vc/installed/x64-linux/lib')
         self.assertEqual(info['include_dir'], '/vc/installed/x64-linux/include')
 
+    def test_msvc_debug_links_debug_lib_subtree(self):
+        # An MSVC-ABI debug build links debug/lib (ABI-incompatible CRT/STL),
+        # but the include dir is shared (headers ship with the release install).
+        info = vcpkg.resolve_reference('fmt:fmt', _WHITELIST, '/vc',
+                                       'x64-windows', profile='debug')
+        self.assertEqual(info['lib_dir'],
+                         os.path.join('/vc', 'installed', 'x64-windows', 'debug', 'lib'))
+        self.assertEqual(info['include_dir'],
+                         os.path.join('/vc', 'installed', 'x64-windows', 'include'))
+
+    def test_non_msvc_debug_still_links_release_lib(self):
+        # clang/gcc/MinGW debug builds reuse the release tree.
+        for triplet in ('x64-linux', 'x64-mingw-dynamic'):
+            info = vcpkg.resolve_reference('fmt:fmt', _WHITELIST, '/vc',
+                                           triplet, profile='debug')
+            self.assertEqual(info['lib_dir'],
+                             os.path.join('/vc', 'installed', triplet, 'lib'))
+
     def test_lib_basename_differs_from_port(self):
         info = self._resolve('openssl:ssl')
         self.assertEqual(info['key'], 'vcpkg#openssl:ssl')
@@ -152,6 +170,23 @@ class HandlerTest(unittest.TestCase):
         self.assertEqual(args[2], 'vcpkg#fmt:fmt')
         self.assertFalse(args[5])
         r.blade.register_target.assert_called_once()
+
+    def test_msvc_debug_passes_debug_lib_dir(self):
+        # The handler forwards the build profile; an MSVC-ABI debug build must
+        # hand VcpkgLibrary the debug/lib dir (include stays shared).
+        r = _Referrer()
+        r.blade.get_options.return_value.profile = 'debug'
+        with mock.patch('blade.config.get_section',
+                        return_value=self._cfg(triplet='x64-windows')), \
+             mock.patch('blade.cc_targets.VcpkgLibrary') as MockVL:
+            vcpkg._vcpkg_dep_handler(r, 'fmt:fmt')
+        args = MockVL.call_args[0]  # port, lib, key, lib_dir, include_dir, header_only
+        # endswith (not ==): install_location abspath()s the root, which differs
+        # by platform (e.g. '/vc' -> 'C:\\vc' on Windows).
+        self.assertTrue(args[3].endswith(
+            os.path.join('installed', 'x64-windows', 'debug', 'lib')), args[3])
+        self.assertTrue(args[4].endswith(
+            os.path.join('installed', 'x64-windows', 'include')), args[4])
 
     def test_already_registered_is_reused(self):
         r = _Referrer(db={'vcpkg#fmt:fmt': object()})


### PR DESCRIPTION
Sub-task of #1236. Targets the **`vcpkg`** branch (not master).

## #1315 — MSVC-ABI debug builds link debug libraries
The overlay triplet forced `VCPKG_BUILD_TYPE release` (#1314). That's right for clang/gcc/MinGW (release libs work in debug), but **wrong for MSVC-ABI** (cl.exe / clang-cl): debug/release CRT (`/MDd` ucrtbased vs `/MD` ucrtbase) and MSVC STL `_ITERATOR_DEBUG_LEVEL` are ABI-incompatible, so a debug MSVC program must link debug libs.

- `is_msvc_abi_triplet` / `vcpkg_build_type` / `lib_subdir` — gate on the triplet's **`-windows` suffix** (covers cl.exe **and** clang-cl, excludes MinGW `-mingw-*`), per the issue (compiler-name gate would miss clang-cl, which blade classifies as clang).
- `overlay_triplet_cmake` **omits** `VCPKG_BUILD_TYPE` for an MSVC-ABI debug build → vcpkg builds both (headers ship with release; a debug-only build would lose them).
- `resolve_reference` + the dep handler + `setup` + `_install_shared` thread the build profile → MSVC debug links `installed/<triplet>/debug/lib`; the include dir stays shared.

## Bundled prerequisite fixes (Windows MSVC vcpkg was non-functional without them)
Validating #1315 on real Windows MSVC surfaced pre-existing blockers; #1315 can't be exercised there without these:
1. **`chainload_cmake`** wrote `C:\...\cl.exe` — CMake parses `\` as an escape → *every* port configure failed (`Invalid character escape`). Now forward-slashed.
2. **`_find_vcpkg_tool`** only looked for `vcpkg`, not `vcpkg.exe`.
3. **`install_env`** — reconstruct the MSVC dev environment for `vcpkg install` (`INCLUDE`/`LIB` + `VCPKG_KEEP_ENV_VARS` whitelist + compiler/SDK tool dirs on `PATH`). blade runs outside a Developer Command Prompt and the chainload pins only the compiler, so without `LIB` every port failed to link (`LNK1104: cannot open file 'LIBCMT.lib'`). Verified this clears the link failure.

## Validation
- **Generation, real `blade build -p debug` (MSVC):** the emitted `blade-x64-windows-static.cmake` correctly **omits `VCPKG_BUILD_TYPE`** (release includes it). ✅
- **`install_env`:** confirmed it resolves the `LNK1104` link failure on a real vcpkg port build. ✅
- **Unit tests:** gate / build_type / lib_subdir / resolve / handler wiring / chainload escaping / install_env. pyright clean; only the 5 pre-existing Windows path-separator unit failures remain (also red on the base `vcpkg` branch; green on CI's POSIX runners).

## Not in scope (filing as separate `#1236` sub-tasks)
A *full* port-build e2e couldn't finish **on this ARM64 Windows host** (cross to x64): vcpkg defaults its host triplet to `arm64-windows` (needs `VCPKG_DEFAULT_HOST_TRIPLET`), and the SDK's x64 `rc.exe` fails under ARM64 emulation during CMake's manifest step. Also, blade's `get_resource_compiler` finds `rc` via `where` (PATH) rather than deriving it from the SDK, so it can't be auto-added to the vcpkg PATH from a bare shell. None of these are #1315 or reproduce on a normal x64 Windows host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)