### PR TITLE
vcpkg: build static libs with -fPIC (so they can link into a .so)

### DIFF
--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -373,6 +373,16 @@ def overlay_triplet_cmake(target_os, target_arch, library_linkage='static',
     # whose ABI-incompatible debug libs must be linked (see vcpkg_build_type).
     if build_type:
         lines.append('set(VCPKG_BUILD_TYPE %s)' % build_type)
+    if target_os != 'windows':
+        # Match blade's compile-once-with-fPIC model: a static vcpkg .a may be
+        # linked into a .so (a generate_dynamic / dynamic_link consumer), which
+        # on ELF requires position-independent code. vcpkg static libs are NOT
+        # -fPIC by default -> "relocation ... can not be used when making a
+        # shared object; recompile with -fPIC". No-op on macOS (always PIC);
+        # -fPIC is unknown to MSVC and ignored-with-a-warning by MinGW, so skip
+        # Windows. VCPKG_C/CXX_FLAGS reach both CMake and autotools/make ports.
+        lines.append('set(VCPKG_C_FLAGS "-fPIC")')
+        lines.append('set(VCPKG_CXX_FLAGS "-fPIC")')
     for port in dynamic_ports:
         lines.append('if(PORT STREQUAL "%s")' % port)
         lines.append('    set(VCPKG_LIBRARY_LINKAGE dynamic)')

--- a/src/tests/unit/vcpkg_manifest_test.py
+++ b/src/tests/unit/vcpkg_manifest_test.py
@@ -85,6 +85,9 @@ class OverlayTripletTest(unittest.TestCase):
         self.assertIn('set(VCPKG_LIBRARY_LINKAGE static)', t)
         # Release-only: blade links the release tree, never debug/.
         self.assertIn('set(VCPKG_BUILD_TYPE release)', t)
+        # -fPIC so a static .a can be linked into a .so (ELF needs PIC).
+        self.assertIn('set(VCPKG_C_FLAGS "-fPIC")', t)
+        self.assertIn('set(VCPKG_CXX_FLAGS "-fPIC")', t)
         self.assertIn('set(VCPKG_CMAKE_SYSTEM_NAME Linux)', t)
         self.assertIn('VCPKG_CHAINLOAD_TOOLCHAIN_FILE', t)
         self.assertIn('../blade-chainload.cmake', t)
@@ -101,6 +104,8 @@ class OverlayTripletTest(unittest.TestCase):
         t = _overlay('windows', 'x64')
         self.assertNotIn('VCPKG_CMAKE_SYSTEM_NAME', t)
         self.assertIn('set(VCPKG_TARGET_ARCHITECTURE x64)', t)
+        # -fPIC is meaningless on Windows (MSVC rejects it, MinGW ignores+warns).
+        self.assertNotIn('-fPIC', t)
 
     def test_dynamic_linkage(self):
         t = _overlay('linux', 'x86_64', library_linkage='dynamic')


### PR DESCRIPTION
## Problem

Blade compiles every TU with `-fPIC` (one object set serves `.a` / `.so` / exe), but that policy was never propagated to vcpkg's builds. vcpkg static libs are **not** `-fPIC` by default, so linking one into a shared library — which happens whenever a `generate_dynamic` / `dynamic_link` consumer pulls a static vcpkg dep into its `.so` — fails on ELF:

```
relocation R_X86_64_32 against `...' can not be used when making a shared object; recompile with -fPIC
```

This was latent because flare was validated on macOS, where the target is **always** position-independent so the missing flag didn't matter. On Linux it would break.

## Fix

Add `VCPKG_C_FLAGS` / `VCPKG_CXX_FLAGS` `"-fPIC"` to the overlay triplet (reaches both CMake and autotools/make ports) on non-Windows. No-op on macOS (already PIC); `-fPIC` is unknown to MSVC and ignored-with-a-warning by MinGW, so Windows is skipped. The `-shared` triplet inherits it too.

## Validation

- Unit tests assert `-fPIC` present on Linux/POSIX triplets, absent on Windows. 584 unit tests pass; pyright clean.
- flare (arm64-osx): regenerated triplet carries `-fPIC`, vcpkg reinstalled all ports with it, build still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)