### PR TITLE
cc_library: add textual_hdrs for #included non-standalone fragments

### DIFF
--- a/doc/en/build_rules/cc.md
+++ b/doc/en/build_rules/cc.md
@@ -132,6 +132,53 @@ Attributes:
   depend on the implementation part of the gtest library. It is suitable to declare it in a separate `gtest_prod`
   library instead of putting it into `gtest` library, Otherwise, the gtest library may be linked into the product code.
 
+- `textual_hdrs`: list = []
+
+  Header-like files that are exposed to dependents and `#include`d **textually**,
+  but are never compiled or parsed on their own. This is the analog of Bazel's
+  `textual_hdrs`.
+
+  Unlike `hdrs` — which must be self-contained, are checked for a header file
+  extension, and are each preprocessed standalone to build the inclusion-
+  dependency graph — `textual_hdrs` are exempt from all of that. They may have
+  any extension and need not be valid in isolation. Like `hdrs`, they are
+  declared as provided by this library, so a dependent that `#include`s one
+  passes the missing-dependency check (and the dependency counts as used).
+
+  Use it for files that only make sense pasted into the middle of another
+  translation unit:
+
+  - **X-macro / token lists** — a file `#include`d repeatedly with different
+    macro definitions to expand a list (no include guard, not standalone):
+
+    ```python
+    cc_library(
+        name = 'opcodes',
+        srcs = ['vm.cc'],          # vm.cc: #define OP(x) ...; #include "opcodes.def"
+        hdrs = ['vm.h'],
+        textual_hdrs = ['opcodes.def'],
+    )
+    ```
+
+  - **Platform-dispatch fragments** — one source `#include`s the right
+    implementation fragment per platform, so the fragments are not compiled
+    directly:
+
+    ```python
+    cc_library(
+        name = 'event_loop',
+        # event_loop.cc: #if __linux__  #include "event_loop_epoll.inc" ...
+        srcs = ['event_loop.cc'],
+        hdrs = ['event_loop.h'],
+        textual_hdrs = ['event_loop_epoll.inc', 'event_loop_kqueue.inc'],
+    )
+    ```
+
+  A file `#include`d textually but listed in `hdrs` instead would fail: blade
+  rejects a non-header extension, and otherwise tries to preprocess it on its
+  own — which errors on a fragment that references symbols/macros only defined
+  by its includer. `textual_hdrs` is the correct home for such files.
+
 - `link_all_symbols`: bool = False
 
   If you depends on the global initialization to register something, but didn't access these

