### PR TITLE
gen_rule: emit a plain (uncolored) build description

### DIFF
--- a/src/blade/gen_rule_target.py
+++ b/src/blade/gen_rule_target.py
@@ -237,7 +237,7 @@ class GenRuleTarget(Target):
         # `build` statement, so any other build scoped variables are expanded to empty.
         rule = '%s__rule__' % regular_variable_name(self._source_file_path(self.name))
         cmd = self._wrap_command(self._expand_command())
-        description = console.colored('{} {}'.format(self.attr['cmd_name'], self.fullname), 'dimpurple')
+        description = f"{self.attr['cmd_name']} {self.fullname}"
         self._write_rule(_RULE_FORMAT % (rule, cmd, description))
 
         outputs = self.attr['outputs']


### PR DESCRIPTION
`gen_rule` was the only rule wrapping its ninja `description` in `console.colored(...)`. Those ANSI codes become part of the description text, so they show up as **raw escape sequences** in any non-color sink — notably the status lines printed when the terminal has no cursor control (#1334), and the `.ninja` file itself. Drop the color so gen_rule matches the other rules' plain descriptions.

Unit suite green (626 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)