### PR TITLE
vcpkg: native MSVC toolchain for ports + match debug lib names (#1236)

### DIFF
--- a/src/blade/build_manager.py
+++ b/src/blade/build_manager.py
@@ -351,17 +351,20 @@ class Blade:
                     os.path.join(self.__blade_path, 'blade')))
         return self.__blade_revision
 
+    def setup_vcpkg(self):
+        """Run the blade-managed `vcpkg install` (issue #1236).
+
+        Invoked as a stage between analyze and generate for building commands
+        (see main.py), so the installed artifacts exist when VcpkgLibrary
+        resolves its lib filenames during generation -- a port may add a debug
+        postfix (e.g. fmt -> fmtd.lib) that can't be predicted at parse time.
+        A no-op unless vcpkg_config(manage=True) with a non-empty packages list.
+        Errors are reported via console.error (the stage loop checks the log)."""
+        from blade import vcpkg
+        vcpkg.setup(self)
+
     def build(self):
         """Implement the "build" subcommand."""
-        # vcpkg orchestration (issue #1236): blade-managed `vcpkg install` runs
-        # here -- deferred from the load seam to the build phase, so commands
-        # that don't build (query/dump/clean) never install, and the install's
-        # progress shows in the build panel. VcpkgLibrary resolves paths
-        # optimistically during load; the artifacts are produced just before
-        # ninja links them. A no-op unless vcpkg_config(manage=True) with packages.
-        from blade import vcpkg
-        if not vcpkg.setup(self):
-            return 1
         console.info('Building...')
         console.flush()
         start_time = time.time()

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -12,6 +12,7 @@ of all of the cc targets, like cc_library, cc_binary.
 """
 
 
+import glob
 import os
 import pickle
 import sys
@@ -1925,6 +1926,43 @@ class VcpkgLibrary(PrebuiltCcLibrary):
         self.attr['dynamic_source'] = shared
         self.attr['dynamic_target'] = dynamic_target
         self._add_target_file(tc.DYNAMIC_LIB_LABEL, dynamic_target)
+
+    def _existing_lib(self, lib_dir, suffix):
+        """Resolve the actual lib file in `lib_dir` once `vcpkg install` has run.
+
+        A vcpkg port may add a debug postfix (CMAKE_DEBUG_POSTFIX -- e.g. fmt's
+        debug lib is fmtd.lib), so the debug/lib filename differs from release
+        and can't be predicted at parse time. Prefer the exact name, then the
+        conventional 'd' postfix, then a unique glob match; fall back to the
+        exact (optimistic) name so a genuinely missing lib still surfaces as
+        ninja's 'missing' error."""
+        tc = self.blade.get_build_toolchain()
+        base = f'{tc.lib_prefix}{self.name}'
+        exact = os.path.join(lib_dir, base + suffix)
+        if os.path.exists(exact):
+            return exact
+        postfixed = os.path.join(lib_dir, base + 'd' + suffix)
+        if os.path.exists(postfixed):
+            return postfixed
+        matches = glob.glob(os.path.join(lib_dir, base + '*' + suffix))
+        return matches[0] if len(matches) == 1 else exact
+
+    def _before_generate(self):  # override
+        super()._before_generate()
+        if self._vcpkg_header_only:
+            return
+        # `vcpkg install` runs before generation (a stage in main.py), so the
+        # real lib files now exist -- re-resolve the static archive in case the
+        # port added a debug postfix we couldn't predict during _setup() at parse
+        # time (e.g. an MSVC debug build's fmt -> fmtd.lib).
+        if self._vcpkg_linkage in ('static', 'auto'):
+            tc = self.blade.get_build_toolchain()
+            archive = self._existing_lib(self._vcpkg_lib_dir, tc.static_lib_suffix)
+            self.attr['static_source'] = archive
+            self._add_target_file(tc.STATIC_LIB_LABEL, archive)
+            if self._vcpkg_linkage == 'static':
+                # static: the archive serves both link modes (see _setup_static).
+                self._add_target_file(tc.DYNAMIC_LIB_LABEL, archive)
 
     def _vcpkg_wants_dynamic(self):
         """Whether this port's shared library should actually be materialized.

--- a/src/blade/main.py
+++ b/src/blade/main.py
@@ -77,8 +77,15 @@ def run_subcommand(blade_path, command, options, ws, targets):
     stages = [
         ('load', builder.load_targets),
         ('analyze', builder.analyze_targets),
-        ('generate', builder.generate),
     ]
+    # vcpkg-managed install runs after analyze (which marks the demanded shared
+    # ports) and BEFORE generate, so the installed artifacts exist on disk when
+    # VcpkgLibrary resolves its lib filenames -- a port may add a debug postfix
+    # (e.g. fmt's debug lib is fmtd.lib) that can't be predicted at parse time.
+    # Only for building commands; query/clean/dump never install.
+    if command in ('build', 'run', 'test'):
+        stages.append(('vcpkg', builder.setup_vcpkg))
+    stages.append(('generate', builder.generate))
     for stage, action in stages:
         action()
         if _check_error_log(stage):

--- a/src/blade/target.py
+++ b/src/blade/target.py
@@ -833,17 +833,23 @@ class Target:
         """
         outputs = var_to_list(outputs)
         implicit_outputs = var_to_list(implicit_outputs)
