### PR TITLE
ninja: print progress lines when the terminal has no cursor control

### DIFF
--- a/src/blade/console.py
+++ b/src/blade/console.py
@@ -76,6 +76,12 @@ _color_enabled = _console_support_ansi_color()
 # Conceptually independent from color support, even if they coincide on most terminals.
 _cursor_control = _console_support_cursor_control()
 
+
+def support_cursor_control():
+    """Whether the terminal supports cursor control (\r, \033[K, ...)."""
+    return _cursor_control
+
+
 # Serializes writes to stdout/stderr so the progress bar and messages don't interleave.
 _print_lock = threading.Lock()
 
@@ -450,6 +456,16 @@ def output(msg):
     """Output message without any decoration"""
     _do_print(msg)
     log(msg)
+
+
+def print_line(msg):
+    """Print a line to the terminal without logging it.
+
+    Like `output` but skips the log file -- for content that is already
+    persisted elsewhere (e.g. ninja status lines, captured in
+    ninja_output.log). Serialized with the progress bar via the print lock.
+    """
+    _do_print(msg)
 
 
 # Global Error Counter

--- a/src/blade/ninja_runner.py
+++ b/src/blade/ninja_runner.py
@@ -97,6 +97,10 @@ def _show_progress(process, file_reader):
     recent = collections.deque(maxlen=console._PANEL_MAX_RECENT)
     # In quiet mode show only the aggregate bar, not the per-step descriptions.
     quiet = console.is_quiet()
+    # A live panel needs cursor control (\r, clear-line). Without it (CI, a pipe,
+    # a dumb terminal) we fall back to printing the status lines as they arrive.
+    # Invariant for the whole build, so resolve it once.
+    cursor_control = console.support_cursor_control()
     total = finished = 0
     start = time.time()
     try:
@@ -107,13 +111,23 @@ def _show_progress(process, file_reader):
                 line = line.rstrip('\r\n')  # keep leading indent of error output
                 m = progress_re.match(line)
                 if m:
+                    # Track totals unconditionally so the final "N build steps
+                    # completed" summary is correct even without a live panel.
                     finished, total = int(m.group(1)), int(m.group(2))
-                    running = max(0, int(m.group(3)) - 1)  # %r counts the finishing edge
-                    recent.append(m.group(4))
-                    elapsed = time.time() - start
-                    eta = (total - finished) * elapsed / finished if finished else None
-                    window = () if quiet else recent
-                    console.render_build_panel(finished, running, total, window, eta)
+                    if cursor_control:
+                        running = max(0, int(m.group(3)) - 1)  # %r counts the finishing edge
+                        recent.append(m.group(4))
+                        elapsed = time.time() - start
+                        eta = (total - finished) * elapsed / finished if finished else None
+                        window = () if quiet else recent
+                        console.render_build_panel(finished, running, total, window, eta)
+                    elif not quiet:
+                        # No cursor control: print the status line so the build
+                        # stays observable. print_line (not console.output): the
+                        # full ninja stream is already persisted to
+                        # ninja_output.log, so re-logging each line is redundant.
+                        # Honors quiet like the panel path above.
+                        console.print_line(line)
                 elif line == 'ninja: no work to do.':
                     pass
                 elif line:


### PR DESCRIPTION
## Problem

blade's live build panel needs cursor control (`\r`, clear-line). On CI, through a pipe, or on a dumb terminal there's none — so the panel can't render and a long build looks stalled (no output until it finishes).

## Change

When there's no cursor control, fall back to printing ninja's status lines (`[finished/total](running) <desc>`) as they arrive, so progress stays observable.

- **console.py**
  - `support_cursor_control()` — exposes the already-cached capability.
  - `print_line(msg)` — a public print-without-log wrapper, so `ninja_runner` no longer reaches into the private `_do_print`. It skips the log file on purpose: the full ninja stream is already persisted to `ninja_output.log`, so re-logging each line would just duplicate it.
- **ninja_runner.py** (`_show_progress`)
  - resolve cursor support **once** before the loop;
  - parse the `finished/total` counts **unconditionally**, so the final `"N build steps completed"` summary still appears without a panel;
  - honor `--quiet` in the fallback exactly like the panel path (quiet → no per-step lines).

## Behavior

| Mode | Output |
|---|---|
| smart terminal | live panel (unchanged) |
| CI / piped / dumb terminal | `[1/5](1) CXX foo.cc` … per step, then `N build steps completed` |
| `--verbosity=quiet` (either) | per-step lines suppressed |

## Testing
Unit suite green (626 passed); verified piped output prints progress + summary, and `--verbosity=quiet` suppresses the per-step lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)