### PR TITLE
vcpkg: clang-cl support via msvc_config.use_clang (#1236)

### DIFF
--- a/doc/en/config.md
+++ b/doc/en/config.md
@@ -118,7 +118,7 @@ Common configuration parameters for all C/C++ build targets:
 **Purpose:** Specifies the default ``cc_toolchain_config`` name to use when
 ``--cc-toolchain=`` is not given on the command line. The value must match
 the ``name`` of a ``cc_toolchain_config()`` entry, or a toolchain kind
-(``gcc`` / ``clang`` / ``msvc`` / ``mingw`` / ``cygwin``).
+(``gcc`` / ``clang`` / ``msvc`` / ``clang-cl`` / ``mingw`` / ``cygwin``).
 
 **Override:** ``blade build --cc-toolchain=<name>`` takes precedence.
 
@@ -766,15 +766,16 @@ The `cc_toolchain_config()` function selects the C/C++ compiler toolchain. You c
 
 `kind` determines the **ToolChain class**, **flag syntax**, **deps style**, and **default target platform**:
 
-| kind     | flag syntax | deps style | default target |
-|----------|-------------|------------|----------------|
-| `gcc`    | GCC         | `gcc`      | host platform  |
-| `clang`  | GCC         | `gcc`      | host platform  |
-| `mingw`  | GCC         | `gcc`      | `windows`      |
-| `cygwin` | GCC         | `gcc`      | `windows`      |
-| `msvc`   | MSVC        | `msvc`     | `windows`      |
+| kind       | flag syntax | deps style | default target |
+|------------|-------------|------------|----------------|
+| `gcc`      | GCC         | `gcc`      | host platform  |
+| `clang`    | GCC         | `gcc`      | host platform  |
+| `mingw`    | GCC         | `gcc`      | `windows`      |
+| `cygwin`   | GCC         | `gcc`      | `windows`      |
+| `msvc`     | MSVC        | `msvc`     | `windows`      |
+| `clang-cl` | MSVC        | `msvc`     | `windows`      |
 
-`gcc` and `clang` both use the GCC-family toolchain class — they differ only in the compiler binary and detected vendor. `mingw` and `cygwin` are GCC-family toolchains targeting Windows.
+`gcc` and `clang` both use the GCC-family toolchain class — they differ only in the compiler binary and detected vendor. `mingw` and `cygwin` are GCC-family toolchains targeting Windows. `clang-cl` is LLVM's MSVC-compatible driver: it shares the MSVC ABI, cl-style flags, Windows SDK and vcpkg `*-windows*` triplet with `msvc`, and only swaps the tools (`clang-cl` / `lld-link` / `llvm-lib` for `cl` / `link` / `lib`).
 
 ### `prefix` — install prefix
 
@@ -788,10 +789,10 @@ This ensures a configured toolchain always pins to its own installation and won'
 ```python
 cc_toolchain_config(
     name   = 'gcc-13',      # Optional — used with --cc-toolchain=gcc-13 to select this config
-    kind   = 'gcc',         # 'gcc' | 'clang' | 'msvc' | 'mingw' | 'cygwin' (see table above)
+    kind   = 'gcc',         # 'gcc' | 'clang' | 'msvc' | 'clang-cl' | 'mingw' | 'cygwin' (see table above)
 
     target = 'linux',       # Optional — target platform: 'linux' | 'darwin' | 'windows'
-                            # Default: derived from host (mingw/cygwin/msvc always 'windows')
+                            # Default: derived from host (mingw/cygwin/msvc/clang-cl always 'windows')
 
     prefix     = '/opt/gcc-13',   # Optional — install prefix, scopes tool lookup (no PATH search)
     tool_prefix = '',             # Optional — tool name prefix for cross-compilation
@@ -802,7 +803,7 @@ cc_toolchain_config(
     ld     = ...,                 # Optional — derived from kind/target by default
     ar     = ...,
 
-    # MSVC-only (when kind='msvc')
+    # MSVC family only (when kind='msvc' or kind='clang-cl')
     msvc_version = '14.44',       # 'auto' or MSVC version prefix like '14.44'
     target_arch  = 'x64',         # 'auto' | 'x64' | 'x86' | 'arm64' | 'arm64ec'
 )
@@ -852,17 +853,27 @@ cc_toolchain_config(kind='clang')   # default toolchain
 
 ### Using clang-cl on Windows
 
-No special `kind` is needed — use `kind='msvc'` with a custom compiler:
+Use `kind='clang-cl'`. This reuses the whole MSVC path — ABI, cl-style flags,
+Windows SDK discovery and the vcpkg `*-windows*` triplet — but compiles with
+`clang-cl` and links/archives with `lld-link` / `llvm-lib` when available
+(falling back to MSVC's `link` / `lib` otherwise):
+
+```python
+cc_toolchain_config(kind='clang-cl')
+```
+
+The LLVM tools are located automatically: from `prefix` if set, else Visual
+Studio's bundled LLVM (`<vs>/VC/Tools/Llvm/<host>/bin`), else `PATH`. Point
+`prefix` at a standalone LLVM install to override:
 
 ```python
 cc_toolchain_config(
-    kind = 'msvc',
-    cc   = 'clang-cl.exe',
-    cxx  = 'clang-cl.exe',
+    kind   = 'clang-cl',
+    prefix = 'C:/Program Files/LLVM',   # looks for clang-cl.exe under <prefix>/bin
 )
 ```
 
-This skips Visual Studio auto-detection and uses clang-cl with MSVC-style flags.
+`msvc_version` and `target_arch` apply the same as for `kind='msvc'`.
 
 ### vcpkg_config
 

--- a/doc/en/config.md
+++ b/doc/en/config.md
@@ -118,7 +118,7 @@ Common configuration parameters for all C/C++ build targets:
 **Purpose:** Specifies the default ``cc_toolchain_config`` name to use when
 ``--cc-toolchain=`` is not given on the command line. The value must match
 the ``name`` of a ``cc_toolchain_config()`` entry, or a toolchain kind
-(``gcc`` / ``clang`` / ``msvc`` / ``clang-cl`` / ``mingw`` / ``cygwin``).
+(``gcc`` / ``clang`` / ``msvc`` / ``mingw`` / ``cygwin``).
 
 **Override:** ``blade build --cc-toolchain=<name>`` takes precedence.
 
@@ -491,6 +491,7 @@ MSVC-specific configuration, only effective on Windows:
 msvc_config(
     target_arch = 'x64',
     msvc_version = 'auto',
+    use_clang = False,
     cppflags = ['/MD', '/EHsc'],
     cxxflags = ['/std:c++17'],
     linkflags = ['/SUBSYSTEM:CONSOLE'],
@@ -531,6 +532,21 @@ all installed Visual Studio instances and selects the first one that provides a
 matching `VC/Tools/MSVC/<version>` directory.  This is useful for pinning a
 compatible toolset — for example, NVIDIA CUDA 13.2 officially supports MSVC 14.4x
 (VS 2022) but not MSVC 14.5x (VS 2026).
+
+#### `use_clang`: bool = False
+
+**Compile with `clang-cl` instead of `cl`.**
+
+When `True`, the MSVC toolchain compiles with `clang-cl` (LLVM's MSVC-compatible
+driver) and links/archives with `lld-link` / `llvm-lib` when present, falling
+back to MSVC's `link` / `lib` otherwise. Everything else — the MSVC ABI,
+cl-style flags, Windows SDK discovery and the vcpkg `*-windows*` triplet — is
+unchanged, so this is a drop-in compiler swap, not a different `kind`.
+
+The LLVM tools are located automatically from the Visual Studio install (its
+bundled LLVM under `VC/Tools/Llvm/<host>/bin`, picked for the host
+architecture), so no extra path configuration is needed. See [Using clang-cl on
+Windows](#using-clang-cl-on-windows).
 
 #### `cppflags`: list = ['/MD', '/EHsc']
 
@@ -766,16 +782,15 @@ The `cc_toolchain_config()` function selects the C/C++ compiler toolchain. You c
 
 `kind` determines the **ToolChain class**, **flag syntax**, **deps style**, and **default target platform**:
 
-| kind       | flag syntax | deps style | default target |
-|------------|-------------|------------|----------------|
-| `gcc`      | GCC         | `gcc`      | host platform  |
-| `clang`    | GCC         | `gcc`      | host platform  |
-| `mingw`    | GCC         | `gcc`      | `windows`      |
-| `cygwin`   | GCC         | `gcc`      | `windows`      |
-| `msvc`     | MSVC        | `msvc`     | `windows`      |
-| `clang-cl` | MSVC        | `msvc`     | `windows`      |
+| kind     | flag syntax | deps style | default target |
+|----------|-------------|------------|----------------|
+| `gcc`    | GCC         | `gcc`      | host platform  |
+| `clang`  | GCC         | `gcc`      | host platform  |
+| `mingw`  | GCC         | `gcc`      | `windows`      |
+| `cygwin` | GCC         | `gcc`      | `windows`      |
+| `msvc`   | MSVC        | `msvc`     | `windows`      |
 
-`gcc` and `clang` both use the GCC-family toolchain class — they differ only in the compiler binary and detected vendor. `mingw` and `cygwin` are GCC-family toolchains targeting Windows. `clang-cl` is LLVM's MSVC-compatible driver: it shares the MSVC ABI, cl-style flags, Windows SDK and vcpkg `*-windows*` triplet with `msvc`, and only swaps the tools (`clang-cl` / `lld-link` / `llvm-lib` for `cl` / `link` / `lib`).
+`gcc` and `clang` both use the GCC-family toolchain class — they differ only in the compiler binary and detected vendor. `mingw` and `cygwin` are GCC-family toolchains targeting Windows. To compile with `clang-cl` (LLVM's MSVC-compatible driver), keep `kind='msvc'` and set [`msvc_config.use_clang`](#use_clang-bool--false) — it is the same MSVC toolchain with LLVM's tools, not a separate kind.
 
 ### `prefix` — install prefix
 
@@ -789,10 +804,10 @@ This ensures a configured toolchain always pins to its own installation and won'
 ```python
 cc_toolchain_config(
     name   = 'gcc-13',      # Optional — used with --cc-toolchain=gcc-13 to select this config
-    kind   = 'gcc',         # 'gcc' | 'clang' | 'msvc' | 'clang-cl' | 'mingw' | 'cygwin' (see table above)
+    kind   = 'gcc',         # 'gcc' | 'clang' | 'msvc' | 'mingw' | 'cygwin' (see table above)
 
     target = 'linux',       # Optional — target platform: 'linux' | 'darwin' | 'windows'
-                            # Default: derived from host (mingw/cygwin/msvc/clang-cl always 'windows')
+                            # Default: derived from host (mingw/cygwin/msvc always 'windows')
 
     prefix     = '/opt/gcc-13',   # Optional — install prefix, scopes tool lookup (no PATH search)
     tool_prefix = '',             # Optional — tool name prefix for cross-compilation
@@ -803,7 +818,7 @@ cc_toolchain_config(
     ld     = ...,                 # Optional — derived from kind/target by default
     ar     = ...,
 
-    # MSVC family only (when kind='msvc' or kind='clang-cl')
+    # MSVC-only (when kind='msvc')
     msvc_version = '14.44',       # 'auto' or MSVC version prefix like '14.44'
     target_arch  = 'x64',         # 'auto' | 'x64' | 'x86' | 'arm64' | 'arm64ec'
 )
@@ -853,27 +868,21 @@ cc_toolchain_config(kind='clang')   # default toolchain
 
 ### Using clang-cl on Windows
 
-Use `kind='clang-cl'`. This reuses the whole MSVC path — ABI, cl-style flags,
-Windows SDK discovery and the vcpkg `*-windows*` triplet — but compiles with
-`clang-cl` and links/archives with `lld-link` / `llvm-lib` when available
-(falling back to MSVC's `link` / `lib` otherwise):
+`clang-cl` is not a separate `kind` — it is the MSVC toolchain compiled with
+LLVM's cl-compatible driver. Keep `kind='msvc'` (or just rely on Windows
+auto-detection) and turn it on in `msvc_config`:
 
 ```python
-cc_toolchain_config(kind='clang-cl')
+msvc_config(use_clang = True)
 ```
 
-The LLVM tools are located automatically: from `prefix` if set, else Visual
-Studio's bundled LLVM (`<vs>/VC/Tools/Llvm/<host>/bin`), else `PATH`. Point
-`prefix` at a standalone LLVM install to override:
-
-```python
-cc_toolchain_config(
-    kind   = 'clang-cl',
-    prefix = 'C:/Program Files/LLVM',   # looks for clang-cl.exe under <prefix>/bin
-)
-```
-
-`msvc_version` and `target_arch` apply the same as for `kind='msvc'`.
+This reuses the whole MSVC path — ABI, cl-style flags, Windows SDK discovery and
+the vcpkg `*-windows*` triplet — but compiles with `clang-cl` and links/archives
+with `lld-link` / `llvm-lib` when available (falling back to MSVC's `link` /
+`lib` otherwise). The LLVM tools are located automatically from the Visual
+Studio install (its bundled LLVM under `VC/Tools/Llvm/<host>/bin`, picked for the
+host architecture), so no path configuration is needed. `msvc_version` and
+`target_arch` apply exactly as for plain MSVC.
 
 ### vcpkg_config
 

--- a/doc/zh_CN/config.md
+++ b/doc/zh_CN/config.md
@@ -129,7 +129,7 @@ global_config(
 **用途：** 指定命令行未提供 ``--cc-toolchain=`` 时使用的默认
 ``cc_toolchain_config`` 名称。值必须匹配某个 ``cc_toolchain_config()``
 的 ``name``，或者是一种工具链种类（``gcc`` / ``clang`` / ``msvc`` /
-``clang-cl`` / ``mingw`` / ``cygwin``）。
+``mingw`` / ``cygwin``）。
 
 **覆盖：** ``blade build --cc-toolchain=<name>`` 优先级更高。
 
@@ -495,6 +495,7 @@ MSVC 专有配置，仅在 Windows 下生效：
 msvc_config(
     target_arch = 'x64',
     msvc_version = 'auto',
+    use_clang = False,
     cppflags = ['/MD', '/EHsc'],
     cxxflags = ['/std:c++17'],
     linkflags = ['/SUBSYSTEM:CONSOLE'],
@@ -531,6 +532,18 @@ msvc_config(
 当 `msvc_version` 设置为特定前缀（如 `'14.44'`）时，Blade 会枚举所有已安装的 Visual Studio
 实例，选择首个 `VC/Tools/MSVC/<version>` 目录匹配的版本。这对于锁定兼容的工具集非常有用——
 例如 NVIDIA CUDA 13.2 官方支持 MSVC 14.4x（VS 2022），但不支持 MSVC 14.5x（VS 2026）。
+
+#### `use_clang`：bool = False
+
+**使用 `clang-cl` 而非 `cl` 进行编译**
+
+设为 `True` 时，MSVC 工具链改用 `clang-cl`（LLVM 的 MSVC 兼容驱动）编译，并在可用时用
+`lld-link` / `llvm-lib` 链接和打包（否则回退到 MSVC 的 `link` / `lib`）。其余部分——MSVC
+ABI、cl 风格选项、Windows SDK 查找以及 vcpkg 的 `*-windows*` triplet——保持不变，因此这只是
+替换编译器，并非另一种 `kind`。
+
+LLVM 工具会从 Visual Studio 安装自动定位（其自带的 LLVM，位于 `VC/Tools/Llvm/<host>/bin`，
+按宿主机架构选取），无需额外配置路径。参见[在 Windows 上使用 clang-cl](#在-windows-上使用-clang-cl)。
 
 #### `cppflags`：list = ['/MD', '/EHsc']
 
@@ -770,16 +783,15 @@ cc_config(
 
 `kind` 决定 **ToolChain 类**、**编译选项风格**、**依赖风格**和**默认目标平台**：
 
-| kind       | 选项风格 | 依赖风格 | 默认目标   |
-|------------|----------|----------|------------|
-| `gcc`      | GCC      | `gcc`    | 宿主机平台 |
-| `clang`    | GCC      | `gcc`    | 宿主机平台 |
-| `mingw`    | GCC      | `gcc`    | `windows`  |
-| `cygwin`   | GCC      | `gcc`    | `windows`  |
-| `msvc`     | MSVC     | `msvc`   | `windows`  |
-| `clang-cl` | MSVC     | `msvc`   | `windows`  |
+| kind     | 选项风格 | 依赖风格 | 默认目标   |
+|----------|----------|----------|------------|
+| `gcc`    | GCC      | `gcc`    | 宿主机平台 |
+| `clang`  | GCC      | `gcc`    | 宿主机平台 |
+| `mingw`  | GCC      | `gcc`    | `windows`  |
+| `cygwin` | GCC      | `gcc`    | `windows`  |
+| `msvc`   | MSVC     | `msvc`   | `windows`  |
 
-`gcc` 和 `clang` 使用相同的 GCC 家族工具链类，区别仅在于编译器二进制文件和检测到的厂商。`mingw` 和 `cygwin` 是面向 Windows 的 GCC 家族工具链。`clang-cl` 是 LLVM 的 MSVC 兼容驱动：与 `msvc` 共用 MSVC ABI、cl 风格选项、Windows SDK 以及 vcpkg 的 `*-windows*` triplet，仅将工具替换为 `clang-cl` / `lld-link` / `llvm-lib`（对应 `cl` / `link` / `lib`）。
+`gcc` 和 `clang` 使用相同的 GCC 家族工具链类，区别仅在于编译器二进制文件和检测到的厂商。`mingw` 和 `cygwin` 是面向 Windows 的 GCC 家族工具链。如需用 `clang-cl`（LLVM 的 MSVC 兼容驱动）编译，保持 `kind='msvc'` 并设置 [`msvc_config.use_clang`](#use_clangbool--false)——它是搭配 LLVM 工具的同一套 MSVC 工具链，并非独立的 kind。
 
 ### `prefix` — 安装前缀
 
@@ -793,10 +805,10 @@ cc_config(
 ```python
 cc_toolchain_config(
     name   = 'gcc-13',      # 可选 — 配合 --cc-toolchain=gcc-13 选择此配置
-    kind   = 'gcc',         # 'gcc' | 'clang' | 'msvc' | 'clang-cl' | 'mingw' | 'cygwin'（参见上表）
+    kind   = 'gcc',         # 'gcc' | 'clang' | 'msvc' | 'mingw' | 'cygwin'（参见上表）
 
     target = 'linux',       # 可选 — 目标平台: 'linux' | 'darwin' | 'windows'
-                            # 默认: 由 host 推导 (mingw/cygwin/msvc/clang-cl 始终为 'windows')
+                            # 默认: 由 host 推导 (mingw/cygwin/msvc 始终为 'windows')
 
     prefix     = '/opt/gcc-13',   # 可选 — 安装前缀，限定工具查找范围（不搜索 PATH）
     tool_prefix = '',             # 可选 — 交叉编译工具名前缀
@@ -807,7 +819,7 @@ cc_toolchain_config(
     ld     = ...,                 # 可选 — 默认由 kind/target 推导
     ar     = ...,
 
-    # 仅 MSVC 家族 (kind='msvc' 或 kind='clang-cl' 时)
+    # 仅 MSVC (kind='msvc' 时)
     msvc_version = '14.44',       # 'auto' 或 MSVC 版本前缀，如 '14.44'
     target_arch  = 'x64',         # 'auto' | 'x64' | 'x86' | 'arm64' | 'arm64ec'
 )
@@ -855,26 +867,18 @@ cc_toolchain_config(kind='clang')   # 默认工具链
 
 ### 在 Windows 上使用 clang-cl
 
-使用 `kind='clang-cl'`。它完整复用 MSVC 路径——ABI、cl 风格选项、Windows SDK
-查找以及 vcpkg 的 `*-windows*` triplet——但用 `clang-cl` 编译，并在可用时用
-`lld-link` / `llvm-lib` 链接和打包（否则回退到 MSVC 的 `link` / `lib`）：
+`clang-cl` 不是独立的 `kind`，而是用 LLVM 的 cl 兼容驱动编译的 MSVC 工具链。保持
+`kind='msvc'`（或直接依赖 Windows 自动检测），在 `msvc_config` 中开启即可：
 
 ```python
-cc_toolchain_config(kind='clang-cl')
+msvc_config(use_clang = True)
 ```
 
-LLVM 工具会自动定位：优先使用 `prefix`（若设置），其次是 Visual Studio 自带的
-LLVM（`<vs>/VC/Tools/Llvm/<host>/bin`），最后是 `PATH`。如需指定独立的 LLVM
-安装，把 `prefix` 指向它即可：
-
-```python
-cc_toolchain_config(
-    kind   = 'clang-cl',
-    prefix = 'C:/Program Files/LLVM',   # 在 <prefix>/bin 下查找 clang-cl.exe
-)
-```
-
-`msvc_version` 和 `target_arch` 的用法与 `kind='msvc'` 时相同。
+它完整复用 MSVC 路径——ABI、cl 风格选项、Windows SDK 查找以及 vcpkg 的
+`*-windows*` triplet——但用 `clang-cl` 编译，并在可用时用 `lld-link` / `llvm-lib`
+链接和打包（否则回退到 MSVC 的 `link` / `lib`）。LLVM 工具会从 Visual Studio
+安装自动定位（其自带的 LLVM，位于 `VC/Tools/Llvm/<host>/bin`，按宿主机架构选取），
+无需配置路径。`msvc_version` 和 `target_arch` 的用法与普通 MSVC 完全相同。
 
 ### vcpkg_config
 

--- a/doc/zh_CN/config.md
+++ b/doc/zh_CN/config.md
@@ -129,7 +129,7 @@ global_config(
 **用途：** 指定命令行未提供 ``--cc-toolchain=`` 时使用的默认
 ``cc_toolchain_config`` 名称。值必须匹配某个 ``cc_toolchain_config()``
 的 ``name``，或者是一种工具链种类（``gcc`` / ``clang`` / ``msvc`` /
-``mingw`` / ``cygwin``）。
+``clang-cl`` / ``mingw`` / ``cygwin``）。
 
 **覆盖：** ``blade build --cc-toolchain=<name>`` 优先级更高。
 
@@ -770,15 +770,16 @@ cc_config(
 
 `kind` 决定 **ToolChain 类**、**编译选项风格**、**依赖风格**和**默认目标平台**：
 
-| kind     | 选项风格 | 依赖风格 | 默认目标   |
-|----------|----------|----------|------------|
-| `gcc`    | GCC      | `gcc`    | 宿主机平台 |
-| `clang`  | GCC      | `gcc`    | 宿主机平台 |
-| `mingw`  | GCC      | `gcc`    | `windows`  |
-| `cygwin` | GCC      | `gcc`    | `windows`  |
-| `msvc`   | MSVC     | `msvc`   | `windows`  |
+| kind       | 选项风格 | 依赖风格 | 默认目标   |
+|------------|----------|----------|------------|
+| `gcc`      | GCC      | `gcc`    | 宿主机平台 |
+| `clang`    | GCC      | `gcc`    | 宿主机平台 |
+| `mingw`    | GCC      | `gcc`    | `windows`  |
+| `cygwin`   | GCC      | `gcc`    | `windows`  |
+| `msvc`     | MSVC     | `msvc`   | `windows`  |
+| `clang-cl` | MSVC     | `msvc`   | `windows`  |
 
-`gcc` 和 `clang` 使用相同的 GCC 家族工具链类，区别仅在于编译器二进制文件和检测到的厂商。`mingw` 和 `cygwin` 是面向 Windows 的 GCC 家族工具链。
+`gcc` 和 `clang` 使用相同的 GCC 家族工具链类，区别仅在于编译器二进制文件和检测到的厂商。`mingw` 和 `cygwin` 是面向 Windows 的 GCC 家族工具链。`clang-cl` 是 LLVM 的 MSVC 兼容驱动：与 `msvc` 共用 MSVC ABI、cl 风格选项、Windows SDK 以及 vcpkg 的 `*-windows*` triplet，仅将工具替换为 `clang-cl` / `lld-link` / `llvm-lib`（对应 `cl` / `link` / `lib`）。
 
 ### `prefix` — 安装前缀
 
@@ -792,10 +793,10 @@ cc_config(
 ```python
 cc_toolchain_config(
     name   = 'gcc-13',      # 可选 — 配合 --cc-toolchain=gcc-13 选择此配置
-    kind   = 'gcc',         # 'gcc' | 'clang' | 'msvc' | 'mingw' | 'cygwin'（参见上表）
+    kind   = 'gcc',         # 'gcc' | 'clang' | 'msvc' | 'clang-cl' | 'mingw' | 'cygwin'（参见上表）
 
     target = 'linux',       # 可选 — 目标平台: 'linux' | 'darwin' | 'windows'
-                            # 默认: 由 host 推导 (mingw/cygwin/msvc 始终为 'windows')
+                            # 默认: 由 host 推导 (mingw/cygwin/msvc/clang-cl 始终为 'windows')
 
     prefix     = '/opt/gcc-13',   # 可选 — 安装前缀，限定工具查找范围（不搜索 PATH）
     tool_prefix = '',             # 可选 — 交叉编译工具名前缀
@@ -806,7 +807,7 @@ cc_toolchain_config(
     ld     = ...,                 # 可选 — 默认由 kind/target 推导
     ar     = ...,
 
-    # 仅 MSVC (kind='msvc' 时)
+    # 仅 MSVC 家族 (kind='msvc' 或 kind='clang-cl' 时)
     msvc_version = '14.44',       # 'auto' 或 MSVC 版本前缀，如 '14.44'
     target_arch  = 'x64',         # 'auto' | 'x64' | 'x86' | 'arm64' | 'arm64ec'
 )
@@ -854,17 +855,26 @@ cc_toolchain_config(kind='clang')   # 默认工具链
 
 ### 在 Windows 上使用 clang-cl
 
-无需新增 kind，使用 `kind='msvc'` 并指定自定义编译器即可：
+使用 `kind='clang-cl'`。它完整复用 MSVC 路径——ABI、cl 风格选项、Windows SDK
+查找以及 vcpkg 的 `*-windows*` triplet——但用 `clang-cl` 编译，并在可用时用
+`lld-link` / `llvm-lib` 链接和打包（否则回退到 MSVC 的 `link` / `lib`）：
+
+```python
+cc_toolchain_config(kind='clang-cl')
+```
+
+LLVM 工具会自动定位：优先使用 `prefix`（若设置），其次是 Visual Studio 自带的
+LLVM（`<vs>/VC/Tools/Llvm/<host>/bin`），最后是 `PATH`。如需指定独立的 LLVM
+安装，把 `prefix` 指向它即可：
 
 ```python
 cc_toolchain_config(
-    kind = 'msvc',
-    cc   = 'clang-cl.exe',
-    cxx  = 'clang-cl.exe',
+    kind   = 'clang-cl',
+    prefix = 'C:/Program Files/LLVM',   # 在 <prefix>/bin 下查找 clang-cl.exe
 )
 ```
 
-这会跳过 Visual Studio 自动检测，直接使用 clang-cl 并采用 MSVC 风格的编译选项。
+`msvc_version` 和 `target_arch` 的用法与 `kind='msvc'` 时相同。
 
 ### vcpkg_config
 

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -383,6 +383,14 @@ _CONFIG_TEMPLATE = {
             'Target architecture: auto (detect from host), x64, x86, arm64, arm64ec',
         'msvc_version': 'auto',
         'msvc_version__help__': 'MSVC compiler version prefix (auto, 14.44, 14.51, ...)',
+        # Compile with clang-cl (LLVM's MSVC-compatible driver) instead of cl,
+        # linking/archiving with lld-link / llvm-lib when present. Same MSVC ABI,
+        # flags, SDK and vcpkg triplet -- only the tools change. The tools are
+        # auto-located from the Visual Studio install (its bundled LLVM), so no
+        # extra path configuration is needed.
+        'use_clang': False,
+        'use_clang__help__':
+            'Compile with clang-cl instead of cl (same MSVC ABI/flags/SDK)',
         'windows_sdk': 'auto',
         'windows_sdk__help__': 'Windows SDK version (auto, 10.0, etc.)',
         'visual_studio': 'auto',

--- a/src/blade/toolchain.py
+++ b/src/blade/toolchain.py
@@ -1430,7 +1430,65 @@ def _classify_msvc_directive(line: str) -> 'str | None':
     return value.lower() or None
 
 
-_CC_TOOLCHAIN_KINDS = {'gcc', 'clang', 'msvc', 'mingw', 'cygwin'}
+class ClangClToolChain(MsvcToolChain):
+    """clang-cl: LLVM's MSVC-compatible driver.
+
+    Same MSVC ABI, cl-style flags and Windows SDK as ``MsvcToolChain`` -- so the
+    MSVC flag path, the SDK include/lib discovery, the vcpkg native-MSVC path and
+    the debug-lib matching all apply unchanged. Only the *tools* differ:
+    clang-cl / lld-link / llvm-lib instead of cl / link / lib. The vendor stays
+    'msvc' (clang-cl is cl-compatible), so every ``cc_is('msvc')`` branch and the
+    `*-windows*` vcpkg triplet are reused as-is.
+    """
+
+    def __init__(self, target_arch='auto', msvc_version='auto', prefix=''):
+        super().__init__(target_arch=target_arch, msvc_version=msvc_version)
+        bindir = self._find_llvm_bindir(prefix)
+        self.cc = self._llvm_tool(bindir, 'clang-cl') or 'clang-cl'
+        self.cxx = self.cc
+        # Prefer LLVM's linker/librarian; fall back to MSVC's (already resolved
+        # by the MsvcToolChain base) when the LLVM ones aren't present.
+        self.ld = self._llvm_tool(bindir, 'lld-link') or self.ld
+        self.ar = self._llvm_tool(bindir, 'llvm-lib') or self.ar
+        self.cc_version = self._get_clang_cl_version()
+
+    def _find_llvm_bindir(self, prefix):
+        """Locate the LLVM bin dir: an explicit prefix, else VS's bundled LLVM
+        (``<vs>/VC/Tools/Llvm/<host>/bin``), else PATH."""
+        import shutil
+        if prefix:
+            for cand in (os.path.join(prefix, 'bin'), prefix):
+                if os.path.isfile(os.path.join(cand, 'clang-cl.exe')):
+                    return cand
+        if self._vs_path:
+            host = {'x64': 'x64', 'x86': 'x86', 'arm64': 'ARM64'}.get(
+                self.host_arch, 'x64')
+            cand = os.path.join(self._vs_path, 'VC', 'Tools', 'Llvm', host, 'bin')
+            if os.path.isfile(os.path.join(cand, 'clang-cl.exe')):
+                return cand
+        found = shutil.which('clang-cl')
+        return os.path.dirname(found) if found else ''
+
+    @staticmethod
+    def _llvm_tool(bindir, name):
+        import shutil
+        if bindir:
+            path = os.path.join(bindir, name + '.exe')
+            if os.path.isfile(path):
+                return path
+        return shutil.which(name) or ''
+
+    def _get_clang_cl_version(self):
+        import re
+        rc, out, err = run_command([self.cc, '--version'])
+        if rc == 0:
+            m = re.search(r'version\s+(\S+)', (out or '') + (err or ''))
+            if m:
+                return m.group(1)
+        return 'unknown'
+
+
+_CC_TOOLCHAIN_KINDS = {'gcc', 'clang', 'msvc', 'mingw', 'cygwin', 'clang-cl'}
 
 _HOST_TARGET_MAP = {
     'linux': 'linux',
@@ -1444,7 +1502,7 @@ _HOST_TARGET_MAP = {
 
 def _default_target_for_kind(kind):
     """Default ``target`` for a given toolchain *kind*."""
-    if kind in ('mingw', 'cygwin', 'msvc'):
+    if kind in ('mingw', 'cygwin', 'msvc', 'clang-cl'):
         return 'windows'
     return _HOST_TARGET_MAP.get(sys.platform, 'linux')
 
@@ -1551,12 +1609,15 @@ def create_toolchain(cc_toolchain=''):
     if cfg is None and cc_toolchain in _CC_TOOLCHAIN_KINDS:
         kind = cc_toolchain
 
-    if kind == 'msvc':
+    if kind in ('msvc', 'clang-cl'):
         msvc_config = blade_config.get_section('msvc_config')
         target_arch = (target_arch or
                        msvc_config.get('target_arch', 'auto'))
         msvc_version = (msvc_version or
                         msvc_config.get('msvc_version', 'auto'))
+        if kind == 'clang-cl':
+            return ClangClToolChain(target_arch=target_arch,
+                                    msvc_version=msvc_version, prefix=prefix)
         return MsvcToolChain(target_arch=target_arch, msvc_version=msvc_version)
 
     return GccToolChain(

--- a/src/blade/toolchain.py
+++ b/src/blade/toolchain.py
@@ -1439,6 +1439,11 @@ class ClangClToolChain(MsvcToolChain):
     clang-cl / lld-link / llvm-lib instead of cl / link / lib. The vendor stays
     'msvc' (clang-cl is cl-compatible), so every ``cc_is('msvc')`` branch and the
     `*-windows*` vcpkg triplet are reused as-is.
+
+    This is not a separate toolchain *kind*: clang-cl ships inside Visual Studio
+    at a fixed, host-native location, so it is selected by setting
+    ``msvc_config.use_clang = True`` alongside ``kind='msvc'`` -- no extra path
+    configuration needed.
     """
 
     def __init__(self, target_arch='auto', msvc_version='auto', prefix=''):
@@ -1488,7 +1493,7 @@ class ClangClToolChain(MsvcToolChain):
         return 'unknown'
 
 
-_CC_TOOLCHAIN_KINDS = {'gcc', 'clang', 'msvc', 'mingw', 'cygwin', 'clang-cl'}
+_CC_TOOLCHAIN_KINDS = {'gcc', 'clang', 'msvc', 'mingw', 'cygwin'}
 
 _HOST_TARGET_MAP = {
     'linux': 'linux',
@@ -1502,7 +1507,7 @@ _HOST_TARGET_MAP = {
 
 def _default_target_for_kind(kind):
     """Default ``target`` for a given toolchain *kind*."""
-    if kind in ('mingw', 'cygwin', 'msvc', 'clang-cl'):
+    if kind in ('mingw', 'cygwin', 'msvc'):
         return 'windows'
     return _HOST_TARGET_MAP.get(sys.platform, 'linux')
 
@@ -1609,13 +1614,15 @@ def create_toolchain(cc_toolchain=''):
     if cfg is None and cc_toolchain in _CC_TOOLCHAIN_KINDS:
         kind = cc_toolchain
 
-    if kind in ('msvc', 'clang-cl'):
+    if kind == 'msvc':
         msvc_config = blade_config.get_section('msvc_config')
         target_arch = (target_arch or
                        msvc_config.get('target_arch', 'auto'))
         msvc_version = (msvc_version or
                         msvc_config.get('msvc_version', 'auto'))
-        if kind == 'clang-cl':
+        # clang-cl is not a separate kind: it is the same MSVC toolchain with
+        # LLVM's cl-compatible tools, toggled by msvc_config.use_clang.
+        if msvc_config.get('use_clang', False):
             return ClangClToolChain(target_arch=target_arch,
                                     msvc_version=msvc_version, prefix=prefix)
         return MsvcToolChain(target_arch=target_arch, msvc_version=msvc_version)

--- a/src/tests/unit/toolchain_test.py
+++ b/src/tests/unit/toolchain_test.py
@@ -312,5 +312,38 @@ class ResolveConfigFallbackTest(unittest.TestCase):
         self.assertEqual(cc, '/opt/clang/bin/clang')
 
 
+class ClangClToolChainTest(unittest.TestCase):
+    """clang-cl is an MSVC-family kind (issue #1236): same MSVC ABI/flags, only
+    the tools differ. Full construction needs a VS install (Windows-only), so
+    here we pin the registration + the pure tool-resolution helpers."""
+
+    def test_kind_registered_and_targets_windows(self):
+        from blade import toolchain
+        self.assertIn('clang-cl', toolchain._CC_TOOLCHAIN_KINDS)
+        self.assertEqual(toolchain._default_target_for_kind('clang-cl'), 'windows')
+
+    def test_llvm_tool_prefers_bindir(self):
+        from blade.toolchain import ClangClToolChain
+        import tempfile
+        import shutil as _sh
+        d = tempfile.mkdtemp()
+        self.addCleanup(_sh.rmtree, d, True)
+        open(os.path.join(d, 'lld-link.exe'), 'w').close()
+        self.assertEqual(ClangClToolChain._llvm_tool(d, 'lld-link'),
+                         os.path.join(d, 'lld-link.exe'))
+
+    def test_llvm_tool_absent_falls_back_to_path_lookup(self):
+        from blade.toolchain import ClangClToolChain
+        import tempfile
+        import shutil as _sh
+        d = tempfile.mkdtemp()
+        self.addCleanup(_sh.rmtree, d, True)
+        with mock.patch('shutil.which', return_value='/usr/bin/lld-link'):
+            self.assertEqual(ClangClToolChain._llvm_tool(d, 'lld-link'),
+                             '/usr/bin/lld-link')
+        with mock.patch('shutil.which', return_value=None):
+            self.assertEqual(ClangClToolChain._llvm_tool(d, 'lld-link'), '')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/tests/unit/toolchain_test.py
+++ b/src/tests/unit/toolchain_test.py
@@ -313,14 +313,14 @@ class ResolveConfigFallbackTest(unittest.TestCase):
 
 
 class ClangClToolChainTest(unittest.TestCase):
-    """clang-cl is an MSVC-family kind (issue #1236): same MSVC ABI/flags, only
-    the tools differ. Full construction needs a VS install (Windows-only), so
-    here we pin the registration + the pure tool-resolution helpers."""
+    """clang-cl is the MSVC toolchain with LLVM's cl-compatible tools, toggled by
+    ``msvc_config.use_clang`` -- it is NOT a separate kind (issue #1236). Full
+    construction needs a VS install (Windows-only), so here we pin that it stays
+    out of the kind set and the pure tool-resolution helpers."""
 
-    def test_kind_registered_and_targets_windows(self):
+    def test_clang_cl_is_not_a_toolchain_kind(self):
         from blade import toolchain
-        self.assertIn('clang-cl', toolchain._CC_TOOLCHAIN_KINDS)
-        self.assertEqual(toolchain._default_target_for_kind('clang-cl'), 'windows')
+        self.assertNotIn('clang-cl', toolchain._CC_TOOLCHAIN_KINDS)
 
     def test_llvm_tool_prefers_bindir(self):
         from blade.toolchain import ClangClToolChain


### PR DESCRIPTION
## What

Adds **clang-cl** support — LLVM's MSVC-compatible driver — as part of the Windows/vcpkg work (#1236).

clang-cl shares the MSVC ABI, cl-style flags, Windows SDK and the vcpkg `*-windows*` triplet with regular MSVC; only the *tools* differ (`clang-cl` / `lld-link` / `llvm-lib` instead of `cl` / `link` / `lib`). Since it ships inside Visual Studio at a fixed, host-native path (`VC/Tools/Llvm/<host>/bin`), it is **not** modeled as a separate toolchain `kind`.

Instead it is a flag on the MSVC toolchain: set **`msvc_config.use_clang = True`** with `kind='msvc'` (or rely on Windows auto-detection). `create_toolchain` then builds `ClangClToolChain` — which auto-locates the bundled LLVM by host arch and falls back to MSVC's `link`/`lib` when the LLVM linker/librarian aren't present — instead of `MsvcToolChain`.

## Usage

```python
msvc_config(use_clang = True)
```

No path configuration needed; `msvc_version` / `target_arch` apply exactly as for plain MSVC.

## Tests

`ClangClToolChainTest` pins that `clang-cl` stays out of the kind set and covers the pure `_llvm_tool` resolution (bindir preference + PATH fallback). Toolchain + MSVC unit tests pass (45).

## Docs

`doc/en/config.md` + `doc/zh_CN/config.md`: document the `msvc_config.use_clang` field and a rewritten "Using clang-cl on Windows" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)