-        outs = outputs[:]
+        # Ninja treats ' ' as a token separator, ':' as the outputs/rule
+        # separator and '$' as the escape char, so paths carrying them (e.g. an
+        # absolute Windows path like C:\...\fmt.lib, or a spaced path) must be
+        # escaped. Relative POSIX-style paths are unaffected.
+        def esc(p):
+            return p.replace('$', '$$').replace(' ', '$ ').replace(':', '$:')
+        outs = [esc(o) for o in outputs]
         if implicit_outputs:
             outs.append('|')
-            outs += implicit_outputs
-        ins = var_to_list(inputs)
+            outs += [esc(o) for o in implicit_outputs]
+        ins = [esc(i) for i in var_to_list(inputs)]
         if implicit_deps:
             ins.append('|')
-            ins += var_to_list(implicit_deps)
+            ins += [esc(d) for d in var_to_list(implicit_deps)]
         if order_only_deps:
             ins.append('||')
-            ins += var_to_list(order_only_deps)
+            ins += [esc(d) for d in var_to_list(order_only_deps)]
         self._write_rule('build {}: {} {}'.format(' '.join(outs), rule, ' '.join(ins)))
         clean = (outputs + implicit_outputs) if clean is None else var_to_list(clean)
         if clean:

--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -342,16 +342,22 @@ def lib_subdir(triplet: str | None, profile: str) -> str:
 
 def overlay_triplet_cmake(target_os, target_arch, library_linkage='static',
                           dynamic_ports=(), cmake_options=None,
-                          build_type: str | None = 'release',
+                          build_type: str | None = 'release', chainload=True,
                           chainload_rel='../blade-chainload.cmake'):
-    """The overlay triplet `.cmake` that chainloads blade's compiler.
+    """The overlay triplet `.cmake` for a vanilla vcpkg triplet.
 
     Mirrors vcpkg's stock triplet for the OS (so ports detect the target
