### PR TITLE
vcpkg: resolve a port's Libs.private system libs on MSVC (#1322)

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -278,6 +278,21 @@ def _windows_dll_basename(path, name):
     return '.'.join(parts) + '.dll'
 
 
+def _system_lib_link_flag(lib, is_msvc):
+    """Render a system library (a `#name` dep) as a linker argument.
+
+    An absolute path is passed through unchanged. A bare name becomes the GNU
+    `-lname` on GCC/Clang; on MSVC (cl / clang-cl) `link.exe` / `lld-link` take
+    the import library as a positional argument instead (`name.lib`), so emit
+    that -- `-lname` is not understood there.
+    """
+    if os.path.isabs(lib):
+        return lib
+    if is_msvc:
+        return lib if lib.lower().endswith('.lib') else lib + '.lib'
+    return '-l%s' % lib
+
+
 class CcTarget(Target):
     """
     This class is derived from Target and it is the base class
@@ -1250,7 +1265,8 @@ class CcTarget(Target):
             vars['target_linkflags'] = ' '.join(target_linkflags)
         if cmd:
             vars['cmd'] = cmd
-        extra_linkflags = [lib if os.path.isabs(lib) else '-l%s' % lib for lib in sys_libs]
+        is_msvc = self.blade.get_build_toolchain().cc_is('msvc')
+        extra_linkflags = [_system_lib_link_flag(lib, is_msvc) for lib in sys_libs]
         extra_linkflags += self.attr.get('extra_linkflags')  # pyright: ignore[reportOperatorIssue]
         if implicit_deps is None:
             implicit_deps = []
@@ -1784,7 +1800,7 @@ class VcpkgLibrary(PrebuiltCcLibrary):
 
     def __init__(self, port, lib, key, lib_dir, include_dir, header_only,
                  linkage='static', dynamic_lib_dir=None,
-                 link_all_symbols=False, include_prefix=None):
+                 link_all_symbols=False, include_prefix=None, system_libs=None):
         # Stash the vcpkg-resolved locations before super().__init__, which
         # calls our _setup() at the end of construction.
         self._vcpkg_port = port
@@ -1844,6 +1860,16 @@ class VcpkgLibrary(PrebuiltCcLibrary):
         # in-tree dirs). Flagging every vcpkg dep as "unused" would be pure
         # noise; precise external-header attribution is a follow-up.
         declare_header_less(self)
+        # The port's pkg-config private system libs (e.g. dbghelp on Windows)
+        # become `#name` deps so they propagate onto every consumer's link line,
+        # exactly like a hand-written `deps=['#dbghelp']` would (issue #1322).
+        # Registered before dependency expansion (which runs in the analyze
+        # phase, after this auto-created target exists), so they expand normally.
+        for sys_name in (system_libs or []):
+            dkey = '#:' + sys_name
+            self._add_system_library(dkey, sys_name)
+            if dkey not in self.deps:
+                self.deps.append(dkey)
 
     def _vcpkg_prefixed_incdir(self, include_prefix, include_dir):
         """Expose the vcpkg include dir under remapped prefixes via symlinks, so

--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -173,6 +173,67 @@ def parse_pkgconfig(text):
     }
 
 
