### PR TITLE
vcpkg: default linkage 'auto'; resolve *_main libs under lib/manual-link (#1236)

### DIFF
--- a/doc/en/build_rules/vcpkg.md
+++ b/doc/en/build_rules/vcpkg.md
@@ -96,38 +96,43 @@ The dict form of a package accepts these keys:
 | --- | --- | --- |
 | `version` | str | Pin the port version (a vcpkg `overrides` entry). |
 | `features` | list[str] | vcpkg features to enable. |
-| `linkage` | `'static'` (default) / `'dynamic'` / `'auto'` | How the port is built (see below). |
+| `linkage` | `'auto'` (default) / `'static'` / `'dynamic'` | How the port is built (see below). |
 | `link_all_symbols` | bool | Whole-archive the static lib. |
 | `include_prefix` | str / list[str] / dict | Remap the header include path. |
 | `cmake_options` | list[str] | Extra CMake configure options for the port. |
 
-### `linkage` — `static` / `dynamic` / `auto`
+### `linkage` — `auto` / `static` / `dynamic`
 
-- **`'static'`** (default) — only the static archive (`.a`) is built.
+- **`'auto'`** (default) — the same rule as `cc_library`: the static archive
+  (`.a`) is always built, **and** the shared library is built *on demand* —
+  only when a `dynamic_link` binary actually depends on the port (via the same
+  `generate_dynamic` flag analyze sets on `cc_library` deps). A static-link
+  binary then links a self-contained `.a`, while a `dynamic_link` binary links
+  one shared library. vcpkg builds one linkage per triplet, so the shared build
+  of an `'auto'` port lands in a separate `blade-<triplet>-shared` install tree
+  alongside the main static tree. A port consumed only by static-link binaries
+  never gets a shared build.
+- **`'static'`** — only the static archive is built; it serves both link modes.
+  Use for a port that has no working shared build (which `'auto'` would fail).
 - **`'dynamic'`** — only the shared library is built; *every* consumer links
   that single instance.
-- **`'auto'`** — the static archive is always built, **and** the shared library
-  is built *on demand* — only when a `dynamic_link` binary actually depends on
-  the port (the same rule as `cc_library`'s `generate_dynamic`). A static-link
-  tool then gets a self-contained `.a`, while a `dynamic_link` binary still
-  shares one shared library. vcpkg builds one linkage per triplet, so the shared
-  build of an `'auto'` port lands in a separate `blade-<triplet>-shared` install
-  tree alongside the main static tree.
 
-### `linkage: 'dynamic'` / `'auto'` — singleton libraries
+### Singleton libraries
 
 Some libraries keep a process-wide registry behind static initializers — gflags
 (the flag registry), glog, protobuf (the descriptor pool), googletest (the test
-registry). Linked **statically** into several shared libs and the executable,
-each copy gets its own registry and they collide at startup (duplicate flag /
-descriptor / test registration). Build such ports **shared** so there is a
-single instance. Use `'auto'` when some binaries link them statically (e.g. a
-self-contained build-time tool / protoc plugin) while others link dynamically;
-use `'dynamic'` to force shared everywhere:
+registry). If such a port is linked **statically into several shared libraries**,
+each `.so`/`.dylib` gets its own copy of the registry and they collide at
+runtime — duplicate flag/test registration, or a descriptor-pool lookup in one
+module that can't see what another module registered (a segfault). The default
+**`'auto'`** already prevents this: every `dynamic_link` consumer links the one
+shared instance. You only need to pin `linkage` for these when you want to
+override the default — e.g. `'dynamic'` to force shared even for static-link
+binaries:
 
 ```python
-'gflags': {'version': '2.2.2', 'linkage': 'auto'},
-'glog':   {'version': '0.7.1', 'linkage': 'auto'},
+'protobuf': {'version': '3.21.12'},   # 'auto' default: one shared libprotobuf
+                                      # across all dylibs, static for static exes
 ```
 
 ### `link_all_symbols: True` — force static initializers
@@ -135,8 +140,8 @@ use `'dynamic'` to force shared everywhere:
 For a port linked statically *once*, the linker may drop object files whose
 symbols are unreferenced — including ones whose static initializers do
 registration. `link_all_symbols` whole-archives the lib so they all run. (The
-duplicate-copy problem above is the opposite case and needs `linkage:
-'dynamic'`, not this.)
+singleton duplicate-copy problem above is the opposite case — it is handled by
+the default `'auto'`/`'dynamic'` linkage, not by this.)
 
 ### `include_prefix` — remap the header path
 