-    correctly) and adds the chainload toolchain. `library_linkage` is the
-    default ('static'); ports in `dynamic_ports` are overridden to dynamic, and
-    `cmake_options` ({port: [opts]}) sets per-port VCPKG_CMAKE_CONFIGURE_OPTIONS.
-    vcpkg re-evaluates the triplet per port, so `if(PORT ...)` guards give
-    per-port behavior. Returns None if os/arch is unsupported.
+    correctly). `library_linkage` is the default ('static'); ports in
+    `dynamic_ports` are overridden to dynamic, and `cmake_options` ({port:
+    [opts]}) sets per-port VCPKG_CMAKE_CONFIGURE_OPTIONS. vcpkg re-evaluates the
+    triplet per port, so `if(PORT ...)` guards give per-port behavior. Returns
+    None if os/arch is unsupported.
+
+    `chainload` adds the chainload toolchain that pins blade's compiler -- used
+    for gcc/clang/MinGW. For MSVC (cl.exe) it is False: a chainload would put
+    vcpkg in `external` toolset mode and make it SKIP its MSVC environment setup,
+    so CMake never gets mt.exe/rc.exe/INCLUDE/LIB and every port fails to link.
+    Letting vcpkg use its native MSVC support sets all of that up correctly.
     """
     arch = _VCPKG_ARCH.get(target_arch)
     if arch is None or target_os not in _VCPKG_OS:
@@ -382,8 +388,9 @@ def overlay_triplet_cmake(target_os, target_arch, library_linkage='static',
     if target_os == 'darwin':
         lines.append('set(VCPKG_OSX_ARCHITECTURES %s)'
                      % _VCPKG_OSX_ARCH.get(arch, arch))
-    lines.append('set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE '
-                 '${CMAKE_CURRENT_LIST_DIR}/%s)' % chainload_rel)
+    if chainload:
+        lines.append('set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE '
+                     '${CMAKE_CURRENT_LIST_DIR}/%s)' % chainload_rel)
     return '\n'.join(lines) + '\n'
 
 
@@ -571,11 +578,16 @@ def setup(builder):
     if not vanilla or vanilla == 'auto':
         vanilla = triplet_for_toolchain(toolchain)
     profile = builder.get_options().profile
+    # MSVC (cl.exe) uses vcpkg's native toolchain (no chainload) so vcpkg sets up
+    # the full MSVC environment; gcc/clang/MinGW are chainloaded to pin blade's
+    # compiler.
+    chainload = not toolchain.cc_is('msvc')
     triplet_cmake = (overlay_triplet_cmake(
         toolchain.target_os, toolchain.target_arch,
         dynamic_ports=dynamic_ports(packages),
         cmake_options=port_cmake_options(packages),
-        build_type=vcpkg_build_type(vanilla, profile)) if vanilla else None)
+        build_type=vcpkg_build_type(vanilla, profile),
+        chainload=chainload) if vanilla else None)
     if not vanilla or triplet_cmake is None:
         console.error('vcpkg: cannot derive a triplet for os=%s arch=%s; set '
                       'vcpkg_config(triplet=...)'
@@ -639,7 +651,7 @@ def setup(builder):
             cmd.append('--binarysource=' + binary_cache)
         console.info('vcpkg: installing %d package(s) for %s ...'
                      % (len(packages), overlay))
-        if not _run_install_with_progress(cmd, install_env(toolchain)):
+        if not _run_install_with_progress(cmd):
             return False
         with open(stamp_file, 'w') as f:
             f.write(stamp)
@@ -700,11 +712,13 @@ def _install_shared(vcpkg_bin, cfg, vanilla, ports, packages,
     import json
     from blade import console, util
     shared_overlay = shared_overlay_triplet_name(vanilla)
+    chainload = not toolchain.cc_is('msvc')
     triplet_cmake = overlay_triplet_cmake(
         toolchain.target_os, toolchain.target_arch,
         library_linkage='dynamic',
         cmake_options=port_cmake_options({p: packages[p] for p in ports}),
-        build_type=vcpkg_build_type(vanilla, profile))
+        build_type=vcpkg_build_type(vanilla, profile),
+        chainload=chainload)
     if triplet_cmake is None:  # pragma: no cover - main triplet already validated
         return True
     shared_base = os.path.join(base, 'shared')
@@ -742,60 +756,14 @@ def _install_shared(vcpkg_bin, cfg, vanilla, ports, packages,
         cmd.append('--binarysource=' + binary_cache)
     console.info('vcpkg: installing %d shared package(s) for %s ...'
                  % (len(ports), shared_overlay))
-    if not _run_install_with_progress(cmd, install_env(toolchain)):
+    if not _run_install_with_progress(cmd):
         return False
     with open(stamp_file, 'w') as f:
         f.write(stamp)
     return True
 
 
-def install_env(toolchain) -> dict | None:
-    """Subprocess environment for `vcpkg install`, or None to inherit os.environ.
-
-    On MSVC, ports are built by vcpkg's own cmake invoking the chainloaded
-    cl.exe / link.exe / rc.exe -- which need the Developer-Command-Prompt
-    environment that blade is normally launched without. The chainload toolchain
-    only pins the compiler, not the environment, so we reconstruct the essential
-    bits from blade's resolved toolchain:
-
-      * `INCLUDE` / `LIB` -- CRT + Windows SDK headers and libraries. Without LIB
-        every port fails to link (`LNK1104: cannot open file 'LIBCMT.lib'`).
-      * `VCPKG_KEEP_ENV_VARS` -- vcpkg scrubs the build environment; INCLUDE/LIB
-        must be whitelisted or they never reach the compiler.
-      * `PATH` -- the SDK + compiler tool dirs, so `rc.exe` (invoked unqualified
-        by CMake's manifest step) and the compiler's own DLLs resolve. PATH is
-        always inherited by vcpkg builds, so it needs no keep entry.
-
-    Non-MSVC toolchains need nothing (gcc/clang locate their own runtime), so
-    return None there."""
-    if not toolchain.cc_is('msvc'):
-        return None
-    inc = toolchain.get_system_include_paths()
-    lib = toolchain.get_system_lib_paths()
-    if not inc and not lib:
-        return None
-    env = dict(os.environ)
-    if inc:
-        env['INCLUDE'] = os.pathsep.join(inc)
-    if lib:
-        env['LIB'] = os.pathsep.join(lib)
-    keep = [v for v in env.get('VCPKG_KEEP_ENV_VARS', '').split(';') if v]
-    for v in ('INCLUDE', 'LIB'):
-        if v not in keep:
-            keep.append(v)
-    env['VCPKG_KEEP_ENV_VARS'] = ';'.join(keep)
-    bindirs = []
-    for key in ('cc', 'rc'):
-        path = toolchain.tool(key)
-        d = os.path.dirname(path) if path else ''
-        if d and d not in bindirs:
-            bindirs.append(d)
-    if bindirs:
-        env['PATH'] = os.pathsep.join(bindirs + [env.get('PATH', '')])
-    return env
-
-
-def _run_install_with_progress(cmd, env=None):
+def _run_install_with_progress(cmd):
     """Run `vcpkg install`, rendering its `Installing N/M ...` stream as blade's
     live build panel. Returns True on success; on failure prints the captured
     output and returns False. Off a TTY the panel is a no-op (CI logs show the
@@ -810,7 +778,7 @@ def _run_install_with_progress(cmd, env=None):
     total = 0
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT, text=True,
-                            errors='replace', bufsize=1, env=env)
+                            errors='replace', bufsize=1)
     start = time.time()
     assert proc.stdout is not None
     for line in proc.stdout:

