### PR TITLE
vcpkg: resolve a port's private system libs lazily at generate time (#1322)

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -811,6 +811,12 @@ class CcTarget(Target):
                 sys_libs.append(lib_name)
                 continue
 
+            # A vcpkg port also contributes the OS/SDK libraries its pkg-config
+            # marks private (issue #1322); resolved now, at generate time, when
+            # the install tree exists. Its own archive is still added below.
+            if dep.type == 'vcpkg_library':
+                sys_libs.extend(dep.system_libs())
+
             lib = dep._get_target_file(tc.STATIC_LIB_LABEL)
             if lib:
                 if dep.attr.get('link_all_symbols'):
@@ -1800,12 +1806,18 @@ class VcpkgLibrary(PrebuiltCcLibrary):
 
     def __init__(self, port, lib, key, lib_dir, include_dir, header_only,
                  linkage='static', dynamic_lib_dir=None,
-                 link_all_symbols=False, include_prefix=None, system_libs=None):
+                 link_all_symbols=False, include_prefix=None,
+                 vcpkg_root='', vcpkg_triplet=''):
         # Stash the vcpkg-resolved locations before super().__init__, which
         # calls our _setup() at the end of construction.
         self._vcpkg_port = port
         self._vcpkg_lib_dir = lib_dir
         self._vcpkg_header_only = header_only
+        # For resolving the port's pkg-config private system libs lazily, at
+        # generate time, when the install tree exists (issue #1322).
+        self._vcpkg_root = vcpkg_root
+        self._vcpkg_triplet = vcpkg_triplet
+        self._vcpkg_system_libs = None
         # linkage (vcpkg_config): 'static' (.a only), 'dynamic' (shared only --
         # one instance across the build for singletons like gflags/glog/protobuf
         # so flags/descriptors are not double-registered), or 'auto' (static .a
@@ -1860,16 +1872,21 @@ class VcpkgLibrary(PrebuiltCcLibrary):
         # in-tree dirs). Flagging every vcpkg dep as "unused" would be pure
         # noise; precise external-header attribution is a follow-up.
         declare_header_less(self)