+def _port_pc_files(root, triplet, port):
+    """Absolute paths of the `*.pc` files `port` installed for `triplet`.
+
+    vcpkg records every file a port lays down in a per-port list under
+    `installed/vcpkg/info/<port>_<version>_<triplet>.list` (paths relative to
+    `installed/`). The `_<triplet>.list` suffix and `<port>_` prefix anchor the
+    glob so a port is not confused with one whose name it prefixes. Returns []
+    when the metadata is absent (never raises)."""
+    import glob
+    info_dir = os.path.join(root, 'installed', 'vcpkg', 'info')
+    pattern = os.path.join(info_dir, '%s_*_%s.list' % (port, triplet))
+    pc_files = []
+    for listing in glob.glob(pattern):
+        try:
+            with open(listing, encoding='utf-8') as f:
+                for line in f:
+                    rel = line.strip()
+                    if rel.endswith('.pc'):
+                        pc_files.append(os.path.join(root, 'installed', rel))
+        except OSError:
+            continue
+    return pc_files
+
+
+def _is_sibling_vcpkg_lib(lib_dir, name):
+    """True if `name` is another vcpkg library installed alongside this one (a
+    real archive in `lib_dir`), rather than an OS/SDK system library. Such a
+    `-lname` in `Libs.private` is an inter-port dependency, linked via the port's
+    own archive, not as a `#name` system lib."""
+    candidates = ('%s.lib' % name, 'lib%s.a' % name, '%s.a' % name)
+    return any(os.path.isfile(os.path.join(lib_dir, c)) for c in candidates)
+
+
+def port_system_libs(root, triplet, port, lib_dir):
+    """OS/SDK libraries a port's pkg-config marks as private link dependencies.
+
+    Reads the port's installed `.pc` file(s), collects their `Libs.private` `-l`
+    names, and drops any that are sibling vcpkg libraries (an archive in
+    `lib_dir`). The remainder are system libraries (e.g. `dbghelp`, `shlwapi` on
+    Windows; `dl`, `pthread` on POSIX) that a consumer must link but that vcpkg
+    does not ship -- on MSVC these otherwise surface as unresolved externals
+    (issue #1322).
+
+    Returns a sorted, de-duplicated list of bare library names ([] if none)."""
+    seen = set()
+    result = []
+    for pc in _port_pc_files(root, triplet, port):
+        try:
+            with open(pc, encoding='utf-8') as f:
+                text = f.read()
+        except OSError:
+            continue
+        for name in parse_pkgconfig(text)['l_private']:
+            if name in seen:
+                continue
+            seen.add(name)
+            if not _is_sibling_vcpkg_lib(lib_dir, name):
+                result.append(name)
+    return sorted(result)
+
+
 # --- Phase 2 orchestration inputs: synthetic manifest + overlay triplet ------
 #
 # When blade drives `vcpkg install` itself, it generates a manifest from the
@@ -540,6 +601,10 @@ def _vcpkg_dep_handler(referrer, coordinate):
             lib_subdir(shared_triplet, profile))
     else:
         dynamic_lib_dir = info['lib_dir']
+    # System libs the port's pkg-config marks private (e.g. dbghelp on Windows):
+    # the consumer must link them, but vcpkg does not ship them (issue #1322).
+    system_libs = ([] if info['header_only']
+                   else port_system_libs(root, triplet, info['port'], info['lib_dir']))
     # Lazy import: cc_targets is loaded before this module, but keeping the
     # import local avoids a hard module-level cycle (cc_targets -> ... -> here).
     from blade.cc_targets import VcpkgLibrary
@@ -547,7 +612,7 @@ def _vcpkg_dep_handler(referrer, coordinate):
                           info['lib_dir'], info['include_dir'], info['header_only'],
                           linkage=linkage, dynamic_lib_dir=dynamic_lib_dir,
                           link_all_symbols=link_all_symbols,
-                          include_prefix=include_prefix)
+                          include_prefix=include_prefix, system_libs=system_libs)
     referrer.blade.register_target(target)
     return key
 