--- a/src/tests/unit/vcpkg_manifest_test.py
+++ b/src/tests/unit/vcpkg_manifest_test.py
@@ -11,7 +11,6 @@ these files + invoking `vcpkg install` is wired separately (PR6)."""
 import os
 import sys
 import unittest
-import unittest.mock as mock
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
@@ -119,6 +118,16 @@ class OverlayTripletTest(unittest.TestCase):
         self.assertNotIn('VCPKG_BUILD_TYPE',
                          _overlay('windows', 'x64', build_type=None))
 
+    def test_chainload_present_by_default(self):
+        self.assertIn('VCPKG_CHAINLOAD_TOOLCHAIN_FILE', _overlay('linux', 'x86_64'))
+
+    def test_chainload_omitted_when_disabled(self):
+        # MSVC uses vcpkg's native toolchain -> no chainload, else vcpkg runs in
+        # `external` toolset mode and skips its MSVC env setup (mt/rc/INCLUDE/LIB),
+        # so ports fail to link.
+        self.assertNotIn('VCPKG_CHAINLOAD_TOOLCHAIN_FILE',
+                         _overlay('windows', 'x64', chainload=False))
+
 
 class MsvcDebugGateTest(unittest.TestCase):
     """The MSVC-ABI debug gate (issue #1315): is_msvc_abi_triplet /
@@ -221,48 +230,6 @@ class PortOptionsTest(unittest.TestCase):
             cmake_options={'snappy': ['-DSNAPPY_WITH_RTTI=ON']})
         self.assertIn('if(PORT STREQUAL "snappy")', t)
         self.assertIn('set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DSNAPPY_WITH_RTTI=ON")', t)
