### PR TITLE
vcpkg: read a port's system libs from CMake config + .pc Libs (#1322)

### DIFF
--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -182,64 +182,108 @@ def parse_pkgconfig(text):
     }
 
 
-def _port_pc_files(root, triplet, port):
-    """Absolute paths of the `*.pc` files `port` installed for `triplet`.
+def _port_installed_files(root, triplet, port):
+    """Absolute paths of every file `port` installed for `triplet`.
 
-    vcpkg records every file a port lays down in a per-port list under
+    vcpkg records them in a per-port list under
     `installed/vcpkg/info/<port>_<version>_<triplet>.list` (paths relative to
-    `installed/`). The `_<triplet>.list` suffix and `<port>_` prefix anchor the
-    glob so a port is not confused with one whose name it prefixes. Returns []
-    when the metadata is absent (never raises)."""
+    `installed/`); manifest mode writes it too. The `_<triplet>.list` suffix and
+    `<port>_` prefix anchor the glob so a port is not confused with one whose
+    name it prefixes. Returns [] when the metadata is absent (never raises)."""
     import glob
     info_dir = os.path.join(root, 'installed', 'vcpkg', 'info')
     pattern = os.path.join(info_dir, '%s_*_%s.list' % (port, triplet))
-    pc_files = []
+    files = []
     for listing in glob.glob(pattern):
         try:
             with open(listing, encoding='utf-8') as f:
                 for line in f:
                     rel = line.strip()
-                    if rel.endswith('.pc'):
-                        pc_files.append(os.path.join(root, 'installed', rel))
+                    if rel:
+                        files.append(os.path.join(root, 'installed', rel))
         except OSError:
             continue