--- a/src/tests/unit/cc_system_lib_flag_test.py
+++ b/src/tests/unit/cc_system_lib_flag_test.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""A `#name` system-lib dep renders differently per toolchain on the link line.
+
+GCC/Clang take `-lname`; MSVC's link.exe / lld-link take the import library as a
+positional argument (`name.lib`) and reject `-lname`. Without this, a vcpkg
+port's private system libs (issue #1322) -- and any plain `#advapi32` dep --
+fail to link on MSVC.
+"""
+
+import os
+import sys
+import unittest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade.cc_targets import _system_lib_link_flag  # noqa: E402
+
+
+class SystemLibLinkFlagTest(unittest.TestCase):
+
+    def test_gcc_clang_uses_dash_l(self):
+        self.assertEqual(_system_lib_link_flag('pthread', is_msvc=False), '-lpthread')
+
+    def test_msvc_appends_dot_lib(self):
+        self.assertEqual(_system_lib_link_flag('dbghelp', is_msvc=True), 'dbghelp.lib')
+
+    def test_msvc_does_not_double_suffix(self):
+        # A name already carrying .lib (any case) is passed through as-is.
+        self.assertEqual(_system_lib_link_flag('shlwapi.lib', is_msvc=True),
+                         'shlwapi.lib')
+        self.assertEqual(_system_lib_link_flag('User32.LIB', is_msvc=True),
+                         'User32.LIB')
+
+    def test_absolute_path_passed_through(self):
+        abs_lib = os.path.join(os.sep, 'abs', 'libfoo.a')
+        self.assertEqual(_system_lib_link_flag(abs_lib, is_msvc=False), abs_lib)
+        self.assertEqual(_system_lib_link_flag(abs_lib, is_msvc=True), abs_lib)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/unit/vcpkg_helpers_test.py
+++ b/src/tests/unit/vcpkg_helpers_test.py
@@ -12,7 +12,9 @@ the next PR.
 """
 
 import os
+import shutil
 import sys
+import tempfile
 import unittest
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
@@ -132,6 +134,79 @@ class ParsePkgConfigTest(unittest.TestCase):
         pc = vcpkg.parse_pkgconfig('')
         self.assertEqual(pc['name'], '')
         self.assertEqual(pc['l_libs'], [])