-
-
-class InstallEnvTest(unittest.TestCase):
-    """install_env: reconstruct the MSVC dev environment for `vcpkg install`."""
-
-    def _tc(self, vendor='msvc', inc=None, lib=None, tools=None):
-        tc = mock.Mock()
-        tc.cc_is = lambda v: v == vendor
-        tc.get_system_include_paths.return_value = inc or []
-        tc.get_system_lib_paths.return_value = lib or []
-        tc.tool = lambda k: (tools or {}).get(k)
-        return tc
-
-    def test_non_msvc_inherits_environment(self):
-        self.assertIsNone(vcpkg.install_env(self._tc(vendor='gcc')))
-
-    def test_msvc_without_discovered_paths_returns_none(self):
-        self.assertIsNone(vcpkg.install_env(self._tc()))
-
-    def test_msvc_sets_include_lib_keep_and_path(self):
-        tc = self._tc(inc=['I:/inc'], lib=['L:/lib'],
-                      tools={'cc': 'C:/vs/bin/cl.exe', 'rc': 'C:/sdk/bin/rc.exe'})
-        with mock.patch.dict(os.environ,
-                             {'PATH': 'P:/old', 'INCLUDE': '', 'LIB': '',
-                              'VCPKG_KEEP_ENV_VARS': ''}, clear=True):
-            env = vcpkg.install_env(tc)
-        self.assertEqual(env['INCLUDE'], 'I:/inc')
-        self.assertEqual(env['LIB'], 'L:/lib')
-        # vcpkg scrubs the build env -> INCLUDE/LIB must be whitelisted.
-        self.assertIn('INCLUDE', env['VCPKG_KEEP_ENV_VARS'].split(';'))
-        self.assertIn('LIB', env['VCPKG_KEEP_ENV_VARS'].split(';'))
-        # compiler + rc tool dirs prepended to PATH (so rc.exe etc. resolve).
-        self.assertIn('C:/vs/bin', env['PATH'])
-        self.assertIn('C:/sdk/bin', env['PATH'])
-        self.assertTrue(env['PATH'].endswith('P:/old'))
-
-    def test_keep_env_vars_preserves_existing(self):
-        tc = self._tc(inc=['I:/inc'], lib=['L:/lib'])
-        with mock.patch.dict(os.environ,
-                             {'VCPKG_KEEP_ENV_VARS': 'FOO'}, clear=True):
-            env = vcpkg.install_env(tc)
-        self.assertEqual(env['VCPKG_KEEP_ENV_VARS'].split(';'), ['FOO', 'INCLUDE', 'LIB'])
 
 
 class ChainloadTest(unittest.TestCase):

--- a/src/tests/unit/vcpkg_resolve_test.py
+++ b/src/tests/unit/vcpkg_resolve_test.py
@@ -290,5 +290,42 @@ class HandlerTest(unittest.TestCase):
         self.assertIn('vcpkg', target_mod._dep_scheme_providers)
 
 
