### PR TITLE
doc: move vcpkg guide under build_rules/ + highlight vcpkg on homepage

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -122,6 +122,7 @@ cc_binary(
 
 ## 特点
 
+* **原生集成 [vcpkg](https://github.com/microsoft/vcpkg) 管理 C/C++ 第三方库。** 长期以来在 Blade 中使用第三方库都比较麻烦；随着 vcpkg 的成熟，Blade 将它作为一等的第三方包管理工具集成进来——在 `deps` 中写 `vcpkg#<port>:<lib>`，Blade 即自动安装并链接，支持版本固定与二进制缓存。详见[使用 vcpkg 包](doc/zh_CN/build_rules/vcpkg.md)。
 * 自动分析头文件依赖关系，重新构建受影响的代码。
 * 增量编译与链接，只重建真正需要重建的部分。
 * 自动计算库的间接依赖；库作者只需声明直接依赖，构建时自动检查间接依赖是否需要重建。

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ In terms of ease of use, besides automatic dependency maintenance, Blade can als
 
 ## Features
 
+* **Native [vcpkg](https://github.com/microsoft/vcpkg) integration for C/C++ third-party libraries.** Using third-party libraries in Blade has long been cumbersome; as vcpkg has matured, Blade now integrates it as a first-class package manager — declare `vcpkg#<port>:<lib>` in `deps` and Blade installs and links them, with version pinning and a binary cache. See [Using vcpkg packages](doc/en/build_rules/vcpkg.md).
 * Automatic analysis of header file dependencies, building affected code.
 * Incremental compilation and linking, only building code that needs to be rebuilt due to changes.
 * Automatic calculation of indirect library dependencies - library authors only need to write direct dependencies, and builds automatically check if dependent libraries need rebuilding.

--- a/doc/en/README.md
+++ b/doc/en/README.md
@@ -14,8 +14,6 @@
 
 [Write a BUILD file](build_file.md)
 
-[Using vcpkg packages](vcpkg.md)
-
 [Command Line](command_line.md)
 
 [Testing Support](test.md)

--- a/doc/en/build_rules/cc.md
+++ b/doc/en/build_rules/cc.md
@@ -2,6 +2,13 @@
 
 C/C++ compilation involves three distinct phases: preprocessing, compiling, and linking, each requiring specific compiler flags.
 
+## Third-party libraries
+
+Besides building dependencies from source, C/C++ targets can link prebuilt
+system libraries (`#name`, e.g. `#pthread`) and packages managed by
+[vcpkg](https://github.com/microsoft/vcpkg) through `vcpkg#<port>:<lib>`
+dependencies. See [Using vcpkg packages](vcpkg.md) for the full guide.
+
 ## Common C/C++ Attributes
 
 ### `warning`: string = ['yes', 'no']

--- a/doc/en/build_rules/vcpkg.md
+++ b/doc/en/build_rules/vcpkg.md
@@ -307,7 +307,7 @@ cc_library(name='payment', srcs=['payment.cc'], deps=['//third_party/openssl:ssl
 ## Configuration reference
 
 All settings live in `vcpkg_config(...)` in `BLADE_ROOT`. See the
-[`vcpkg_config`](config.md#vcpkg_config) section of the configuration manual for
+[`vcpkg_config`](../config.md#vcpkg_config) section of the configuration manual for
 the full list of fields (`manage`, `baseline`, `packages`, `registries`, `root`,
 `triplet`, `install_dir`, `binary_cache`, `direct_use_allowed`).
 

--- a/doc/en/config.md
+++ b/doc/en/config.md
@@ -868,7 +868,7 @@ This skips Visual Studio auto-detection and uses clang-cl with MSVC-style flags.
 
 Configuration for consuming [vcpkg](https://github.com/microsoft/vcpkg)
 packages as `vcpkg#<port>:<lib>` dependencies. See [Using vcpkg
-packages](vcpkg.md) for the full guide. A single workspace-level section:
+packages](build_rules/vcpkg.md) for the full guide. A single workspace-level section:
 vcpkg allows one version and one feature set per package per workspace.
 
 #### `manage`: bool = True

--- a/doc/zh_CN/README.md
+++ b/doc/zh_CN/README.md
@@ -15,8 +15,6 @@ Blade 用户手册
 
 [编写 BUILD 文件](build_file.md)
 
-[使用 vcpkg 包](vcpkg.md)
-
 [命令行参考](command_line.md)
 
 [测试支持](test.md)

--- a/doc/zh_CN/build_rules/cc.md
+++ b/doc/zh_CN/build_rules/cc.md
@@ -2,6 +2,12 @@
 
 C/C++ 的编译过程分为三个阶段：预处理、编译（将预处理后的源文件转换为 `.o` 文件）、链接（将 `.o`、`.a` 链接为可执行文件或动态库）。各阶段使用各自的编译器选项。
 
+## 第三方库
+
+除了从源码构建依赖，C/C++ 目标还可以链接预编译的系统库（`#name`，如 `#pthread`），
+以及通过 `vcpkg#<port>:<lib>` 依赖使用 [vcpkg](https://github.com/microsoft/vcpkg)
+管理的第三方包。完整说明见[使用 vcpkg 包](vcpkg.md)。
+
 ## C/C++ 通用属性
 
 ### `warning`：string = ['yes', 'no']

--- a/doc/zh_CN/build_rules/vcpkg.md
+++ b/doc/zh_CN/build_rules/vcpkg.md
@@ -285,7 +285,7 @@ cc_library(name='payment', srcs=['payment.cc'], deps=['//third_party/openssl:ssl
 所有设置都在 `BLADE_ROOT` 的 `vcpkg_config(...)` 中。完整字段（`manage`、
 `baseline`、`packages`、`registries`、`root`、`triplet`、`install_dir`、
 `binary_cache`、`direct_use_allowed`）见配置手册的
-[`vcpkg_config`](config.md#vcpkg_config) 一节。
+[`vcpkg_config`](../config.md#vcpkg_config) 一节。
 
 ## 排错
 

--- a/doc/zh_CN/config.md
+++ b/doc/zh_CN/config.md
@@ -869,7 +869,7 @@ cc_toolchain_config(
 ### vcpkg_config
 
 用于把 [vcpkg](https://github.com/microsoft/vcpkg) 包作为 `vcpkg#<port>:<lib>`
-依赖使用的配置。完整说明见[使用 vcpkg 包](vcpkg.md)。这是一个工作区级别的单一
+依赖使用的配置。完整说明见[使用 vcpkg 包](build_rules/vcpkg.md)。这是一个工作区级别的单一
 节：vcpkg 每个包每个工作区只允许一个版本、一组 features。
 
 #### `manage`: bool = True


### PR DESCRIPTION
Review feedback on #1311:

- **Relocate the vcpkg guide.** It only serves C/C++ targets, so `vcpkg.md` moves from the top-level manual into `doc/{en,zh_CN}/build_rules/` next to `cc.md`. Dropped the standalone "Using vcpkg packages" TOC entry; `cc.md` now references it under a new "Third-party libraries" section. Fixed the `config.md` ↔ `vcpkg.md` backlinks for the new path.
- **Homepage feature.** Added native vcpkg integration as a highlighted feature in the root `README.md` / `README-zh.md` — framed as: using third-party C/C++ libraries in Blade has long been cumbersome; with vcpkg matured, Blade integrates it as a first-class package manager.

All cross-doc links verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)