+
+
+class PortSystemLibsTest(unittest.TestCase):
+    """`port_system_libs` reads a port's installed .pc Libs.private and returns
+    the OS/SDK libs a consumer must link (issue #1322), excluding sibling vcpkg
+    libraries it finds as archives in the lib dir."""
+
+    TRIPLET = 'blade-x64-windows-static'
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.root, True)
+        self.installed = os.path.join(self.root, 'installed')
+        self.tdir = os.path.join(self.installed, self.TRIPLET)
+        self.lib_dir = os.path.join(self.tdir, 'lib')
+        self.pkgconfig = os.path.join(self.lib_dir, 'pkgconfig')
+        os.makedirs(self.pkgconfig)
+
+    def _write_pc(self, name, libs_private):
+        path = os.path.join(self.pkgconfig, name)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write('Name: %s\nLibs.private: %s\n' % (name, libs_private))
+        return '%s/lib/pkgconfig/%s' % (self.TRIPLET, name)
+
+    def _write_list(self, port, version, rel_paths):
+        info = os.path.join(self.installed, 'vcpkg', 'info')
+        os.makedirs(info, exist_ok=True)
+        fname = '%s_%s_%s.list' % (port, version, self.TRIPLET)
+        with open(os.path.join(info, fname), 'w', encoding='utf-8') as f:
+            f.write('\n'.join(rel_paths) + '\n')
+
+    def _touch(self, name):
+        open(os.path.join(self.lib_dir, name), 'w').close()
+
+    def test_collects_private_system_libs(self):
+        rel = self._write_pc('libglog.pc', '-ldbghelp')
+        self._write_list('glog', '0.6.0', [self.TRIPLET + '/lib/', rel])
+        self.assertEqual(
+            vcpkg.port_system_libs(self.root, self.TRIPLET, 'glog', self.lib_dir),
+            ['dbghelp'])
+
+    def test_excludes_sibling_vcpkg_libs(self):
+        # glog's Libs.private references gflags (a sibling vcpkg lib, present as
+        # an archive) plus dbghelp (a real system lib). Only dbghelp is returned.
+        rel = self._write_pc('libglog.pc', '-lgflags -ldbghelp')
+        self._touch('gflags.lib')
+        self._write_list('glog', '0.6.0', [rel])
+        self.assertEqual(
+            vcpkg.port_system_libs(self.root, self.TRIPLET, 'glog', self.lib_dir),
+            ['dbghelp'])
+
+    def test_sorted_and_deduplicated(self):
+        r1 = self._write_pc('libssl.pc', '-lcrypt32 -lws2_32')
+        r2 = self._write_pc('libcrypto.pc', '-lws2_32 -ladvapi32')
+        self._write_list('openssl', '3.2.1', [r1, r2])
+        self.assertEqual(
+            vcpkg.port_system_libs(self.root, self.TRIPLET, 'openssl', self.lib_dir),
+            ['advapi32', 'crypt32', 'ws2_32'])
+
+    def test_missing_metadata_returns_empty(self):
+        # No info .list for the port -> no system libs, no error.
+        self.assertEqual(
+            vcpkg.port_system_libs(self.root, self.TRIPLET, 'absent', self.lib_dir),
+            [])
+
+    def test_prefix_named_port_not_matched(self):
+        # A port whose name prefixes another ('gflag' vs 'gflags') must not pick
+        # up the other's list: the '_' separator anchors the glob.
+        rel = self._write_pc('libgflags.pc', '-lshlwapi')
+        self._write_list('gflags', '2.2.2', [rel])
+        self.assertEqual(
+            vcpkg.port_system_libs(self.root, self.TRIPLET, 'gflag', self.lib_dir),
+            [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #1322.

## Problem

A `vcpkg#port:lib` consumer linked the port's archive but **not** the OS/SDK libraries the port marks `Libs.private` in its pkg-config. On MSVC this surfaced as unresolved externals, forcing consumers to hand-maintain `extra_linkflags=['dbghelp.lib', ...]`:

- glog → `dbghelp`, gflags → `shlwapi`, openssl → `advapi32`/`crypt32`/`ws2_32`/`gdi32`/`bcrypt`/`user32`

While tracing this I found the premise was slightly off: `parse_pkgconfig` existed but was wired into the `VcpkgLibrary` path on **no** platform. POSIX only "worked" because `dl`/`pthread`/`m` are folded into modern glibc, so the linker needed no explicit `-l`. So this PR *implements* the mapping rather than extending it.

## Fix (end to end)

1. **`vcpkg.port_system_libs()`** — reads the port's installed `.pc` file(s), located via vcpkg's per-port `installed/vcpkg/info/<port>_*_<triplet>.list`, collects their `Libs.private` `-l` names, and drops sibling vcpkg libraries (a real archive in `lib_dir` — those arrive via the port's own deps, not as system libs).
2. **`VcpkgLibrary`** — registers each as a `#name` system-lib dep, so it propagates to every consumer's link line exactly like a hand-written `deps=['#dbghelp']`. Registered before dependency expansion, so it expands normally.
3. **`_cc_link`** — renders a bare `#name` system lib per toolchain: `-lname` on GCC/Clang, **`name.lib` on MSVC** (link.exe / lld-link take the import lib as a positional arg and reject `-lname`). This also makes a plain `#advapi32` dep work on MSVC, which it never did before.

## Tests

- `port_system_libs`: private-lib collection, sibling-vcpkg-lib exclusion, sort/dedup, missing-metadata → `[]`, and the prefix-named-port glob anchor (`gflag` vs `gflags`).
- `_system_lib_link_flag`: per-toolchain rendering (`-lname` vs `name.lib`, no double-suffix, absolute passthrough).

Full unit suite: no new failures (the 30 pre-existing failures are unrelated Windows POSIX-path assumptions in fixtures). pyright clean on both changed modules.

## Follow-up

Once merged, the `extra_linkflags=['dbghelp.lib', ...]` workaround in the blade-test vcpkg suite can be removed (verifies end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)