### PR TITLE
ci: exclude vcpkg_basic from the blade-test e2e-smoke

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -141,5 +141,4 @@ jobs:
         # exclude it here so this smoke does not install vcpkg ports on every
         # blade PR (blade is demand-driven, so the excluded target = no install).
         ./blade.sh test //suites/... \
-          --exclude-targets '//suites/cu_basic/...' \
-          --exclude-targets '//suites/vcpkg_basic/...'
+          --exclude-targets '//suites/cu_basic/...,//suites/vcpkg_basic/...'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -136,5 +136,10 @@ jobs:
     - name: Run blade-test suites
       working-directory: blade-test
       run: |
-        # CUDA toolkit not available on CI — skip cu_basic suites
-        ./blade.sh test //suites/... --exclude-targets '//suites/cu_basic/...'
+        # CUDA toolkit not available on CI — skip cu_basic suites.
+        # vcpkg_basic is exercised by blade-test's own dedicated vcpkg jobs;
+        # exclude it here so this smoke does not install vcpkg ports on every
+        # blade PR (blade is demand-driven, so the excluded target = no install).
+        ./blade.sh test //suites/... \
+          --exclude-targets '//suites/cu_basic/...' \
+          --exclude-targets '//suites/vcpkg_basic/...'


### PR DESCRIPTION
Follow-up to demand-driven install (#1323) + blade-test declaring vcpkg_config unconditionally. vcpkg_basic has its own dedicated jobs in blade-test; exclude it from this e2e-smoke so blade PRs don't install vcpkg ports (openssl etc.). Demand-driven means the excluded target = no install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)