--- a/doc/zh_CN/build_rules/cc.md
+++ b/doc/zh_CN/build_rules/cc.md
@@ -125,6 +125,47 @@ cc_library(
   常用来在产品代码中为测试提供支持，但是它本身只包含一些声明，并不依赖 gtest 库的实现部分。这种情况就适合再单独声明成一个
   独立的 `gtest_prod` 库，而不是和 `gtest` 库放在一起，否则可能导致 gtest 库被链接进产品代码。
 
+- `textual_hdrs`: list = []，以**文本方式**被 `#include` 的类头文件文件。
+
+  这类文件会暴露给依赖方并被文本包含，但从不单独编译或解析。这是 Bazel
+  `textual_hdrs` 的对应物。
+
+  与 `hdrs` 不同——`hdrs` 必须是自洽的、会检查头文件扩展名、并且每个都会被单独
+  预处理以构建包含依赖图——`textual_hdrs` 不受这些约束：可以是任意扩展名，也无需
+  能够独立编译。与 `hdrs` 一样，它们会被声明为由本库提供，因此依赖方 `#include`
+  其中之一即可通过“缺失依赖”检查（并使该依赖计为已使用）。
+
+  它适用于那些只有被粘贴进另一个翻译单元中间才有意义的文件：
+
+  - **X-macro / 列表展开**——一个文件以不同的宏定义被反复 `#include` 以展开一张表
+    （没有 include guard，无法独立编译）：
+
+    ```python
+    cc_library(
+        name = 'opcodes',
+        srcs = ['vm.cc'],          # vm.cc: #define OP(x) ...; #include "opcodes.def"
+        hdrs = ['vm.h'],
+        textual_hdrs = ['opcodes.def'],
+    )
+    ```
+
+  - **按平台分发的实现片段**——某个源文件按平台 `#include` 对应的实现片段，因此这些
+    片段不会被直接编译：
+
+    ```python
+    cc_library(
+        name = 'event_loop',
+        # event_loop.cc: #if __linux__  #include "event_loop_epoll.inc" ...
+        srcs = ['event_loop.cc'],
+        hdrs = ['event_loop.h'],
+        textual_hdrs = ['event_loop_epoll.inc', 'event_loop_kqueue.inc'],
+    )
+    ```
+
+  若把这种被文本包含的文件错误地列入 `hdrs`，则会失败：blade 会拒绝非头文件扩展名，
+  否则会尝试单独预处理它——而引用了仅由其包含者定义的符号/宏的片段会因此报错。
+  `textual_hdrs` 才是这类文件的正确归属。
+
 - `link_all_symbols`: bool = False，整个库的内容不管是否用到，全部链接到可执行文件中。
 
   如果你通过全局对象的构造函数执行一些动作（比如注册一些可以按运行期间字符串形式的名字动态创建的类），而这个全局变量本身没有被任何地方引用到。

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -461,6 +461,30 @@ class CcTarget(Target):
         declare_hdrs(self, hdrs)
         self.attr['expanded_hdrs'] += self._expand_sources(hdrs)
 
+    def _set_textual_hdrs(self, textual_hdrs):
+        """Set the "textual_hdrs" attribute (the bazel `textual_hdrs` analog).
+
+        Textual headers are files exposed to dependents and `#include`d
+        textually, but NEVER compiled or parsed on their own -- so any
+        extension is allowed (e.g. an `.inc`, an X-macro token-list `.list`, or
+        a platform `.cc`/`.cpp` fragment dispatched by another source). Unlike
+        `hdrs`, they are NOT added to `expanded_hdrs`, so the standalone
+        header inclusion-stack preprocess (the `cxxhdrs` rule, which would
+        choke on a fragment that isn't valid in isolation) skips them. They are
+        still declared as provided-by-this-target, so a dependent that
+        `#include`s one satisfies the inclusion-dependency check (and marks
+        this library as a used dependency).
+        """
+        textual_hdrs = var_to_list(textual_hdrs)
+        self.attr['textual_hdrs'] = textual_hdrs
+        if not textual_hdrs:
+            return
+        # Empty `exts` validates the path (no '..' / absolute, no duplicates)
+        # while skipping the header-extension check -- the whole point is to
+        # allow non-header extensions here.
+        self._check_sources('textual header', textual_hdrs, set())
+        declare_hdrs(self, textual_hdrs)
+
     __cxx_keyword_list = frozenset([
         'and', 'and_eq', 'alignas', 'alignof', 'asm', 'auto',
         'bitand', 'bitor', 'bool', 'break', 'case', 'catch',
@@ -1478,6 +1502,7 @@ class CcLibrary(CcTarget):
                  name: str | None,
                  srcs: StrOrListOpt,
                  hdrs: StrOrListOpt,
+                 textual_hdrs: StrOrListOpt,
                  deps: StrOrListOpt,
                  visibility: StrOrListOpt,
                  tags: StrOrListOpt,
@@ -1590,6 +1615,7 @@ class CcLibrary(CcTarget):
         self._add_tags('lang:cc', 'type:library')
         self._set_secret(secret, secret_revision_file)
         self._set_hdrs(hdrs)
+        self._set_textual_hdrs(textual_hdrs)
 
     def _validate_allow_undefined(self, allow_undefined):
         """Normalize and validate the target's allow_undefined attribute.
@@ -2148,6 +2174,7 @@ def cc_library(
         name: str,
         srcs: StrOrListOpt = None,
         hdrs: StrOrListOpt = None,
+        textual_hdrs: StrOrListOpt = None,
         deps: StrOrListOpt = None,
         keep_deps: StrOrListOpt = None,
         visibility: StrOrListOpt = None,
@@ -2216,6 +2243,7 @@ def cc_library(
             name=name,
             srcs=srcs,
             hdrs=hdrs,
+            textual_hdrs=textual_hdrs,
             deps=deps,
             visibility=visibility,
             tags=tags,

--- a/src/test/cc_library_test.py
+++ b/src/test/cc_library_test.py
@@ -39,6 +39,17 @@ class TestCcLibrary(blade_test.TargetTest):
 
         self.assertDynamicLinkFlags(string_depends_libs)
 
+    def testTextualHdrs(self):
+        """textual_hdrs: a #included fragment is exposed but never compiled standalone."""
+        self.assertTrue(self.runBlade())
+        # The includer is compiled normally...
+        self.assertTrue(self.findCommand(['-c', 'textual_user.cpp.o']))
+        # ...but the textual .cc fragment is not compiled on its own. (Listing
+        # it in `hdrs` instead would have failed to load -- a non-header
+        # extension -- so a successful build already proves it was accepted as
+        # a textual header.)
+        self.assertFalse(any('numbers_data.cc.o' in line for line in self.build_output))
+
 
 if __name__ == '__main__':
     blade_test.run(TestCcLibrary)

--- a/src/test/testdata/cc/BUILD
+++ b/src/test/testdata/cc/BUILD
@@ -31,6 +31,16 @@ cc_library(
     link_all_symbols=1
 )
 
+cc_library(
+    name='textual',
+    srcs=['textual_user.cpp'],
+    hdrs=[],
+    # numbers_data.cc is #included textually by textual_user.cpp; it is not a
+    # standalone TU and has a non-header extension, so it belongs in
+    # textual_hdrs rather than hdrs.
+    textual_hdrs=['numbers_data.cc'],
+)
+
 resource_library(
     name = 'static_resource',
     srcs = [

--- a/src/test/testdata/cc/numbers_data.cc
+++ b/src/test/testdata/cc/numbers_data.cc
@@ -1,0 +1,4 @@
+// A textual fragment: only valid pasted into an array initializer, never
+// compiled on its own. Declared via cc_library.textual_hdrs (a non-header
+// extension that `hdrs` would reject and try to compile standalone).
+1, 2, 3, 4

--- a/src/test/testdata/cc/textual_user.cpp
+++ b/src/test/testdata/cc/textual_user.cpp
@@ -1,0 +1,14 @@
+// Exercises cc_library.textual_hdrs: the .cc fragment below is #included
+// textually (it is not a standalone translation unit).
+
+namespace blade_test {
+
+static const int kNumbers[] = {
+#include "cc/numbers_data.cc"
+};
+
+unsigned num_numbers() {
+    return sizeof(kNumbers) / sizeof(kNumbers[0]);
+}
+
+}  // namespace blade_test


### PR DESCRIPTION
Adds **`textual_hdrs`** to `cc_library` — the analog of Bazel's `textual_hdrs`: header-like files exposed to dependents and `#include`d **textually**, but never compiled or parsed on their own.

## Why

blade's `hdrs` must be self-contained: they're restricted to header file extensions and each is preprocessed **standalone** (the `cxxhdrs` rule) to build the inclusion-dependency graph. That's wrong for files that only make sense pasted into another translation unit:

- X-macro / token-list files (`.def` / `.list` / `.inc`, no include guard)
- platform-dispatch fragments a sibling source `#include`s per-OS
- a `.cc` implementation pasted into another TU

Such files in `hdrs` fail — the non-header extension is rejected, or the standalone preprocess errors on a fragment that references symbols/macros only its includer defines. Previously the only escape was the coarse global `cc_config.allowed_undeclared_hdrs`; `textual_hdrs` is the precise, per-target home.

## Semantics

`textual_hdrs` are exempt from the three `hdrs` rules (any extension, no standalone compile, no self-containment), but are still **declared as provided by the library**, so a dependent that `#include`s one passes the missing-dependency check and the dependency counts as used.

## Implementation

`CcTarget._set_textual_hdrs` registers them via `declare_hdrs` (provider map) but does **not** add them to `expanded_hdrs` (so `cxxhdrs` skips them), and validates the path with an empty extension set (skips the header-extension/standalone-existence checks). Wired through `cc_library`. The only `CcLibrary` instantiation is `cc_library()`; prebuilt/foreign/vcpkg libs extend other bases, so no other call sites change.

## Testing
- Integration test (`testdata/cc`): a `.cc` fragment `#include`d by a source, declared in `textual_hdrs`; asserts the build accepts it and never compiles it standalone.
- en/zh docs with concrete examples (X-macro and platform-dispatch).
- Full unit suite green (626 passed).
- Exercised end-to-end porting Apache brpc (its `event_dispatcher_*.cpp`, `offset_inl.list`, `dtoa.cc` now use `textual_hdrs` instead of the global whitelist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)