--- a/doc/en/config.md
+++ b/doc/en/config.md
@@ -903,7 +903,11 @@ you installed yourself under `<root>/installed/<triplet>`.
 **Purpose:** The whitelist of allowed ports — the single source of truth for
 what a `vcpkg#<port>:<lib>` reference may resolve to. Referencing a port that
 is not listed is a hard error. Each value is a version string or a dict with
-`version` and/or `features`:
+`version` and/or `features` (plus the optional `linkage`, `link_all_symbols`,
+`include_prefix`, `cmake_options` keys — see [Per-port
+options](build_rules/vcpkg.md#per-port-options)). `linkage` defaults to `'auto'`
+(like `cc_library`: static for static-link consumers, shared on demand for
+dynamic-link ones):
 
 ```python
 vcpkg_config(

--- a/doc/zh_CN/build_rules/vcpkg.md
+++ b/doc/zh_CN/build_rules/vcpkg.md
@@ -91,41 +91,43 @@ vcpkg_config(
 | --- | --- | --- |
 | `version` | str | 固定 port 版本（一条 vcpkg `overrides`）。 |
 | `features` | list[str] | 启用的 vcpkg features。 |
-| `linkage` | `'static'`（默认）/ `'dynamic'` / `'auto'` | 该 port 如何构建（见下）。 |
+| `linkage` | `'auto'`（默认）/ `'static'` / `'dynamic'` | 该 port 如何构建（见下）。 |
 | `link_all_symbols` | bool | 对静态库做 whole-archive。 |
 | `include_prefix` | str / list[str] / dict | 重映射头文件包含路径。 |
 | `cmake_options` | list[str] | 该 port 的额外 CMake 配置选项。 |
 
-### `linkage`——`static` / `dynamic` / `auto`
+### `linkage`——`auto` / `static` / `dynamic`
 
-- **`'static'`**（默认）——只构建静态库（`.a`）。
+- **`'auto'`**（默认）——与 `cc_library` 同一规则：静态库（`.a`）总是构建，**且**
+  共享库**按需**构建——仅当某个 `dynamic_link` 二进制真正依赖该 port 时才构建
+  （analyze 阶段在 `cc_library` 依赖上设置的 `generate_dynamic` 标志同样作用于此）。
+  这样静态链接的二进制拿到自包含的 `.a`，而 `dynamic_link` 二进制链接同一份共享库。
+  vcpkg 一个 triplet 只构建一种 linkage，所以 `'auto'` port 的共享构建落在独立的
+  `blade-<triplet>-shared` 安装树里，与主静态树并列。只被静态链接的 port 不会构建
+  共享库。
+- **`'static'`**——只构建静态库，两种链接模式共用它。用于没有可用共享构建的 port
+  （此时 `'auto'` 会构建失败）。
 - **`'dynamic'`**——只构建共享库；*所有*消费者都链接这唯一一份实例。
-- **`'auto'`**——静态库总是构建，**且**共享库**按需**构建——仅当某个
-  `dynamic_link` 二进制真正依赖该 port 时才构建（与 `cc_library` 的
-  `generate_dynamic` 同一规则）。这样静态链接的工具拿到自包含的 `.a`，而
-  `dynamic_link` 二进制仍共享同一份共享库。vcpkg 一个 triplet 只构建一种
-  linkage，所以 `'auto'` port 的共享构建落在独立的 `blade-<triplet>-shared`
-  安装树里，与主静态树并列。
 
-### `linkage: 'dynamic'` / `'auto'`——单例库
+### 单例库
 
 有些库通过静态初始化维护进程级注册表——gflags（flag 注册表）、glog、protobuf
-（descriptor pool）、googletest（测试注册表）。当它们被**静态**链接进多个共享库
-和可执行文件时，每份拷贝各有一份注册表，启动时冲突（重复注册 flag / descriptor /
-测试）。把这类 port 编成**共享库**，全进程只有一份实例。当一部分二进制静态链接
-它们（如自包含的构建期工具 / protoc 插件）、另一部分动态链接时，用 `'auto'`；要
-全程强制共享，用 `'dynamic'`：
+（descriptor pool）、googletest（测试注册表）。若这类 port 被**静态链接进多个共享库**，
+每个 `.so`/`.dylib` 各有一份注册表，运行时冲突——重复注册 flag/测试，或一个模块里
+的 descriptor pool 查不到另一个模块注册的内容（段错误）。默认的 **`'auto'`** 已经
+避免了这点：每个 `dynamic_link` 消费者都链接同一份共享实例。只有要覆盖默认行为时
+才需要显式指定 `linkage`——例如用 `'dynamic'` 强制连静态链接的二进制也用共享库：
 
 ```python
-'gflags': {'version': '2.2.2', 'linkage': 'auto'},
-'glog':   {'version': '0.7.1', 'linkage': 'auto'},
+'protobuf': {'version': '3.21.12'},   # 'auto' 默认：所有 dylib 共享同一份
+                                      # libprotobuf，静态 exe 仍用静态库
 ```
 
 ### `link_all_symbols: True`——强制运行静态初始化
 
 对只被静态链接**一次**的 port，链接器可能丢弃未被引用的目标文件——包括其中做注册
-的静态初始化。`link_all_symbols` 对该库做 whole-archive，使它们都运行。（上面的
-“多份拷贝”是相反的问题，需要 `linkage: 'dynamic'`，而不是这个。）
+的静态初始化。`link_all_symbols` 对该库做 whole-archive，使它们都运行。（上面单例库
+的“多份拷贝”是相反的问题，由默认的 `'auto'`/`'dynamic'` linkage 处理，而不是这个。）
 
 ### `include_prefix`——重映射头文件路径
 

--- a/doc/zh_CN/config.md
+++ b/doc/zh_CN/config.md
@@ -896,7 +896,10 @@ msvc_config(use_clang = True)
 
 **作用：** 允许的 port 白名单——`vcpkg#<port>:<lib>` 可解析到什么的唯一事实来源。
 引用未列出的 port 是硬错误。每个值是版本字符串，或带 `version` 和/或 `features`
-的字典：
+的字典（还可带 `linkage`、`link_all_symbols`、`include_prefix`、`cmake_options`
+等键，见[单个 port 的选项](build_rules/vcpkg.md#单个-port-的选项)）。`linkage`
+默认为 `'auto'`（与 `cc_library` 一致：静态链接消费者用静态库，动态链接消费者按需
+用共享库）：
 
 ```python
 vcpkg_config(

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -2048,17 +2048,30 @@ class VcpkgLibrary(PrebuiltCcLibrary):
         and can't be predicted at parse time. Prefer the exact name, then the
         conventional 'd' postfix, then a unique glob match; fall back to the
         exact (optimistic) name so a genuinely missing lib still surfaces as
-        ninja's 'missing' error."""
+        ninja's 'missing' error.
+
+        Some ports install a lib under `lib/manual-link/` rather than `lib/`
+        (a vcpkg convention for libs that must not be auto-linked, e.g. gtest's
+        gtest_main / gmock_main -- main() belongs in exactly one TU per exe). So
+        each candidate dir is probed, `lib_dir` first then its `manual-link`."""
         tc = self.blade.get_build_toolchain()
         base = f'{tc.lib_prefix}{self.name}'
-        exact = os.path.join(lib_dir, base + suffix)
-        if os.path.exists(exact):
-            return exact
-        postfixed = os.path.join(lib_dir, base + 'd' + suffix)
-        if os.path.exists(postfixed):
-            return postfixed
-        matches = glob.glob(os.path.join(lib_dir, base + '*' + suffix))
-        return matches[0] if len(matches) == 1 else exact
+        lib_dirs = [lib_dir, os.path.join(lib_dir, 'manual-link')]
+        for d in lib_dirs:
+            exact = os.path.join(d, base + suffix)
+            if os.path.exists(exact):
+                return exact
+        for d in lib_dirs:
+            postfixed = os.path.join(d, base + 'd' + suffix)
+            if os.path.exists(postfixed):
+                return postfixed
+        for d in lib_dirs:
+            matches = glob.glob(os.path.join(d, base + '*' + suffix))
+            if len(matches) == 1:
+                return matches[0]
+        # Optimistic fallback: the conventional lib_dir path, so a genuinely
+        # missing lib surfaces as ninja's 'missing' error on the expected name.
+        return os.path.join(lib_dir, base + suffix)
 
     def _before_generate(self):  # override
         super()._before_generate()
@@ -2068,14 +2081,29 @@ class VcpkgLibrary(PrebuiltCcLibrary):
         # real lib files now exist -- re-resolve the static archive in case the
         # port added a debug postfix we couldn't predict during _setup() at parse
         # time (e.g. an MSVC debug build's fmt -> fmtd.lib).
+        tc = self.blade.get_build_toolchain()
         if self._vcpkg_linkage in ('static', 'auto'):
-            tc = self.blade.get_build_toolchain()
             archive = self._existing_lib(self._vcpkg_lib_dir, tc.static_lib_suffix)
             self.attr['static_source'] = archive
             self._add_target_file(tc.STATIC_LIB_LABEL, archive)
             if self._vcpkg_linkage == 'static':
                 # static: the archive serves both link modes (see _setup_static).
                 self._add_target_file(tc.DYNAMIC_LIB_LABEL, archive)
+        # Re-resolve the shared lib too: like the static archive it may sit under
+        # `manual-link/` (gtest_main / gmock_main are shared there in a shared
+        # triplet), which _setup() couldn't predict. Only when a .dylib was
+        # actually built -- a 'dynamic' port always, an 'auto' port only when a
+        # dynamic_link binary depends on it.
+        if self._vcpkg_wants_dynamic():
+            shared = self._existing_lib(self._vcpkg_dynamic_lib_dir,
+                                        tc.dynamic_lib_suffix)
+            dynamic_target = self._target_file_path(os.path.basename(shared))
+            self.attr['dynamic_source'] = shared
+            self.attr['dynamic_target'] = dynamic_target
+            self._add_target_file(tc.DYNAMIC_LIB_LABEL, dynamic_target)
+            if self._vcpkg_linkage == 'dynamic':
+                # dynamic: the shared lib serves both link modes (_setup_dynamic).
+                self._add_target_file(tc.STATIC_LIB_LABEL, dynamic_target)
 
     def _vcpkg_wants_dynamic(self):
         """Whether this port's shared library should actually be materialized.

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -443,7 +443,10 @@ _CONFIG_TEMPLATE = {
         # The allow-list of packages: the single source of truth for what a
         # `vcpkg#<port>:<lib>` reference may resolve to. Each value is either a
         # version string ('fmt': '10.2.1') or a dict with version/features
-        # ('curl': {'version': '8.5.0', 'features': ['ssl', 'http2']}).
+        # ('curl': {'version': '8.5.0', 'features': ['ssl', 'http2']}). A dict
+        # may also carry linkage/link_all_symbols/include_prefix/cmake_options;
+        # linkage defaults to 'auto' (like cc_library: static for static-link
+        # consumers, shared on demand for dynamic-link ones).
         'packages': {},
         # Optional private registries -> vcpkg-configuration.json "registries".
         'registries': [],

--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -206,13 +206,23 @@ def _port_installed_files(root, triplet, port):
     return files
 
 
+def _lib_candidate_dirs(lib_dir):
+    """`lib_dir` and its `manual-link/` subdir. Some ports install an archive
+    under `lib/manual-link/` rather than `lib/` (a vcpkg convention for libs
+    that must not be auto-linked, e.g. gtest's gtest_main / gmock_main); both
+    must be searched when classifying / locating a sibling vcpkg library."""
+    return (lib_dir, os.path.join(lib_dir, 'manual-link'))
+
+
 def _is_sibling_vcpkg_lib(lib_dir, name):
     """True if `name` is another vcpkg library installed alongside this one (a
-    real archive in `lib_dir`), rather than an OS/SDK system library. Such a
-    reference is an inter-port dependency, linked via the port's own archive,
-    not as a system lib."""
+    real archive in `lib_dir` or its `manual-link/`), rather than an OS/SDK
+    system library. Such a reference is an inter-port dependency, linked via the
+    port's own archive, not as a system lib -- a `.pc`'s `Libs: -lgtest_main`
+    must not become a bare `-lgtest_main` the linker can't find."""
     candidates = ('%s.lib' % name, 'lib%s.a' % name, '%s.a' % name)
-    return any(os.path.isfile(os.path.join(lib_dir, c)) for c in candidates)
+    return any(os.path.isfile(os.path.join(d, c))
+               for d in _lib_candidate_dirs(lib_dir) for c in candidates)
 
 
 _CMAKE_LINK_LIBS_RE = re.compile(r'INTERFACE_LINK_LIBRARIES\s+"([^"]*)"')
@@ -288,11 +298,13 @@ def port_system_libs(root, triplet, port, lib_dir):
 
 
 def _sibling_archive_path(lib_dir, bare):
-    """Absolute path of a sibling vcpkg archive given its bare stem."""
-    for c in ('lib%s.a' % bare, '%s.a' % bare, '%s.lib' % bare):
-        p = os.path.join(lib_dir, c)
-        if os.path.isfile(p):
-            return os.path.abspath(p)
+    """Absolute path of a sibling vcpkg archive given its bare stem (searching
+    `lib_dir` then its `manual-link/`)."""
+    for d in _lib_candidate_dirs(lib_dir):
+        for c in ('lib%s.a' % bare, '%s.a' % bare, '%s.lib' % bare):
+            p = os.path.join(d, c)
+            if os.path.isfile(p):
+                return os.path.abspath(p)
     return ''
 
 
@@ -436,47 +448,67 @@ _VCPKG_SYSTEM_NAME = {'linux': 'Linux', 'darwin': 'Darwin'}
 _VCPKG_OSX_ARCH = {'x64': 'x86_64', 'arm64': 'arm64', 'x86': 'i386'}
 
 
+def _effective_linkage(spec):
+    """The resolved linkage for a package spec, defaulting to 'auto'.
+
+    A bare version string, or a dict without an explicit `linkage`, resolves to
+    'auto' -- matching cc_library, where a static-link binary links a dep's .a
+    and a dynamic-link binary links its .so. (Before, the default was 'static',
+    which whole-archived a private copy of a port into every consuming dylib --
+    fine for stateless libs, but it duplicated process-global singletons like
+    protobuf's descriptor pool / gflags' flag registry across dylibs.)"""
+    if isinstance(spec, dict):
+        return spec.get('linkage') or 'auto'
+    return 'auto'
+
+
 def port_options(packages, port):
     """Per-port (linkage, link_all_symbols, include_prefix) from the spec.
 
-    A bare version string -> defaults ('static', False, None). A dict spec may
+    A bare version string -> defaults ('auto', False, None). A dict spec may
     carry `linkage`, `link_all_symbols` (bool) and `include_prefix` (str: expose
     vcpkg's include dir under this subdir, for libs flare includes as
     "<prefix>/<header>" but vcpkg ships at include top).
 
     `linkage` is one of:
-      'static'  (default) -- only the static archive (.a) is built.
-      'dynamic'           -- only the shared library (.dylib/.so) is built; both
-                             link modes share that single instance.
-      'auto'              -- the static archive is always built; the shared
+      'auto'    (default) -- the static archive is always built; the shared
                              library is built *on demand*, only when a
                              dynamic_link binary actually depends on the port
                              (mirrors cc_library's generate_dynamic). This gives
                              a static-link tool a self-contained .a while a
-                             dynamic-link binary still shares one .dylib.
+                             dynamic-link binary shares one .dylib -- so a
+                             process-global singleton (protobuf descriptor pool,
+                             gflags registry) stays a single instance.
+      'static'            -- only the static archive (.a) is built; it serves
+                             both link modes. Use for a port with no working
+                             shared build (the default 'auto' would fail it).
+      'dynamic'           -- only the shared library (.dylib/.so) is built; both
+                             link modes share that single instance.
     """
     spec = packages.get(port)
-    if isinstance(spec, dict):
-        return (spec.get('linkage') or 'static',
-                bool(spec.get('link_all_symbols')),
-                spec.get('include_prefix') or None)
-    return 'static', False, None
+    link_all_symbols = bool(spec.get('link_all_symbols')) if isinstance(spec, dict) else False
+    include_prefix = spec.get('include_prefix') or None if isinstance(spec, dict) else None
+    return _effective_linkage(spec), link_all_symbols, include_prefix
 
 
 def dynamic_ports(packages):
-    """Ports whose spec requests linkage='dynamic' (sorted, deterministic).
+    """Ports whose effective linkage is 'dynamic' (sorted, deterministic).
 
     These build their shared library in the *main* install tree. 'auto' ports
     are excluded here: they build static in the main tree and their shared lib
     lands in the separate `-shared` tree (see auto_ports / setup)."""
     return sorted(p for p, s in packages.items()
-                  if isinstance(s, dict) and s.get('linkage') == 'dynamic')
+                  if _effective_linkage(s) == 'dynamic')
 
 
 def auto_ports(packages):
-    """Ports whose spec requests linkage='auto' (sorted, deterministic)."""
+    """Ports whose effective linkage is 'auto' (sorted, deterministic).
+
+    This is the default, so it includes bare-version ports and dict specs that
+    don't pin `linkage` -- every such port's shared variant is built on demand
+    in the `-shared` tree when a dynamic_link binary depends on it."""
     return sorted(p for p, s in packages.items()
-                  if isinstance(s, dict) and s.get('linkage') == 'auto')
+                  if _effective_linkage(s) == 'auto')
 
 
 def port_cmake_options(packages):

--- a/src/tests/unit/vcpkg_manifest_test.py
+++ b/src/tests/unit/vcpkg_manifest_test.py
@@ -167,31 +167,44 @@ class MsvcDebugGateTest(unittest.TestCase):
 
 class PortOptionsTest(unittest.TestCase):
 
-    def test_bare_version_defaults(self):
+    def test_bare_version_defaults_to_auto(self):
+        # Default linkage is 'auto' (cc_library-like): static for static-link
+        # consumers, shared on demand for dynamic-link ones.
         self.assertEqual(vcpkg.port_options({'fmt': '7.1.3'}, 'fmt'),
-                         ('static', False, None))
+                         ('auto', False, None))
+
+    def test_dict_without_linkage_defaults_to_auto(self):
+        self.assertEqual(
+            vcpkg.port_options({'fmt': {'version': '7.1.3'}}, 'fmt'),
+            ('auto', False, None))
 
     def test_dynamic_linkage(self):
         self.assertEqual(
             vcpkg.port_options({'gflags': {'linkage': 'dynamic'}}, 'gflags'),
             ('dynamic', False, None))
 
+    def test_explicit_static_linkage(self):
+        self.assertEqual(
+            vcpkg.port_options({'p': {'linkage': 'static'}}, 'p'),
+            ('static', False, None))
+
     def test_link_all_symbols(self):
+        # No explicit linkage -> 'auto'.
         self.assertEqual(
             vcpkg.port_options({'g': {'link_all_symbols': True}}, 'g'),
-            ('static', True, None))
+            ('auto', True, None))
 
     def test_include_prefix(self):
         self.assertEqual(
             vcpkg.port_options({'snappy': {'include_prefix': 'snappy'}}, 'snappy'),
-            ('static', False, 'snappy'))
+            ('auto', False, 'snappy'))
 
     def test_include_prefix_dict(self):
         # prefix -> vcpkg subdir mapping (e.g. "thirdparty/glog" -> include/glog).
         self.assertEqual(
             vcpkg.port_options(
                 {'glog': {'include_prefix': {'thirdparty/glog': 'glog'}}}, 'glog'),
-            ('static', False, {'thirdparty/glog': 'glog'}))
+            ('auto', False, {'thirdparty/glog': 'glog'}))
 
     def test_auto_linkage(self):
         self.assertEqual(
@@ -199,15 +212,17 @@ class PortOptionsTest(unittest.TestCase):
             ('auto', False, None))
 
     def test_dynamic_ports_sorted(self):
+        # 'fmt' (bare) is 'auto' by default, not 'dynamic'.
         pkgs = {'fmt': '7', 'gflags': {'linkage': 'dynamic'},
                 'glog': {'linkage': 'dynamic'}, 'z': {'linkage': 'static'}}
         self.assertEqual(vcpkg.dynamic_ports(pkgs), ['gflags', 'glog'])
 
-    def test_auto_ports_sorted_and_excluded_from_dynamic(self):
-        pkgs = {'fmt': '7', 'glog': {'linkage': 'auto'},
-                'gflags': {'linkage': 'auto'}, 'z': {'linkage': 'dynamic'}}
-        # 'auto' ports build static in the main tree -> not in dynamic_ports.
-        self.assertEqual(vcpkg.auto_ports(pkgs), ['gflags', 'glog'])
+    def test_auto_ports_includes_default_and_excludes_static_dynamic(self):
+        # Default is 'auto', so a bare version ('fmt') and a dict without an
+        # explicit linkage ('lz4') are 'auto'; explicit static/dynamic are not.
+        pkgs = {'fmt': '7', 'lz4': {'version': '1'},
+                's': {'linkage': 'static'}, 'z': {'linkage': 'dynamic'}}
+        self.assertEqual(vcpkg.auto_ports(pkgs), ['fmt', 'lz4'])
         self.assertEqual(vcpkg.dynamic_ports(pkgs), ['z'])
 
     def test_shared_overlay_triplet_name(self):

--- a/src/tests/unit/vcpkg_resolve_test.py
+++ b/src/tests/unit/vcpkg_resolve_test.py
@@ -275,9 +275,14 @@ class HandlerTest(unittest.TestCase):
             kw['dynamic_lib_dir'])
 
     def test_static_port_dynamic_lib_dir_falls_back_to_main(self):
+        # An explicit 'static' port has no separate `-shared` tree, so its
+        # dynamic_lib_dir falls back to the main install lib dir. (A bare version
+        # now defaults to 'auto', so pin linkage='static' to exercise this path.)
         r = _Referrer()
         with mock.patch('blade.config.get_section',
-                        return_value=self._cfg(packages={'fmt': '10.2.1'})), \
+                        return_value=self._cfg(
+                            packages={'fmt': {'version': '10.2.1',
+                                              'linkage': 'static'}})), \
              mock.patch('blade.cc_targets.VcpkgLibrary') as MockVL:
             vcpkg._vcpkg_dep_handler(r, 'fmt:fmt')
         kw = MockVL.call_args[1]


### PR DESCRIPTION
Two related vcpkg linkage/resolution fixes.

## Default linkage `'auto'`
Was `'static'`. Now matches `cc_library`: a static-link consumer links the port's static `.a`; a dynamic-link consumer links its shared lib, built **on demand** (the analyze stage already sets `generate_dynamic` on the dep closure, and `setup()` runs after analyze, so only demanded ports build shared).

This makes process-global singletons — protobuf's descriptor pool, the gflags/glog/gtest registries — resolve to a **single shared instance** across dylibs with no per-port annotation. The old `'static'` default whole-archived a private copy (and its own registry) into every consuming dylib, which collided at runtime (e.g. protobuf `FindFileByName` returning NULL in one dylib for a `.proto` registered in another → segfault).

Bare versions and dicts without an explicit `linkage` resolve to `'auto'`. Pin `linkage: 'static'` for a port with no working shared build (no fallback by design).

## `lib/manual-link/` resolution
vcpkg installs `*_main` libs (gtest_main, gmock_main) under `lib/manual-link/` so they're not auto-linked. `_existing_lib` now probes `lib/` then `lib/manual-link/`, and the sibling-lib classifier searches both.

## Docs/tests
`doc/{en,zh_CN}/build_rules/vcpkg.md` + `config.md`, the config template comment, and the unit tests updated. All vcpkg unit tests pass (140).

🤖 Generated with [Claude Code](https://claude.com/claude-code)