### PR TITLE
vcpkg: make the install demand-driven (skip when no vcpkg target is built)

### DIFF
--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -582,6 +582,13 @@ def setup(builder):
     packages = cfg.get('packages') or {}
     if not cfg.get('manage', True) or not packages:
         return True
+    # Demand-driven: only install when the build actually references a vcpkg
+    # package. This lets a workspace declare vcpkg_config unconditionally (its
+    # use of vcpkg is a fixed project property) without forcing every build --
+    # or every consumer of an unrelated target -- to need the vcpkg tool or pay
+    # the install. A build with no `vcpkg#...` dependency is a no-op here.
+    if not _build_uses_vcpkg(builder):
+        return True
 
     toolchain = builder.get_build_toolchain()
     vanilla = cfg.get('triplet')
@@ -679,6 +686,17 @@ def setup(builder):
 def _read_text(path):
     with open(path) as f:
         return f.read()
+
+
+def _build_uses_vcpkg(builder):
+    """True if the build graph contains a vcpkg target (some built target
+    referenced a `vcpkg#...` dependency). get_build_targets() is the build set
+    with command-line exclusions already applied, so excluding the only vcpkg
+    target makes this False -> the install is skipped."""
+    for target in builder.get_build_targets().values():
+        if getattr(target, 'type', None) == 'vcpkg_library':
+            return True
+    return False
 
 
 def _auto_dynamic_ports(builder, packages):

--- a/src/tests/unit/vcpkg_setup_test.py
+++ b/src/tests/unit/vcpkg_setup_test.py
@@ -77,6 +77,10 @@ class SetupTest(unittest.TestCase):
     def _run(self, build_dir, cfg=None, run_result=(0, 'ok', ''),
              tool: 'str | None' = '/vc/vcpkg', targets=None):
         cfg = dict(_CFG if cfg is None else cfg)
+        # Default: the build references the 'fmt' package, so the demand-driven
+        # check passes and the install runs (these tests exercise that path).
+        if targets is None:
+            targets = {'fmt': _vcpkg_lib('fmt', False)}
         with mock.patch('blade.config.get_section', return_value=cfg), \
              mock.patch('blade.vcpkg._find_vcpkg_tool', return_value=tool), \
              mock.patch('blade.console.info'), \
@@ -95,6 +99,14 @@ class SetupTest(unittest.TestCase):
     def test_no_packages_is_noop(self):
         with tempfile.TemporaryDirectory() as d:
             ok, rc = self._run(d, cfg=dict(_CFG, packages={}))
+        self.assertTrue(ok)
+        rc.assert_not_called()
+
+    def test_no_vcpkg_target_skips_install(self):
+        # Demand-driven: packages are declared but the build references no vcpkg
+        # target, so the install is skipped (no vcpkg tool required).
+        with tempfile.TemporaryDirectory() as d:
+            ok, rc = self._run(d, targets={})
         self.assertTrue(ok)
         rc.assert_not_called()
 


### PR DESCRIPTION
## Why

`setup()` ran `vcpkg install` on **every** build whenever `vcpkg_config` declared packages — even if nothing in the build referenced vcpkg. That forced workspaces to gate `vcpkg_config` behind an env check so that unrelated builds (and cross-repo consumers that don't use vcpkg) wouldn't need the vcpkg tool or pay the install. Whether a project uses vcpkg is a fixed property; it should be declared unconditionally.

## What

Skip the install when the build graph contains no `vcpkg_library` target. `get_build_targets()` is the build set with command-line exclusions already applied, so a build that references no `vcpkg#...` dependency (or one that excludes the only vcpkg target) is a no-op here; a build that references a port installs as before.

## Validated

- Unit: new `test_no_vcpkg_target_skips_install`; existing setup tests updated to pass a vcpkg target. 603 unit tests pass, pyright clean.
- Local (blade-test, `vcpkg_config` active): `//suites/cc_basic` (no vcpkg dep) skips the install even with a cleared stamp; `//suites/vcpkg_basic` installs its 4 ports.

Enables removing the `$VCPKG_ROOT` gate from blade-test's `BLADE_ROOT` (follow-up in blade-test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)