### PR TITLE
cc: silence macOS ld64 "ignoring duplicate libraries" warnings

### DIFF
--- a/src/blade/cc_rule_support.py
+++ b/src/blade/cc_rule_support.py
@@ -379,6 +379,17 @@ class CcRuleGenerator:
                 and self.build_toolchain.cc_is('gcc')):
             cppflags.append('-fno-semantic-interposition')
 
+        # macOS / Xcode 15+ ld64 warns "ignoring duplicate libraries" when
+        # several objects each carry an embedded `-lc++` auto-link option
+        # (LC_LINKER_OPTION) -- benign noise inherent to compiling C++ on
+        # macOS, and not something on blade's command line to dedup away.
+        # Silence it with ld64's own flag, but only when the linker accepts
+        # it (older ld64 doesn't know the flag and doesn't emit the warning).
+        if self.build_toolchain.target_os == 'darwin':
+            no_warn_dup = '-Wl,-no_warn_duplicate_libraries'
+            if self.build_toolchain.supports_link_flag(no_warn_dup):
+                linkflags.append(no_warn_dup)
+
         cppflags = self.build_toolchain.filter_cc_flags(cppflags)
         return cppflags, linkflags
 

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1272,7 +1272,12 @@ class CcTarget(Target):
         if cmd:
             vars['cmd'] = cmd
         is_msvc = self.blade.get_build_toolchain().cc_is('msvc')
-        extra_linkflags = [_system_lib_link_flag(lib, is_msvc) for lib in sys_libs]
+        # Dedup the system libraries: several deps can name the same one (e.g.
+        # every C++ vcpkg port's pkg-config Libs.private lists `c++` on macOS),
+        # and a repeated `-lfoo` makes ld64 warn "ignoring duplicate libraries".
+        # stable_unique keeps first occurrence, so link order is preserved.
+        extra_linkflags = [_system_lib_link_flag(lib, is_msvc)
+                           for lib in stable_unique(sys_libs)]
         extra_linkflags += self.attr.get('extra_linkflags')  # pyright: ignore[reportOperatorIssue]
         if implicit_deps is None:
             implicit_deps = []

--- a/src/blade/toolchain.py
+++ b/src/blade/toolchain.py
@@ -386,6 +386,46 @@ class ToolChain:
 
         return valid_flags
 
+    def supports_link_flag(self, flag):
+        """Whether the linker accepts *flag* (a ``-Wl,...`` driver option).
+
+        Probes by linking a tiny program and checking the exit status; an
+        unknown ``-Wl,`` option makes the driver hand it to ``ld``, which
+        errors out. Cached per (instance, flag) -- a link probe is ~100 ms
+        and the answer is invariant for the toolchain.
+
+        Used for ld64-version-specific options such as
+        ``-Wl,-no_warn_duplicate_libraries`` (new in Xcode 15's ld) that
+        error on older linkers -- which don't emit the matching warning
+        anyway, so the flag is simply omitted there.
+        """
+        cache = getattr(self, '_link_flag_support', None)
+        if cache is None:
+            cache = self._link_flag_support = {}
+        if flag in cache:
+            return cache[flag]
+        fd, exe = tempfile.mkstemp('', 'blade_linkflag_probe')
+        os.close(fd)
+        env = os.environ.copy()
+        env['LC_ALL'] = 'C'
+        argv = [self.cc, '-x', 'c', flag, '-o', exe, '-']
+        supported = False
+        try:
+            proc = subprocess.Popen(
+                argv, stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+            proc.communicate(input=b'int main() { return 0; }\n')
+            supported = proc.returncode == 0
+        except OSError:
+            supported = False
+        finally:
+            try:
+                os.remove(exe)
+            except OSError:
+                pass
+        cache[flag] = supported
+        return supported
+
 
 class GccToolChain(ToolChain):
     """GCC/Clang/MinGW/Cygwin toolchain (all GCC-family compilers)."""


### PR DESCRIPTION
## Problem

On macOS with Xcode 15+'s ld64, `blade build` emitted a flood of:

```
ld: warning: ignoring duplicate libraries: '-lc++'
```

(15 of them on a `blade build flare/...`).

## Diagnosis — two distinct sources

1. **A genuine command-line duplicate.** `_cc_link` concatenated each dep's `system_libs()` into `sys_libs` without dedup, so a single binary could receive `-lc++` / `-lpthread` more than once — e.g. several C++ vcpkg ports each list `c++` in their pkg-config `Libs.private`.

2. **Embedded auto-link directives (the majority).** Grep found *zero* `-lc++` on the actual link command lines for most warnings. Every C++ object on macOS carries an embedded `-lc++` auto-link option (`LC_LINKER_OPTION`); the new ld64 dedups these and warns. This is inherent to compiling C++ on macOS and is **not** something blade puts on the command line, so it can't be deduped away there.

## Fix

- **(1)** `stable_unique(sys_libs)` in `_cc_link` — keeps first occurrence, so link order is preserved.
- **(2)** Append `-Wl,-no_warn_duplicate_libraries` (ld64's own flag) to the intrinsic link flags on darwin — but **only when the linker accepts it**. A new `ToolChain.supports_link_flag()` probes by linking a tiny program (cached per-instance, like the existing `-###` probes). Older ld64 errors on the unknown flag and doesn't emit the warning anyway, so it's simply omitted there.

This is a general macOS/ld64 improvement, not vcpkg-specific (though C++ vcpkg ports were a common trigger of case 1).

## Verification

- `blade build flare/...`: **15 → 0** warnings; confirmed on a forced relink, not a skipped build.
- Full unit suite: **624 passed, 4 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)