### PR TITLE
inclusion-check: treat MSVC external (/external:I) headers as system (#1321)

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1329,6 +1329,12 @@ class CcTarget(Target):
         declared_hdrs, declared_incs = self._collect_declared_headers()
         declared_genhdrs, declared_genincs = _transitive_declared_generated_includes(self)
         direct_hdrs, generated_hdrs = self._collect_compiler_reported_hdrs(filename + '.details')
+        # System/external include dirs (`/external:I` / `-isystem`), absolute so
+        # the check can recognize headers compiled out of them (e.g. a vcpkg
+        # tree) as system on MSVC, where every header is reported absolute and
+        # would otherwise be mis-filed as in-tree. See issue #1321.
+        _, system_incs = self._get_incs_list()
+        system_incs = [os.path.abspath(inc) for inc in system_incs]
 
         target_check_info = {
             'type': self.type,
@@ -1345,6 +1351,7 @@ class CcTarget(Target):
             'declared_incs': declared_incs,
             'declared_genhdrs': declared_genhdrs,
             'declared_genincs': declared_genincs,
+            'system_incs': system_incs,
             'severity': config.get_item('cc_config', 'hdr_dep_missing_severity'),
             'suppress': verify_suppress.get(self.key, {}),
             'unused_deps_severity': config.get_item('cc_config', 'unused_deps_severity'),

--- a/src/blade/inclusion_check.py
+++ b/src/blade/inclusion_check.py
@@ -62,7 +62,7 @@ def _scan_source_includes(full_src):
             for quoted, angle in _INCLUDE_RE.findall(text)}
 
 
-def _read_all_incstk_paths(incstk_path, build_dir):
+def _read_all_incstk_paths(incstk_path, build_dir, system_incs=()):
     """Return the set of all relative paths the compiler traversed.
 
     Used to filter source-scanned `#include`s down to paths the compiler
@@ -79,7 +79,7 @@ def _read_all_incstk_paths(incstk_path, build_dir):
                 line = line.rstrip()
                 if not _is_inclusion_line(line):
                     break
-                level, hdr = _parse_hdr_level_line(line)
+                level, hdr = _parse_hdr_level_line(line, system_incs)
                 if level == -1 or os.path.isabs(hdr):
                     continue
                 # See `_scan_source_includes` for why posixpath.normpath.
@@ -204,7 +204,7 @@ def _is_inclusion_line(line):
     return line.startswith('.')
 
 
-def _parse_inclusion_stacks(path, build_dir):
+def _parse_inclusion_stacks(path, build_dir, system_incs=()):
     """Parae headers inclusion stacks from file.
 
     Given the following inclusions found in the app/example/foo.cc.incstk:
@@ -263,7 +263,7 @@ def _parse_inclusion_stacks(path, build_dir):
             if not _is_inclusion_line(line):
                 # The remaining lines are useless for us
                 break
-            level, hdr = _parse_hdr_level_line(line)
+            level, hdr = _parse_hdr_level_line(line, system_incs)
             if level == -1:
                 console.log(f'{path}: Unrecognized line {line}')
                 break
@@ -293,7 +293,7 @@ def _parse_inclusion_stacks(path, build_dir):
     return direct_hdrs, stacks
 
 
-def _parse_hdr_level_line(line):
+def _parse_hdr_level_line(line, system_incs=()):
     """Parse a normal line of a header stack file (GCC or MSVC format).
 
     GCC example:
@@ -302,7 +302,7 @@ def _parse_hdr_level_line(line):
         Note: including file:  common/rpc/rpc_client.h
     """
     if os.name == 'nt' and line.startswith(_MSVC_INCUSION_PREFIX):
-        return _parse_msvc_hdr_level_line(line)
+        return _parse_msvc_hdr_level_line(line, system_incs)
     return _parse_gcc_hdr_level_line(line)
 
 
@@ -318,20 +318,33 @@ def _parse_gcc_hdr_level_line(line):
     return level, hdr
 
 
-def _parse_msvc_hdr_level_line(line):
+def _parse_msvc_hdr_level_line(line, system_incs=()):
     """Parse an MSVC /showIncludes format header line.
 
     MSVC format: 'Note: including file:  path\\to\\header.h'
     where the whitespace between the prefix and the path indicates the nesting level.
+
+    `system_incs` are the consumer's system/external include dirs (`/external:I`,
+    lower-cased, '/'-separated, absolute). MSVC prints *every* header absolute;
+    one under a system dir (e.g. a vcpkg tree) is external, so it is kept
+    absolute here -- the caller skips absolute headers as system, exactly as GCC
+    reports `-isystem` headers absolute on POSIX. Other headers get the cwd
+    prefix stripped to the project-relative path MSVC does not print; doing that
+    to an external header would mis-file it as a project one, since these trees
+    live under the build dir (hence under cwd). See issue #1321.
     """
     line = line[len(_MSVC_INCUSION_PREFIX):]
     hdr = line.lstrip()
     level = len(line) - len(hdr)
     # Normalize to Unix-style paths for consistency with GCC output
     hdr = to_unix_path(hdr)
+    low = hdr.lower()
+    for inc in system_incs:
+        if low.startswith(inc + '/'):
+            return level, hdr  # external header: keep absolute -> skipped
     # Remove current working directory prefix if present
     cwd = to_unix_path(os.getcwd()).lower()
-    if hdr.lower().startswith(cwd):
+    if low.startswith(cwd):
         hdr = hdr[len(cwd) + 1:]
     return level, hdr
 
@@ -367,6 +380,12 @@ class Checker:
         self.declared_incs = _unix_path_set(target['declared_incs'])
         self.declared_genhdrs = _unix_path_set(target['declared_genhdrs'])
         self.declared_genincs = _unix_path_set(target['declared_genincs'])
+        # System/external include dirs (`/external:I`): lower-cased, '/'-sep,
+        # absolute. Used to keep MSVC's absolute external headers absolute so the
+        # check treats them as system, like GCC's -isystem on POSIX (issue #1321).
+        # `.get` for forward compatibility with incchk files from older blades.
+        self.system_incs = tuple(
+            p.replace('\\', '/').lower() for p in (target.get('system_incs') or []))
         self.hdrs_deps = _unix_path_dict(target['hdrs_deps'])
         self.private_hdrs_deps = _unix_path_dict(target['private_hdrs_deps'])
         self.allowed_undeclared_hdrs = _unix_path_dict(target['allowed_undeclared_hdrs'])
@@ -595,7 +614,8 @@ class Checker:
                 console.warning('No inclusion file found for %s' % full_src)
                 return
             scanned_count[0] += 1
-            direct_hdrs, stacks = _parse_inclusion_stacks(path, self.build_dir)
+            direct_hdrs, stacks = _parse_inclusion_stacks(
+                path, self.build_dir, self.system_incs)
             # `-H` silently elides direct `#include`s already pulled in by an
             # earlier transitive chain (multiple-include-guard optimization),
             # so supplement the depth-1 set with the source's literal
@@ -605,7 +625,8 @@ class Checker:
             # out because they never reached the compiler. See issue #1171
             # and the design note in `doc/*/develop/hdrs_check.md`.
             scanned = _scan_source_includes(full_src)
-            compiled_paths = _read_all_incstk_paths(path, self.build_dir)
+            compiled_paths = _read_all_incstk_paths(
+                path, self.build_dir, self.system_incs)
             direct_hdrs = list(set(direct_hdrs) | (scanned & compiled_paths))
             all_direct_hdrs.update(direct_hdrs)
             missing_dep_hdrs = set()

--- a/src/tests/unit/parse_inclusion_stacks_test.py
+++ b/src/tests/unit/parse_inclusion_stacks_test.py
@@ -75,5 +75,38 @@ class ParseInclusionStacksTest(unittest.TestCase):
         self.assertEqual([], stacks)
 
 
+class MsvcExternalHeaderTest(unittest.TestCase):
+    """MSVC's /showIncludes prints every header absolute. A header under a
+    system/external include dir (a vcpkg `/external:I` tree) must stay absolute
+    so the checker skips it as a system header, even though it lives under the
+    build dir (hence under cwd) and would otherwise be stripped to a project-
+    relative path and flagged as an undeclared dependency. See issue #1321."""
+
+    def _line(self, abspath, level=1):
+        return '%s%s%s' % (inclusion_check._MSVC_INCUSION_PREFIX,
+                           ' ' * level, abspath)
+
+    def test_external_header_under_cwd_kept_absolute(self):
+        cwd = inclusion_check.to_unix_path(os.getcwd())
+        inc = cwd + '/build64_release/.cache/vcpkg/installed/x64-windows-static/include'
+        hdr = inc + '/fmt/format.h'
+        # Without the system-dir hint cwd is stripped -> looks in-tree (the bug).
+        _, stripped = inclusion_check._parse_msvc_hdr_level_line(self._line(hdr))
+        self.assertFalse(os.path.isabs(stripped))
+        # With it, the header stays absolute -> treated as a system header.
+        level, kept = inclusion_check._parse_msvc_hdr_level_line(
+            self._line(hdr), system_incs=(inc.lower(),))
+        self.assertEqual(kept, hdr)
+        self.assertTrue(os.path.isabs(kept))
+        self.assertEqual(level, 1)
+
+    def test_project_header_still_relativized(self):
+        cwd = inclusion_check.to_unix_path(os.getcwd())
+        hdr = cwd + '/app/example/foo.h'
+        _, out = inclusion_check._parse_msvc_hdr_level_line(
+            self._line(hdr), system_incs=('c:/some/other/include',))
+        self.assertEqual(out, 'app/example/foo.h')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #1321.

## Problem

On MSVC the inclusion check flagged a vcpkg port's **own** installed headers as a missing dependency:

```
suites/vcpkg_basic/BUILD: error: vcpkg_test: Missing dependency declaration:
  ".cache/vcpkg/installed/blade-x64-windows-static/include/fmt/format.h" is not
  declared in any cc target ...
```

## Cause

MSVC's `/showIncludes` prints **every** header as an absolute path. The parser strips the workspace (cwd) prefix to recover the project-relative path MSVC doesn't print — but a vcpkg `/external:I` tree lives under the build dir (hence under cwd), so its headers were rewritten to project-relative paths and treated as in-tree.

On POSIX this never happens: GCC's `-H` prints `-isystem` headers **absolute**, and the check already skips absolute headers as system ([`_process_hdr`](src/blade/inclusion_check.py)).

## Fix

Pass the target's system/external include dirs (the `/external:I` / `-isystem` set — exactly what `_get_incs_list()` emits for the compile line) into the check. When an MSVC header's absolute path is under one of them, **keep it absolute** so the existing absolute-header skip treats it as a system header — mirroring POSIX. This also covers any other `/external:I` consumer (e.g. `foreign_cc_library`) on MSVC, not just vcpkg.

The check-info gains a `system_incs` field (absolute); `Checker` reads it with a default so it stays compatible with `.incchk` files written by older blades.

## Verification

Unit tests for the parser (external header kept absolute incl. the under-cwd case; project header still relativized). The plumbing is sound by construction — `_get_incs_list()` is the same source that emits `/external:I "<dir>"`, and the flagged header in the bug report is exactly under that dir.

End-to-end gate: a follow-up blade-test change removes the `hdr_dep_missing_severity='warning'` Windows workaround so the `vcpkg suite (Windows MSVC)` job runs the check at `error`.

Note: local repro was impractical (this dev box is an ARM64 host; the bug is x64-CI-specific), so the authoritative check is the blade-test Windows CI job, as with #1322.