-    return pc_files
+    return files
 
 
 def _is_sibling_vcpkg_lib(lib_dir, name):
     """True if `name` is another vcpkg library installed alongside this one (a
     real archive in `lib_dir`), rather than an OS/SDK system library. Such a
-    `-lname` in `Libs.private` is an inter-port dependency, linked via the port's
-    own archive, not as a `#name` system lib."""
+    reference is an inter-port dependency, linked via the port's own archive,
+    not as a system lib."""
     candidates = ('%s.lib' % name, 'lib%s.a' % name, '%s.a' % name)
     return any(os.path.isfile(os.path.join(lib_dir, c)) for c in candidates)
 
 
+_CMAKE_LINK_LIBS_RE = re.compile(r'INTERFACE_LINK_LIBRARIES\s+"([^"]*)"')
+_CMAKE_LINK_ONLY_RE = re.compile(r'\\?\$<LINK_ONLY:(.+)>$')
+
+
+def _cmake_link_libs(text):
+    """System-lib names from a CMake config's INTERFACE_LINK_LIBRARIES.
+
+    CMake-config ports declare their transitive link deps here -- gflags ->
+    `shlwapi.lib`, glog -> `\\$<LINK_ONLY:dbghelp>;...`. `$<LINK_ONLY:x>` is
+    unwrapped; namespaced imported targets (`Foo::Bar`), other generator
+    expressions and unresolved `${vars}` are skipped (the caller drops sibling
+    vcpkg libs). Only generated `*-targets*.cmake` files should be fed in -- a
+    hand-written `*Config.cmake` may gate libs behind `if(UNIX)` etc., which
+    flat text reading cannot honor (e.g. it would pull `dl` in on Windows)."""
+    libs = []
+    for m in _CMAKE_LINK_LIBS_RE.finditer(text):
+        for tok in m.group(1).split(';'):
+            tok = tok.strip()
+            only = _CMAKE_LINK_ONLY_RE.match(tok)
+            if only:
+                tok = only.group(1)
+            if tok and '::' not in tok and '$<' not in tok and '${' not in tok:
+                libs.append(tok)
+    return libs
+
+
+def _strip_lib_ext(name):
+    """`ws2_32.lib` / `libfoo.a` -> bare stem (basename); other names unchanged."""
+    base = os.path.basename(name)
+    stem, ext = os.path.splitext(base)
+    return stem if ext.lower() in ('.lib', '.a') else base
+
+
 def port_system_libs(root, triplet, port, lib_dir):
-    """OS/SDK libraries a port's pkg-config marks as private link dependencies.
+    """OS/SDK libraries a port needs at link time but does not itself ship.
 
-    Reads the port's installed `.pc` file(s), collects their `Libs.private` `-l`
-    names, and drops any that are sibling vcpkg libraries (an archive in
-    `lib_dir`). The remainder are system libraries (e.g. `dbghelp`, `shlwapi` on
-    Windows; `dl`, `pthread` on POSIX) that a consumer must link but that vcpkg
-    does not ship -- on MSVC these otherwise surface as unresolved externals
-    (issue #1322).
-
-    Returns a sorted, de-duplicated list of bare library names ([] if none)."""
-    seen = set()
-    result = []
-    for pc in _port_pc_files(root, triplet, port):
+    vcpkg ports declare these in different places: autotools ports (OpenSSL) in
+    their pkg-config `Libs`/`Libs.private`; CMake-config ports (gflags, glog) in
+    a generated `*-targets*.cmake`'s INTERFACE_LINK_LIBRARIES. Both are read.
+    Sibling vcpkg libraries (a real archive in `lib_dir`) are dropped; the rest
+    -- the genuine system libs (dbghelp, shlwapi, ws2_32, advapi32, ...) -- are
+    returned sorted and de-duplicated. A consumer must link these or hit
+    unresolved externals on MSVC (issue #1322). [] if none / metadata absent."""
+    names = []
+    for path in _port_installed_files(root, triplet, port):
+        is_pc = path.endswith('.pc')
+        is_targets = (path.endswith('.cmake')
+                      and '-targets' in os.path.basename(path))
+        if not (is_pc or is_targets):
+            continue  # skip the port's binaries, headers, etc.
         try:
-            with open(pc, encoding='utf-8') as f:
+            with open(path, encoding='utf-8', errors='ignore') as f:
                 text = f.read()
         except OSError:
             continue
-        for name in parse_pkgconfig(text)['l_private']:
-            if name in seen:
-                continue
-            seen.add(name)
-            if not _is_sibling_vcpkg_lib(lib_dir, name):
-                result.append(name)
+        if is_pc:
+            pc = parse_pkgconfig(text)
+            names += pc['l_libs'] + pc['l_private']
+        else:
+            names += _cmake_link_libs(text)
+    seen, result = set(), []
+    for name in names:
+        bare = _strip_lib_ext(name)
+        key = bare.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        if not _is_sibling_vcpkg_lib(lib_dir, bare):
+            result.append(bare)
     return sorted(result)
 
 

--- a/src/tests/unit/vcpkg_helpers_test.py
+++ b/src/tests/unit/vcpkg_helpers_test.py
@@ -144,9 +144,11 @@ class ParsePkgConfigTest(unittest.TestCase):
 
 
 class PortSystemLibsTest(unittest.TestCase):
-    """`port_system_libs` reads a port's installed .pc Libs.private and returns
-    the OS/SDK libs a consumer must link (issue #1322), excluding sibling vcpkg
-    libraries it finds as archives in the lib dir."""
+    """`port_system_libs` returns the OS/SDK libs a consumer must link for a port
+    (issue #1322). It reads them from wherever vcpkg records them -- pkg-config
+    `Libs`/`Libs.private` (autotools ports, e.g. OpenSSL) or a generated
+    `*-targets*.cmake`'s INTERFACE_LINK_LIBRARIES (CMake ports, e.g. gflags/glog)
+    -- and excludes sibling vcpkg libraries it finds as archives in the lib dir."""
 
     TRIPLET = 'blade-x64-windows-static'
 
@@ -159,11 +161,26 @@ class PortSystemLibsTest(unittest.TestCase):
         self.pkgconfig = os.path.join(self.lib_dir, 'pkgconfig')
         os.makedirs(self.pkgconfig)
 
-    def _write_pc(self, name, libs_private):
+    def _write_pc(self, name, libs_private='', libs=''):
         path = os.path.join(self.pkgconfig, name)
         with open(path, 'w', encoding='utf-8') as f:
-            f.write('Name: %s\nLibs.private: %s\n' % (name, libs_private))
+            f.write('Name: %s\n' % name)
+            if libs:
+                f.write('Libs: %s\n' % libs)
+            if libs_private:
+                f.write('Libs.private: %s\n' % libs_private)
         return '%s/lib/pkgconfig/%s' % (self.TRIPLET, name)
+
+    def _write_cmake(self, port, name, interface_link_libraries, body=''):
+        share = os.path.join(self.tdir, 'share', port)
+        os.makedirs(share, exist_ok=True)
+        with open(os.path.join(share, name), 'w', encoding='utf-8') as f:
+            if interface_link_libraries is not None:
+                f.write('set_target_properties(%s::%s PROPERTIES\n'
+                        '  INTERFACE_LINK_LIBRARIES "%s"\n)\n'
+                        % (port, port, interface_link_libraries))
+            f.write(body)
+        return '%s/share/%s/%s' % (self.TRIPLET, port, name)
 
     def _write_list(self, port, version, rel_paths):
         info = os.path.join(self.installed, 'vcpkg', 'info')
@@ -207,6 +224,48 @@ class PortSystemLibsTest(unittest.TestCase):
         self.assertEqual(
             vcpkg.port_system_libs(self.root, self.TRIPLET, 'openssl', self.lib_dir),
             ['advapi32', 'crypt32', 'ws2_32'])
+
+    def test_libs_field_not_just_private(self):
+        # OpenSSL on Windows lists system libs in `Libs:` (no Libs.private),
+        # alongside its own -llibcrypto, which the sibling filter drops.
+        self._touch('libcrypto.lib')
+        rel = self._write_pc(
+            'libcrypto.pc',
+            libs='"-L${libdir}" -llibcrypto -lcrypt32 -lws2_32 -ladvapi32 -luser32')
+        self._write_list('openssl', '3.6.3', [rel])
+        self.assertEqual(
+            vcpkg.port_system_libs(self.root, self.TRIPLET, 'openssl', self.lib_dir),
+            ['advapi32', 'crypt32', 'user32', 'ws2_32'])
+
+    def test_cmake_targets_interface_link_libraries(self):
+        # CMake-config ports (no .pc): system libs come from a *-targets*.cmake.
+        # glog wraps them in $<LINK_ONLY:...> and references sibling/imported
+        # targets (gflags::gflags, Threads::Threads) which must be skipped.
+        self._touch('gflags.lib')
+        rel = self._write_cmake(
+            'glog', 'glog-targets.cmake',
+            '\\$<LINK_ONLY:dbghelp>;\\$<LINK_ONLY:Threads::Threads>;gflags::gflags')
+        self._write_list('glog', '0.7.1', [rel])
+        self.assertEqual(
+            vcpkg.port_system_libs(self.root, self.TRIPLET, 'glog', self.lib_dir),
+            ['dbghelp'])
+
+    def test_cmake_dot_lib_token(self):
+        rel = self._write_cmake('gflags', 'gflags-targets.cmake', 'shlwapi.lib')
+        self._write_list('gflags', '2.3.0', [rel])
+        self.assertEqual(
+            vcpkg.port_system_libs(self.root, self.TRIPLET, 'gflags', self.lib_dir),
+            ['shlwapi'])
+
+    def test_conditional_config_cmake_ignored(self):
+        # A hand-written *Config.cmake may gate libs behind if(UNIX); only
+        # generated *-targets*.cmake is read, so a Windows build never picks up
+        # the POSIX-only `dl`.
+        rel = self._write_cmake('openssl', 'OpenSSLConfig.cmake', 'dl')
+        self._write_list('openssl', '3.6.3', [rel])
+        self.assertEqual(
+            vcpkg.port_system_libs(self.root, self.TRIPLET, 'openssl', self.lib_dir),
+            [])
 
     def test_missing_metadata_returns_empty(self):
         # No info .list for the port -> no system libs, no error.


### PR DESCRIPTION
Follow-up to #1327. That fixed the *timing* (resolve at generate, after install) but the link line was still empty on MSVC — because it only read pkg-config `Libs.private`, and that's not where vcpkg ports actually keep their system libs.

I installed `gflags`/`glog`/`openssl` into a real `x64-windows-static` tree and inspected it. The libs come in **three shapes**:

| port | where | example |
|---|---|---|
| gflags | `*-targets*.cmake` `INTERFACE_LINK_LIBRARIES` (no `.pc` at all) | `shlwapi.lib` |
| glog | same | `$<LINK_ONLY:dbghelp>;$<LINK_ONLY:Threads::Threads>;gflags::gflags` |
| openssl | `.pc` **`Libs:`** (not `Libs.private`), next to its own `-llibcrypto` | `-lcrypt32 -lws2_32 -ladvapi32 -luser32` |

## Fix

`port_system_libs` now reads, per the port's vcpkg file manifest (`installed/vcpkg/info/<port>_*.list`):
- every `.pc`: union of **`Libs`** and `Libs.private` link names;
- every generated **`*-targets*.cmake`**: `INTERFACE_LINK_LIBRARIES`, unwrapping `$<LINK_ONLY:x>` and skipping namespaced imported targets (`Foo::Bar`), other generator expressions, and unresolved `${vars}`.

Hand-written `*Config.cmake` files are **deliberately not read** — they gate libs behind `if(UNIX)` etc. that flat-text parsing can't honor (it would pull POSIX `dl` into a Windows link; openssl's config does exactly this). Sibling vcpkg libs (an archive in `lib_dir`, e.g. openssl's own `-llibcrypto`) are still dropped; names are de-duped case-insensitively.

## Verified against a real install

```
gflags  -> ['shlwapi']
glog    -> ['dbghelp']
openssl -> ['advapi32', 'crypt32', 'user32', 'ws2_32']
```
— exactly the symbols that were failing to link (`PathMatchSpec`, `Sym*`, `CryptGenRandom`/`CertOpenSystemStore`/`WSA*`).

Final end-to-end gate is blade-test PR #28's Windows MSVC job.