### PR TITLE
cc: support Objective-C (.m) and Objective-C++ (.mm) sources

### DIFF
--- a/doc/en/build_rules/cc.md
+++ b/doc/en/build_rules/cc.md
@@ -2,6 +2,16 @@
 
 C/C++ compilation involves three distinct phases: preprocessing, compiling, and linking, each requiring specific compiler flags.
 
+## Source languages
+
+`srcs` accepts C (`.c`), C++ (`.cc`/`.cpp`/`.cxx`), assembly (`.s`/`.S`/`.asm`),
+and Objective-C / Objective-C++ (`.m` / `.mm`). Objective-C(++) compiles through
+the same rules — the clang/gcc driver infers the language from the extension —
+and `.mm` is treated as C++ (gets `cxxflags`/`extra_cxxflags`). Link Apple
+frameworks via `extra_linkflags`, e.g. `extra_linkflags=['-framework', 'Foundation']`.
+The MSVC toolchain has no Objective-C support, so keep `.m`/`.mm` out of `srcs`
+on Windows (gate them with a `blade.cc_toolchain` conditional in the BUILD file).
+
 ## Third-party libraries
 
 Besides building dependencies from source, C/C++ targets can link prebuilt

--- a/doc/zh_CN/build_rules/cc.md
+++ b/doc/zh_CN/build_rules/cc.md
@@ -2,6 +2,15 @@
 
 C/C++ 的编译过程分为三个阶段：预处理、编译（将预处理后的源文件转换为 `.o` 文件）、链接（将 `.o`、`.a` 链接为可执行文件或动态库）。各阶段使用各自的编译器选项。
 
+## 源语言
+
+`srcs` 接受 C（`.c`）、C++（`.cc`/`.cpp`/`.cxx`）、汇编（`.s`/`.S`/`.asm`），以及
+Objective-C / Objective-C++（`.m` / `.mm`）。Objective-C(++) 走相同的编译规则——
+clang/gcc 驱动按扩展名自动判定语言——`.mm` 按 C++ 处理（用 `cxxflags`/`extra_cxxflags`）。
+链接 Apple framework 用 `extra_linkflags`，例如 `extra_linkflags=['-framework', 'Foundation']`。
+MSVC 工具链不支持 Objective-C，因此在 Windows 上要把 `.m`/`.mm` 从 `srcs` 里排除掉
+（在 BUILD 里用 `blade.cc_toolchain` 条件判断）。
+
 ## 第三方库
 
 除了从源码构建依赖，C/C++ 目标还可以链接预编译的系统库（`#name`，如 `#pthread`），

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -43,7 +43,10 @@ from blade.version import LooseVersion as version_parse
 # _SOURCE_FILE_EXTS is a tuple (not a set) so it fits the Sequence[str] shape
 # callers expect; it is only ever consumed as the resolved default for the
 # `src_exts=` parameter, and ordering has no semantic effect.
-_SOURCE_FILE_EXTS: 'tuple[str, ...]' = ('c', 'cc', 'cp', 'cxx', 'cpp', 'CPP', 'c++', 'C', 's', 'S', 'asm')
+# 'm' / 'mm' are Objective-C / Objective-C++ (the clang/gcc driver infers the
+# language from these extensions); they compile through the same cc/cxx rules.
+_SOURCE_FILE_EXTS: 'tuple[str, ...]' = ('c', 'cc', 'cp', 'cxx', 'cpp', 'CPP', 'c++', 'C',
+                                        'm', 'mm', 's', 'S', 'asm')
 # _HEADER_FILE_EXTS stays a set because it is consumed by `in` membership
 # checks in :func:`is_header_file`, which benefit from O(1) lookup.
 _HEADER_FILE_EXTS = {'h', 'hh', 'H', 'hp', 'hpp', 'hxx', 'HPP', 'h++', 'inc', 'inl', 'tcc'}
@@ -627,12 +630,19 @@ class CcTarget(Target):
 
     def _get_rule_from_suffix(self, src, secret):
         """
-        Return cxx for C++ source files with suffix as .cc/.cpp/.cxx,
-        return cc otherwise for C, Assembler, etc.
+        Return cxx for C++ / Objective-C++ source files (.cc/.cpp/.cxx/.mm),
+        return cc otherwise for C, Objective-C (.m), Assembler, etc.
+
+        Objective-C(++) compiles through the same cc/cxx rules: the clang/gcc
+        driver infers the language from the .m/.mm extension (no -x flag needed),
+        and .mm needs the C++ flags so it routes to cxx just like .cc. The MSVC
+        toolchain has no Objective-C support, so a workspace targeting MSVC must
+        keep .m/.mm out of `srcs` itself (e.g. a `blade.cc_toolchain` conditional
+        in the BUILD file), the same way platform-specific sources are gated.
         """
         if secret:
             return 'secretcc'
-        for suffix in ('.cc', '.cpp', '.cxx'):
+        for suffix in ('.cc', '.cpp', '.cxx', '.mm'):
             if src.endswith(suffix):
                 return 'cxx'
         # MASM .asm can't go through cl.exe; route to the ml64/ml 'as' rule.