-        # The port's pkg-config private system libs (e.g. dbghelp on Windows)
-        # become `#name` deps so they propagate onto every consumer's link line,
-        # exactly like a hand-written `deps=['#dbghelp']` would (issue #1322).
-        # Registered before dependency expansion (which runs in the analyze
-        # phase, after this auto-created target exists), so they expand normally.
-        for sys_name in (system_libs or []):
-            dkey = '#:' + sys_name
-            self._add_system_library(dkey, sys_name)
-            if dkey not in self.deps:
-                self.deps.append(dkey)
+
+    def system_libs(self):
+        """OS/SDK libraries this port needs at link time (its pkg-config
+        `Libs.private`), e.g. dbghelp / ws2_32 on Windows (issue #1322).
+
+        Resolved lazily and cached: the vcpkg install tree is written *after*
+        analyze (when this target is created) and *before* generate (when a
+        consumer's link rule asks for this), so the `.pc` files exist only by
+        the time this is first called. A header-only port links nothing."""
+        if self._vcpkg_system_libs is None:
+            from blade import vcpkg  # local import: avoid module cycle
+            self._vcpkg_system_libs = ([] if self._vcpkg_header_only else
+                vcpkg.port_system_libs(self._vcpkg_root, self._vcpkg_triplet,
+                                       self._vcpkg_port, self._vcpkg_lib_dir))
+        return self._vcpkg_system_libs
 
     def _vcpkg_prefixed_incdir(self, include_prefix, include_dir):
         """Expose the vcpkg include dir under remapped prefixes via symlinks, so

--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -113,7 +113,14 @@ def _parse_module_list(value):
 
 
 def _extract_l_libs(tokens):
-    """Pull bare library names from `-lfoo` tokens (also `-l foo`)."""
+    """Pull bare library names from a pkg-config Libs/Libs.private token list.
+
+    Handles the GNU `-lfoo` / `-l foo` spelling and the MSVC import-library
+    spelling `foo.lib` given as a bare token -- how vcpkg/OpenSSL list Windows
+    system libs (e.g. `Libs.private: ws2_32.lib advapi32.lib crypt32.lib`). The
+    `.lib` suffix (and any directory) is stripped so a name renders uniformly;
+    the link rule re-adds it per toolchain. `-L` search-path tokens are skipped.
+    """
     libs = []
     want_name = False
     for tok in tokens:
@@ -124,6 +131,8 @@ def _extract_l_libs(tokens):
             want_name = True
         elif tok.startswith('-l'):
             libs.append(tok[2:])
+        elif tok.lower().endswith('.lib') and not tok.startswith('-'):
+            libs.append(os.path.splitext(os.path.basename(tok))[0])
     return libs
 
 
@@ -601,18 +610,18 @@ def _vcpkg_dep_handler(referrer, coordinate):
             lib_subdir(shared_triplet, profile))
     else:
         dynamic_lib_dir = info['lib_dir']
-    # System libs the port's pkg-config marks private (e.g. dbghelp on Windows):
-    # the consumer must link them, but vcpkg does not ship them (issue #1322).
-    system_libs = ([] if info['header_only']
-                   else port_system_libs(root, triplet, info['port'], info['lib_dir']))
     # Lazy import: cc_targets is loaded before this module, but keeping the
     # import local avoids a hard module-level cycle (cc_targets -> ... -> here).
     from blade.cc_targets import VcpkgLibrary
+    # root/triplet are stashed so the target can resolve the port's pkg-config
+    # private system libs (issue #1322) lazily at *generate* time -- the install
+    # tree does not exist yet here, during analyze (install runs in between).
     target = VcpkgLibrary(info['port'], info['lib'], key,
                           info['lib_dir'], info['include_dir'], info['header_only'],
                           linkage=linkage, dynamic_lib_dir=dynamic_lib_dir,
                           link_all_symbols=link_all_symbols,
-                          include_prefix=include_prefix, system_libs=system_libs)
+                          include_prefix=include_prefix,
+                          vcpkg_root=root or '', vcpkg_triplet=triplet or '')
     referrer.blade.register_target(target)
     return key
 

--- a/src/tests/unit/vcpkg_helpers_test.py
+++ b/src/tests/unit/vcpkg_helpers_test.py
@@ -109,6 +109,13 @@ class ParsePkgConfigTest(unittest.TestCase):
         self.assertEqual(pc['l_private'], ['dl'])
         self.assertIn('-pthread', pc['libs_private'])
 
+    def test_libs_private_msvc_dot_lib_form(self):
+        # vcpkg/OpenSSL on Windows list system libs as bare `foo.lib` tokens, not
+        # `-lfoo`; the `.lib` is stripped to a uniform bare name.
+        pc = vcpkg.parse_pkgconfig(
+            'Name: libcrypto\nLibs.private: ws2_32.lib advapi32.lib crypt32.lib\n')
+        self.assertEqual(pc['l_private'], ['ws2_32', 'advapi32', 'crypt32'])
+
     def test_header_only_has_no_libs(self):
         pc = vcpkg.parse_pkgconfig(_HEADER_ONLY_PC)
         self.assertEqual(pc['l_libs'], [])
@@ -189,6 +196,14 @@ class PortSystemLibsTest(unittest.TestCase):
         r1 = self._write_pc('libssl.pc', '-lcrypt32 -lws2_32')
         r2 = self._write_pc('libcrypto.pc', '-lws2_32 -ladvapi32')
         self._write_list('openssl', '3.2.1', [r1, r2])
+        self.assertEqual(
+            vcpkg.port_system_libs(self.root, self.TRIPLET, 'openssl', self.lib_dir),
+            ['advapi32', 'crypt32', 'ws2_32'])
+
+    def test_msvc_dot_lib_private_libs(self):
+        # The real OpenSSL-on-Windows case: Libs.private uses `foo.lib` tokens.
+        rel = self._write_pc('libcrypto.pc', 'ws2_32.lib advapi32.lib crypt32.lib')
+        self._write_list('openssl', '3.5.0', [rel])
         self.assertEqual(
             vcpkg.port_system_libs(self.root, self.TRIPLET, 'openssl', self.lib_dir),
             ['advapi32', 'crypt32', 'ws2_32'])


### PR DESCRIPTION
Follow-up to #1326, which did not actually work on MSVC (caught by the blade-test `vcpkg suite (Windows MSVC)` job: openssl still failed to link with `unresolved external symbol __imp_WSAGetLastError` / `__imp_CryptGenRandom` / `__imp_CertOpenSystemStoreW` — i.e. ws2_32 / advapi32 / crypt32 were never linked).

## Two root causes

**1. Timing.** #1326 read each port's `.pc` `Libs.private` in `VcpkgLibrary.__init__` and injected `#name` deps. But that runs during **analyze**, while the vcpkg install tree is written **after** analyze and **before** generate (`main.py`: analyze → vcpkg → generate). So the `.pc` files didn't exist yet and `port_system_libs` always returned `[]` — the link line got zero system libs.

**2. Format.** vcpkg/OpenSSL list Windows system libs in `Libs.private` as bare `ws2_32.lib` tokens, not `-lws2_32`, which the `-l`-only parser dropped.

## Fix

- `VcpkgLibrary` stashes `(root, triplet)` and exposes **`system_libs()`**, resolved lazily on first call (cached). A consumer's `_static_dependencies` asks for it at **generate** time — after the install — so the `.pc` files exist.
- Dropped the `#name`-deps mechanism; the libs are added directly to the consumer's `sys_libs`, which `_cc_link` already renders per toolchain (`name.lib` on MSVC). This also keeps them out of the dependency graph / inclusion check.
- `_extract_l_libs` now accepts both `-lfoo` and bare `foo.lib`.

## Tests

Added `.lib`-form coverage to `parse_pkgconfig` and `port_system_libs`. pyright clean; no new unit-suite failures.

End-to-end verification is blade-test PR #28 (drops the manual `extra_linkflags` workaround); its Windows MSVC job exercises this path.