### PR TITLE
vcpkg: link macOS frameworks a port's pkg-config requires (#1236)

### DIFF
--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -281,11 +281,15 @@ def _windows_dll_basename(path, name):
 def _system_lib_link_flag(lib, is_msvc):
     """Render a system library (a `#name` dep) as a linker argument.
 
-    An absolute path is passed through unchanged. A bare name becomes the GNU
-    `-lname` on GCC/Clang; on MSVC (cl / clang-cl) `link.exe` / `lld-link` take
-    the import library as a positional argument instead (`name.lib`), so emit
-    that -- `-lname` is not understood there.
+    An absolute path is passed through unchanged. A `framework:<Name>` token (a
+    macOS framework a vcpkg port's pkg-config requires, see vcpkg.port_system_libs)
+    becomes `-framework <Name>`. A bare name becomes the GNU `-lname` on
+    GCC/Clang; on MSVC (cl / clang-cl) `link.exe` / `lld-link` take the import
+    library as a positional argument instead (`name.lib`), so emit that --
+    `-lname` is not understood there.
     """
+    if lib.startswith('framework:'):
+        return '-framework %s' % lib[len('framework:'):]
     if os.path.isabs(lib):
         return lib
     if is_msvc:

--- a/src/blade/vcpkg.py
+++ b/src/blade/vcpkg.py
@@ -136,6 +136,23 @@ def _extract_l_libs(tokens):
     return libs
 
 
+def _extract_frameworks(tokens):
+    """macOS framework names from `-framework <Name>` pairs in a pkg-config
+    Libs line. vcpkg ports that use Apple system frameworks list them this way
+    (e.g. libcurl.pc: `-framework SystemConfiguration -framework Security ...`);
+    a consumer must pass `-framework <Name>` or hit unresolved CF*/Sec*/SC*
+    symbols at link time."""
+    fws = []
+    want = False
+    for tok in tokens:
+        if want:
+            fws.append(tok)
+            want = False
+        elif tok == '-framework':
+            want = True
+    return fws
+
+
 def parse_pkgconfig(text):
     """Parse pkg-config (`.pc`) content into a structured dict.
 
@@ -179,6 +196,7 @@ def parse_pkgconfig(text):
         'cflags': tokens('cflags'),
         'l_libs': _extract_l_libs(libs),
         'l_private': _extract_l_libs(libs_private),
+        'frameworks': _extract_frameworks(libs) + _extract_frameworks(libs_private),
     }
 
 
@@ -269,6 +287,7 @@ def port_system_libs(root, triplet, port, lib_dir):
     returned sorted and de-duplicated. A consumer must link these or hit
     unresolved externals on MSVC (issue #1322). [] if none / metadata absent."""
     names = []
+    frameworks = []
     for path in _port_installed_files(root, triplet, port):
         is_pc = path.endswith('.pc')
         is_targets = (path.endswith('.cmake')
@@ -283,6 +302,7 @@ def port_system_libs(root, triplet, port, lib_dir):
         if is_pc:
             pc = parse_pkgconfig(text)
             names += pc['l_libs'] + pc['l_private']
+            frameworks += pc['frameworks']
         else:
             names += _cmake_link_libs(text)
     seen, result = set(), []
@@ -294,7 +314,15 @@ def port_system_libs(root, triplet, port, lib_dir):
         seen.add(key)
         if not _is_sibling_vcpkg_lib(lib_dir, bare):
             result.append(bare)
-    return sorted(result)
+    # macOS frameworks (e.g. libcurl -> SystemConfiguration/Security/CoreFoundation)
+    # are emitted as `framework:<Name>` tokens; the cc link rule renders them as
+    # `-framework <Name>` (see _system_lib_link_flag), not `-l<Name>`.
+    fw_seen, fw_result = set(), []
+    for fw in frameworks:
+        if fw.lower() not in fw_seen:
+            fw_seen.add(fw.lower())
+            fw_result.append('framework:' + fw)
+    return sorted(result) + sorted(fw_result)
 
 
 def _sibling_archive_path(lib_dir, bare):

--- a/src/tests/unit/vcpkg_helpers_test.py
+++ b/src/tests/unit/vcpkg_helpers_test.py
@@ -109,6 +109,18 @@ class ParsePkgConfigTest(unittest.TestCase):
         self.assertEqual(pc['l_private'], ['dl'])
         self.assertIn('-pthread', pc['libs_private'])
 
+    def test_macos_frameworks_extracted(self):
+        # libcurl.pc on macOS: `Libs: ... -framework SystemConfiguration
+        # -framework Security ...`. Each `-framework <Name>` pair -> a framework
+        # name; the bare names are not mistaken for -l libs.
+        pc = vcpkg.parse_pkgconfig(
+            'Name: libcurl\n'
+            'Libs: -L${libdir} -lcurl -framework SystemConfiguration '
+            '-framework Security -framework CoreFoundation\n')
+        self.assertEqual(pc['frameworks'],
+                         ['SystemConfiguration', 'Security', 'CoreFoundation'])
+        self.assertEqual(pc['l_libs'], ['curl'])
+
     def test_libs_private_msvc_dot_lib_form(self):
         # vcpkg/OpenSSL on Windows list system libs as bare `foo.lib` tokens, not
         # `-lfoo`; the `.lib` is stripped to a uniform bare name.


### PR DESCRIPTION
A vcpkg port's pkg-config can list Apple system frameworks in `Libs`/`Libs.private` as `-framework <Name>` pairs — e.g. libcurl on macOS:

```
Libs: ... -lcurl -framework SystemConfiguration -framework Security -framework CoreFoundation -framework CoreServices
```

The system-lib extraction (`_extract_l_libs`) only handled `-l`/`.lib` tokens, so `-framework X` was silently dropped and a consumer of the port hit unresolved `CF*`/`Sec*`/`SC*` symbols at link time.

**Fix:** `parse_pkgconfig` now also returns `frameworks`; `port_system_libs` emits them as `framework:<Name>` tokens; and `_system_lib_link_flag` renders those as `-framework <Name>` (not `-l<Name>`). No effect off macOS (a port's `.pc` lists no frameworks there). Unit test added; all vcpkg unit tests pass (141).

🤖 Generated with [Claude Code](https://claude.com/claude-code)