@@ -644,12 +654,13 @@ class CcTarget(Target):
     def _extra_compile_flags_for(self, src):
         """Per-source-language extra compile flags (issue #492).
 
-        `extra_cxxflags` for C++ (`.cc`/`.cpp`/`.cxx`, matching the cxx rule
-        selection above), `extra_asflags` for assembly (`.s`/`.S`/`.asm`), and
-        `extra_cflags` for everything else (C). These are *in addition to*
-        `extra_cppflags`, which applies to all C-family sources.
+        `extra_cxxflags` for C++ / Objective-C++ (`.cc`/`.cpp`/`.cxx`/`.mm`,
+        matching the cxx rule selection above), `extra_asflags` for assembly
+        (`.s`/`.S`/`.asm`), and `extra_cflags` for everything else (C and
+        Objective-C `.m`). These are *in addition to* `extra_cppflags`, which
+        applies to all C-family sources.
         """
-        if src.endswith(('.cc', '.cpp', '.cxx')):
+        if src.endswith(('.cc', '.cpp', '.cxx', '.mm')):
             return self.attr.get('extra_cxxflags', [])
         if src.endswith(('.s', '.S', '.asm')):
             return self.attr.get('extra_asflags', [])

--- a/src/tests/unit/cc_targets_test.py
+++ b/src/tests/unit/cc_targets_test.py
@@ -197,6 +197,12 @@ class ExtraCompileFlagsForTest(unittest.TestCase):
         for src in ('a.s', 'a.S', 'a.asm'):
             self.assertEqual(['-as-only'], t._extra_compile_flags_for(src), src)
 
+    def test_objc_sources(self):
+        # Objective-C++ (.mm) is C++; Objective-C (.m) is C.
+        t = self._target()
+        self.assertEqual(['-cxx-only'], t._extra_compile_flags_for('a.mm'))
+        self.assertEqual(['-c-only'], t._extra_compile_flags_for('a.m'))
+
     def test_c_and_other_sources_get_cflags(self):
         t = self._target()
         self.assertEqual(['-c-only'], t._extra_compile_flags_for('a.c'))
@@ -206,6 +212,27 @@ class ExtraCompileFlagsForTest(unittest.TestCase):
         t.attr = {}
         self.assertEqual([], t._extra_compile_flags_for('a.cc'))
         self.assertEqual([], t._extra_compile_flags_for('a.c'))
+
+
+class RuleFromSuffixTest(unittest.TestCase):
+    """Source-suffix -> compile rule (cxx for C++/Objective-C++, else cc)."""
+
+    def _target(self):
+        return cc_targets.CcTarget.__new__(cc_targets.CcTarget)
+
+    def test_cxx_and_objcxx_use_cxx_rule(self):
+        t = self._target()
+        for src in ('a.cc', 'a.cpp', 'a.cxx', 'a.mm'):
+            self.assertEqual('cxx', t._get_rule_from_suffix(src, secret=False), src)
+
+    def test_c_and_objc_use_cc_rule(self):
+        t = self._target()
+        for src in ('a.c', 'a.m'):
+            self.assertEqual('cc', t._get_rule_from_suffix(src, secret=False), src)
+
+    def test_objc_recognized_as_source(self):
+        self.assertIn('m', cc_targets._SOURCE_FILE_EXTS)
+        self.assertIn('mm', cc_targets._SOURCE_FILE_EXTS)
 
 
 class CcLinkPlatformGuardTest(unittest.TestCase):


### PR DESCRIPTION
## Why

blade didn't recognize `.m`/`.mm` as source files — `_SOURCE_FILE_EXTS` lacked them — so they couldn't be compiled at all.

## What

Add `.m`/`.mm` to the recognized source extensions and route them by suffix through the **existing** cc/cxx rules:
- `.mm` → `cxx` (Objective-C++ is C++; gets `cxxflags`/`extra_cxxflags`), alongside `.cc`/`.cpp`/`.cxx`.
- `.m` → `cc` (Objective-C).

No `-x` flag needed: the clang/gcc driver infers Objective-C(++) from the extension, so ObjC slots into blade's compile-once model with no new rule. This keeps `.mm` mixable with `.cc` in one target (the common ObjC++ bridging case) rather than a near-duplicate `objc_library`. Apple frameworks link via `extra_linkflags` (e.g. `['-framework', 'Foundation']`).

MSVC has no Objective-C support, so a Windows build keeps `.m`/`.mm` out of `srcs` itself via a `blade.cc_toolchain` conditional (like other platform-specific sources); blade doesn't special-case it.

## Validation

- Unit tests: suffix → rule routing (`.mm`→cxx, `.m`→cc) + per-language extra-flags + `_SOURCE_FILE_EXTS` membership. 607 unit tests pass, pyright clean.
- End-to-end on macOS: a `cc_binary` mixing `.cc` + `.m` (NSString) + `.mm` (NSString + `std::string`), linking Foundation via `extra_linkflags`, builds and runs.

Docs: `doc/{en,zh_CN}/build_rules/cc.md` "Source languages" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)