+class VcpkgExistingLibTest(unittest.TestCase):
+    """VcpkgLibrary._existing_lib resolves the real lib file after install,
+    handling a port's debug postfix (issue #1315: fmt -> fmtd.lib)."""
+
+    def _lib(self):
+        from blade.cc_targets import VcpkgLibrary
+        t = VcpkgLibrary.__new__(VcpkgLibrary)
+        t.name = 'fmt'
+        tc = mock.Mock(); tc.lib_prefix = ''; tc.static_lib_suffix = '.lib'
+        t.blade = mock.Mock()
+        t.blade.get_build_toolchain.return_value = tc
+        return t
+
+    def _with_files(self, *names):
+        import tempfile
+        d = tempfile.mkdtemp()
+        self.addCleanup(__import__('shutil').rmtree, d, True)
+        for n in names:
+            open(os.path.join(d, n), 'w').close()
+        return d
+
+    def test_exact_name_preferred(self):
+        d = self._with_files('fmt.lib', 'fmtd.lib')
+        self.assertEqual(self._lib()._existing_lib(d, '.lib'),
+                         os.path.join(d, 'fmt.lib'))
+
+    def test_debug_postfix_when_no_exact(self):
+        d = self._with_files('fmtd.lib')  # only the 'd'-postfixed debug lib
+        self.assertEqual(self._lib()._existing_lib(d, '.lib'),
+                         os.path.join(d, 'fmtd.lib'))
+
+    def test_missing_falls_back_to_exact(self):
+        d = self._with_files()  # nothing yet -> optimistic exact name
+        self.assertEqual(self._lib()._existing_lib(d, '.lib'),
+                         os.path.join(d, 'fmt.lib'))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Sub-task of #1236, building on #1315/#1316. Targets the **`vcpkg`** branch. Makes blade-managed vcpkg actually build C++ ports on **Windows MSVC** end-to-end.

### The core fix — don't chainload MSVC
The overlay triplet set `VCPKG_CHAINLOAD_TOOLCHAIN_FILE` for *every* compiler. For MSVC that puts vcpkg in `external` toolset mode, so vcpkg **skips its MSVC environment setup** — CMake never gets `mt.exe`/`rc.exe`/`INCLUDE`/`LIB`, and every port dies with `CMAKE_MT-NOTFOUND` / `LNK1104`. `overlay_triplet_cmake` now **omits the chainload for MSVC** (`cc_is('msvc')`) and lets vcpkg use its **native MSVC support**, which sets all of that up correctly. gcc/clang/MinGW still chainload (to pin blade's compiler). This **supersedes the `install_env()`** env-reconstruction from #1316 (removed — vcpkg-native handles it, verified from a bare shell).

### Install before generate
`vcpkg install` moves from the build phase to a stage **between analyze and generate** (build/run/test only; query/clean/dump never install), so the artifacts exist when `VcpkgLibrary` resolves lib filenames.

### Match debug lib names (completes #1315)
Many ports add a debug postfix (`CMAKE_DEBUG_POSTFIX` — fmt's debug lib is **`fmtd.lib`**), so the `debug/lib` filename differs from release and can't be predicted at parse time. `VcpkgLibrary._before_generate` re-resolves the static archive against the installed tree: exact name → `d` postfix → unique glob.

### Ninja-escape paths
`generate_build` now escapes `' '`, `':'`, `'$'` in output/input paths, so an absolute Windows path (`C:\…\fmt.lib`) no longer breaks ninja on the drive-letter colon. Relative POSIX paths unchanged.

### Validation (Windows ARM64 + MSVC, real run)
`blade build -p debug` of a `cc_binary` depending on `vcpkg#fmt:fmt`:
- vcpkg installs fmt (**release + debug**),
- blade links the debug **`fmtd.lib`** from `debug/lib`,
- `hello.exe` runs → `hello vcpkg debug 42`. ✅

Unit tests added for the chainload toggle and the debug-postfix probe; pyright clean; no new unit-test failures (the pre-existing Windows path-separator failures are unchanged from the base `vcpkg` branch).

### Notes
- Needs the **ARM64 MSVC toolset** for native arm64 targets; x64 cross also works. vcpkg's own arm64-toolset detection for VS "18" preview is a separate environment matter.
- clang-cl-via-vcpkg (chainloaded MSVC-ABI) and the dynamic/shared debug-postfix are possible follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)