### PR TITLE
feat(coverage): C/C++ coverage report via gcovr; variant build dir (#643)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install coverage coveralls ninja
+        # gcovr drives the C/C++ coverage report exercised by cc_coverage_test.
+        python -m pip install coverage coveralls ninja gcovr
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Run integration tests
       run: |

--- a/doc/en/test.md
+++ b/doc/en/test.md
@@ -90,13 +90,19 @@ marking tests exclusive; reserve it for the two cases above.
 
 Blade supports code coverage analysis for C++, Java, and Scala tests using the `--coverage` option.
 
-### C/C++ Coverage (GCOV)
+### C/C++ Coverage (gcov + gcovr)
 
-C/C++ test coverage utilizes GCC's [gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html) implementation:
+C/C++ test coverage uses the compiler's [gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html) instrumentation (GCC, and Clang via `llvm-cov gcov`):
 
-- Coverage-related compilation flags are automatically included
-- Coverage data is collected after test execution
-- Generate reports using third-party tools like gcov or lcov
+```bash
+blade test //foo/... --coverage
+```
+
+- The coverage compile/link flags are added automatically; `.gcno`/`.gcda` data is produced during the test run.
+- After the tests finish, Blade runs [gcovr](https://gcovr.com/) to produce a directory-navigable HTML report (drill down folder by folder to per-file line views) at `<build_dir>/cc_coverage_report/index.html` (plus `coverage.xml` in Cobertura format). Install it with `pip install gcovr`; if gcovr is absent, Blade just warns and skips the report.
+- Sources under the build directory are excluded, so the report reflects your own code rather than generated sources (e.g. `*.pb.cc`) or vendored dependencies (vcpkg installs under the build dir).
+
+**Separate build directory.** A `--coverage` build is instrumented differently from a normal build, so Blade gives it its own sibling build directory with a `_coverage` suffix — e.g. `build64_release_coverage` instead of `build64_release`. The plain build directory name is unchanged, so a normal build and a coverage build coexist without clobbering or rebuilding each other, and existing workspaces/scripts are unaffected.
 
 ### Java/Scala Coverage (JaCoCo)
 

--- a/doc/zh_CN/test.md
+++ b/doc/zh_CN/test.md
@@ -86,13 +86,19 @@ cc_test(
 
 Blade 支持 C++、Java、Scala 测试的覆盖率分析，使用 `--coverage` 选项即可开启。
 
-### C/C++ 覆盖率（GCOV）
+### C/C++ 覆盖率（gcov + gcovr）
 
-C/C++ 测试覆盖率基于 GCC 的 [gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html) 实现：
+C/C++ 测试覆盖率基于编译器的 [gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html) 插桩（GCC 原生支持，Clang 通过 `llvm-cov gcov`）：
 
-- 自动加入覆盖率相关的编译选项
-- 测试执行后自动收集覆盖率数据
-- 可通过 `gcov`、`lcov` 等第三方工具生成报告
+```bash
+blade test //foo/... --coverage
+```
+
+- 自动加入覆盖率相关的编译/链接选项；测试运行时产生 `.gcno`/`.gcda` 数据。
+- 测试结束后，Blade 调用 [gcovr](https://gcovr.com/) 在 `<build_dir>/cc_coverage_report/index.html` 生成可逐级目录下钻（目录 → 文件 → 逐行）的 HTML 报告（并附带 Cobertura 格式的 `coverage.xml`）。请先 `pip install gcovr`；若未安装，Blade 只会告警并跳过报告生成。
+- 构建目录下的源文件会被排除，报告只反映你自己的代码，而非生成代码（如 `*.pb.cc`）或第三方依赖（vcpkg 安装在构建目录下）。
+
+**独立的构建目录。** `--coverage` 构建的插桩方式与普通构建不同，因此 Blade 为它单独使用一个带 `_coverage` 后缀的兄弟目录——例如 `build64_release_coverage` 而非 `build64_release`。普通构建目录名保持不变，普通构建与覆盖率构建可以并存、互不覆盖、互不触发重新编译，现有工作区与脚本也完全不受影响。
 
 ### Java / Scala 覆盖率（JaCoCo）
 

--- a/src/blade/coverage.py
+++ b/src/blade/coverage.py
@@ -11,6 +11,8 @@ Code Test Coverage.
 
 import collections
 import os
+import re
+import shutil
 import subprocess
 import zipfile
 
@@ -211,3 +213,89 @@ class JacocoReporter:
             console.warning('Failed to generate java coverage report')
             return
         self._postprocess_report(report_dir)
+
+
+class CcCoverageReporter:
+    """Generate a C/C++ coverage report from gcov data using gcovr.
+
+    Under ``blade test --coverage`` cc targets are compiled and linked with
+    ``--coverage``, emitting ``.gcno`` (at compile) and ``.gcda`` (at run)
+    next to the objects in the build dir. gcovr turns those into an HTML
+    report. The reporter degrades gracefully: it is a no-op when there is no
+    coverage data, and only warns (never fails the build) when gcovr is
+    missing or errors.
+    """
+
+    def __init__(self, build_dir, root_dir, cc_is_clang):
+        self.__build_dir = build_dir
+        self.__root_dir = root_dir
+        self.__cc_is_clang = cc_is_clang
+
+    def _has_coverage_data(self):
+        for _dirpath, _dirnames, filenames in os.walk(self.__build_dir):
+            if any(f.endswith('.gcda') for f in filenames):
+                return True
+        return False
+
+    def _gcov_executable(self):
+        """The `gcov` command for the active toolchain, or None for the default.
+
+        gcovr defaults to GNU `gcov`, which is right for GCC. Clang provides
+        gcov compatibility via `llvm-cov gcov`; on Apple toolchains llvm-cov is
+        reachable only through `xcrun`, not directly on PATH.
+        """
+        if not self.__cc_is_clang:
+            return None
+        if shutil.which('llvm-cov'):
+            return 'llvm-cov gcov'
+        if shutil.which('xcrun'):
+            return 'xcrun llvm-cov gcov'
+        return 'llvm-cov gcov'
+
+    def build_gcovr_command(self, gcovr, report_dir, gcov_executable=None):
+        """Build the gcovr command line (split out for testing)."""
+        cmd = [
+            gcovr,
+            '--root', self.__root_dir,
+            self.__build_dir,
+            # Exclude everything under the build dir: generated sources
+            # (e.g. *.pb.cc, scm.cc) and vendored deps (vcpkg installs under
+            # the build dir) are not the project's own code. Without this the
+            # report is diluted by uncovered library headers.
+            '--exclude', re.escape(self.__build_dir) + '/',
+            # gcov's counters can overflow / go negative on hot concurrent code
+            # (spin loops etc.) -- a known gcov bug (gcc #68080). Warn and keep
+            # going instead of aborting the whole report on one bad line.
+            '--gcov-ignore-parse-errors=all',
+            '--print-summary',
+            # Nested HTML: navigable directory-by-directory, drilling down to
+            # per-file line views (vs the flat file list of --html-details).
+            '--html-nested', '-o', os.path.join(report_dir, 'index.html'),
+            '--xml', os.path.join(report_dir, 'coverage.xml'),
+        ]
+        if gcov_executable:
+            cmd += ['--gcov-executable', gcov_executable]
+        return cmd
+
+    def generate(self):
+        """Run gcovr to produce an HTML (+ XML) C/C++ coverage report."""
+        if not self._has_coverage_data():
+            console.debug('No C/C++ coverage data (.gcda) found, '
+                          'skipping the C/C++ coverage report')
+            return
+
+        gcovr = shutil.which('gcovr')
+        if not gcovr:
+            console.warning('gcovr not found, skipping the C/C++ coverage '
+                            'report (install it with `pip install gcovr`)')
+            return
+
+        report_dir = os.path.join(self.__build_dir, 'cc_coverage_report')
+        if not os.path.exists(report_dir):
+            os.makedirs(report_dir)
+        console.info('Generating C/C++ coverage report `%s`' % report_dir)
+
+        cmd = self.build_gcovr_command(gcovr, report_dir, self._gcov_executable())
+        console.debug(' '.join(cmd))
+        if subprocess.call(cmd, shell=False) != 0:
+            console.warning('Failed to generate the C/C++ coverage report')

--- a/src/blade/test_runner.py
+++ b/src/blade/test_runner.py
@@ -322,11 +322,16 @@ class TestRunner(binary_runner.BinaryRunner):
                                    reverse=True)
 
     def _generate_coverage_report(self):
-        reporter = coverage.JacocoReporter(self.build_dir,
-                                           self.target_database,
-                                           self.__command_targets,
-                                           self.test_jobs)
-        reporter.generate()
+        coverage.JacocoReporter(self.build_dir,
+                                self.target_database,
+                                self.__command_targets,
+                                self.test_jobs).generate()
+        # C/C++ coverage: gcov data (.gcno/.gcda) lands in the build dir under
+        # --coverage; gcovr turns it into an HTML report.
+        from blade import build_manager  # pylint: disable=import-outside-toplevel
+        toolchain = build_manager.instance.get_build_toolchain()
+        coverage.CcCoverageReporter(self.build_dir, os.getcwd(),
+                                    toolchain.cc_is('clang')).generate()
 
     def _show_banner(self, text):
         pads = int((76 - len(text)) / 2)

--- a/src/blade/workspace.py
+++ b/src/blade/workspace.py
@@ -18,6 +18,24 @@ from blade import console
 from blade import util
 
 
+def _build_variant_suffix(options):
+    """Suffix appended to the build dir name for variant builds.
+
+    Each active variant contributes a `_<tag>` segment; with no variant the
+    result is the empty string, so the normal build dir keeps its exact
+    historical name (e.g. ``build64_release``). New variants only need to
+    append their tag here.
+    """
+    variants = []
+    if getattr(options, 'coverage', False):
+        variants.append('coverage')
+    # Future: sanitizers, e.g.
+    #   sanitizer = getattr(options, 'sanitizer', None)
+    #   if sanitizer:
+    #       variants.append(sanitizer)  # 'asan' / 'tsan' / 'ubsan'
+    return ''.join('_' + v for v in variants)
+
+
 def _generate_scm_svn():
     url = revision = 'unknown'
     returncode, stdout, stderr = util.run_command(['svn', 'info'])
@@ -109,6 +127,11 @@ class Workspace:
         build_path_format = config.get_item('global_config', 'build_path_template')
         s = string.Template(build_path_format)
         build_dir = s.substitute(bits=self.__options.bits, profile=self.__options.profile)
+        # Give variant builds (coverage, and later sanitizers) their own sibling
+        # build dir so they don't clobber or force-rebuild the normal one. The
+        # plain build keeps its exact historical name (no suffix), so existing
+        # workspaces/scripts/blade-bin are unaffected.
+        build_dir += _build_variant_suffix(self.__options)
 
         if not os.path.exists(build_dir):
             os.mkdir(build_dir)

--- a/src/test/blade_main_test.py
+++ b/src/test/blade_main_test.py
@@ -41,6 +41,7 @@ from linker_scripts_test import LinkerScriptsTest
 from build_from_subdir_test import BuildFromSubdirTest
 from root_command_test import RootCommandTest
 from deprecated_dep_test import TestDeprecatedDep
+from cc_coverage_test import TestCcCoverage
 
 from html_test_runner import HTMLTestRunner
 from test_target_test import TestTestRunner
@@ -76,6 +77,7 @@ def _main():
         unittest.defaultTestLoader.loadTestsFromTestCase(BuildFromSubdirTest),
         unittest.defaultTestLoader.loadTestsFromTestCase(RootCommandTest),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestDeprecatedDep),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestCcCoverage),
         ])
 
     generate_html = len(sys.argv) > 1 and sys.argv[1].startswith('html')

--- a/src/test/cc_coverage_test.py
+++ b/src/test/cc_coverage_test.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Author: CHEN Feng <chen3feng@gmail.com>
+
+"""Integration test for `blade test --coverage` C/C++ coverage (#643).
+
+A `--coverage` test build goes to its own sibling build dir
+(`build64_release_coverage`), instruments the cc targets, and -- when gcovr
+is available -- produces an HTML report. The plain `build64_release` name is
+left untouched.
+"""
+
+
+import os
+import shutil
+
+import blade_test
+
+
+class TestCcCoverage(blade_test.TargetTest):
+    """`blade test --coverage` instruments cc targets and reports."""
+
+    COVERAGE_BUILD_DIR = 'build64_release_coverage'
+
+    def setUp(self):
+        """setup method."""
+        self.doSetUp('coverage', 'cov_lib_test')
+        shutil.rmtree(self.COVERAGE_BUILD_DIR, ignore_errors=True)
+
+    def doTearDown(self):
+        # The base harness only cleans build64_release; remove the coverage
+        # sibling dir too.
+        shutil.rmtree(self.COVERAGE_BUILD_DIR, ignore_errors=True)
+
+    def testCoverageBuildAndReport(self):
+        self.assertTrue(self.runBlade('test', '--coverage'),
+                        'blade test --coverage failed')
+        cov_dir = self.COVERAGE_BUILD_DIR
+        # The coverage variant gets its own dir; the plain name is not renamed.
+        self.assertTrue(os.path.isdir(cov_dir),
+                        'coverage build dir %s not created' % cov_dir)
+        # Instrumented and executed -> .gcda data was produced.
+        gcda = [f for _d, _s, fs in os.walk(cov_dir) for f in fs
+                if f.endswith('.gcda')]
+        self.assertTrue(gcda, 'no .gcda coverage data produced under %s' % cov_dir)
+        # The HTML report needs gcovr; assert it whenever gcovr is installed.
+        if shutil.which('gcovr'):
+            report = os.path.join(cov_dir, 'cc_coverage_report', 'index.html')
+            self.assertTrue(os.path.exists(report),
+                            'gcovr present but no report at %s' % report)
+
+
+if __name__ == '__main__':
+    blade_test.run(TestCcCoverage)

--- a/src/test/testdata/coverage/BUILD
+++ b/src/test/testdata/coverage/BUILD
@@ -1,0 +1,4 @@
+# Self-contained fixture for the C/C++ coverage report test (#643):
+# a library + a cc_test with its own main (no gtest, no prebuilt deps).
+cc_library(name = 'cov_lib', srcs = 'cov_lib.cc', hdrs = 'cov_lib.h')
+cc_test(name = 'cov_lib_test', srcs = 'cov_lib_test.cc', deps = [':cov_lib'])

--- a/src/test/testdata/coverage/cov_lib.cc
+++ b/src/test/testdata/coverage/cov_lib.cc
@@ -1,0 +1,2 @@
+#include "coverage/cov_lib.h"
+int cov_add(int a, int b) { return a + b; }

--- a/src/test/testdata/coverage/cov_lib.h
+++ b/src/test/testdata/coverage/cov_lib.h
@@ -1,0 +1,4 @@
+#ifndef COVERAGE_COV_LIB_H
+#define COVERAGE_COV_LIB_H
+int cov_add(int a, int b);
+#endif

--- a/src/test/testdata/coverage/cov_lib_test.cc
+++ b/src/test/testdata/coverage/cov_lib_test.cc
@@ -1,0 +1,2 @@
+#include "coverage/cov_lib.h"
+int main() { return cov_add(1, 2) == 3 ? 0 : 1; }

--- a/src/tests/unit/cc_coverage_test.py
+++ b/src/tests/unit/cc_coverage_test.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for C/C++ coverage support (#643).
+
+Covers the variant build-dir suffix (so `--coverage` builds get their own
+sibling dir without renaming the plain one) and the gcovr-based
+CcCoverageReporter command construction + graceful degradation.
+"""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import coverage  # noqa: E402
+from blade.workspace import _build_variant_suffix  # noqa: E402
+
+
+class _Opts:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+class BuildVariantSuffixTest(unittest.TestCase):
+    """The plain build keeps its historical name; variants self-prefix `_`."""
+
+    def test_no_variant_is_empty(self):
+        # Empty => build dir name unchanged (e.g. build64_release).
+        self.assertEqual('', _build_variant_suffix(_Opts()))
+        self.assertEqual('', _build_variant_suffix(_Opts(coverage=False)))
+
+    def test_coverage_variant(self):
+        self.assertEqual('_coverage', _build_variant_suffix(_Opts(coverage=True)))
+
+
+class CcCoverageReporterTest(unittest.TestCase):
+    """Cover the gcovr command builder and the no-op/degradation paths."""
+
+    def _reporter(self, clang=False):
+        return coverage.CcCoverageReporter('build64_release_coverage', '.', clang)
+
+    def test_command_uses_root_and_html(self):
+        cmd = self._reporter().build_gcovr_command('gcovr', 'report')
+        self.assertEqual(cmd[0], 'gcovr')
+        self.assertIn('--root', cmd)
+        self.assertIn('build64_release_coverage', cmd)
+        self.assertIn('--html-nested', cmd)
+
+    def test_command_excludes_build_dir(self):
+        # Generated sources (*.pb.cc) and vcpkg (installed under the build dir)
+        # must be excluded so the report reflects the project's own code.
+        cmd = self._reporter().build_gcovr_command('gcovr', 'report')
+        self.assertIn('--exclude', cmd)
+        self.assertIn('build64_release_coverage/', cmd)
+
+    def test_command_tolerates_gcov_counter_glitches(self):
+        # gcov's known counter overflow/underflow bug must not abort the report.
+        cmd = self._reporter().build_gcovr_command('gcovr', 'report')
+        self.assertIn('--gcov-ignore-parse-errors=all', cmd)
+
+    def test_command_omits_gcov_executable_by_default(self):
+        cmd = self._reporter().build_gcovr_command('gcovr', 'report')
+        self.assertNotIn('--gcov-executable', cmd)
+
+    def test_command_includes_gcov_executable_when_given(self):
+        cmd = self._reporter().build_gcovr_command(
+            'gcovr', 'report', 'xcrun llvm-cov gcov')
+        self.assertIn('--gcov-executable', cmd)
+        self.assertIn('xcrun llvm-cov gcov', cmd)
+
+    def test_gcov_executable_gcc_is_default(self):
+        self.assertIsNone(self._reporter(clang=False)._gcov_executable())
+
+    def test_gcov_executable_clang_prefers_llvm_cov_on_path(self):
+        with mock.patch.object(coverage.shutil, 'which',
+                               side_effect=lambda p: '/usr/bin/llvm-cov'
+                               if p == 'llvm-cov' else None):
+            self.assertEqual('llvm-cov gcov',
+                             self._reporter(clang=True)._gcov_executable())
+
+    def test_gcov_executable_clang_falls_back_to_xcrun(self):
+        # Apple toolchain: llvm-cov not on PATH, reachable via xcrun.
+        with mock.patch.object(coverage.shutil, 'which',
+                               side_effect=lambda p: '/usr/bin/xcrun'
+                               if p == 'xcrun' else None):
+            self.assertEqual('xcrun llvm-cov gcov',
+                             self._reporter(clang=True)._gcov_executable())
+
+    def test_generate_noop_without_coverage_data(self):
+        r = self._reporter()
+        with mock.patch.object(r, '_has_coverage_data', return_value=False), \
+                mock.patch.object(coverage.subprocess, 'call') as call:
+            r.generate()
+            call.assert_not_called()
+
+    def test_generate_warns_when_gcovr_missing(self):
+        r = self._reporter()
+        with mock.patch.object(r, '_has_coverage_data', return_value=True), \
+                mock.patch.object(coverage.shutil, 'which', return_value=None), \
+                mock.patch.object(coverage.subprocess, 'call') as call:
+            r.generate()
+            call.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #643.

## What
`blade test --coverage` now generates an **HTML C/C++ coverage report** — closing the long-standing gap where only Java/Scala (JaCoCo) had report generation.

- After the tests run, Blade runs **gcovr** over the gcov data → `<build_dir>/cc_coverage_report/index.html` (+ a Cobertura `coverage.xml`). Mirrors the existing `JacocoReporter`.
- **Clang-aware**: uses `llvm-cov gcov` on Clang/Apple toolchains, plain `gcov` on GCC.
- **Graceful**: a no-op when there's no coverage data; only *warns* (never fails the build) when gcovr is missing (`pip install gcovr`).

## Variant build directory
A `--coverage` build is instrumented differently, so it gets its **own sibling build dir** via a `_coverage` suffix — `build64_release_coverage` instead of `build64_release`:

- The **plain build dir name is unchanged** → existing workspaces, `blade-bin`, `.gitignore` (`build64_*`), CI paths, scripts: zero change, nothing to migrate.
- Normal and coverage builds **coexist** — no clobbering, no forced rebuilds when toggling `--coverage` (the spirit of #627).
- The suffix is produced by a `_build_variant_suffix(options)` helper where each active variant self-prefixes `_` (empty ⇒ historical name). **Sanitizer-ready**: adding `asan`/`tsan` later is a one-line append, no new logic.

## Tests
- **Unit** (`cc_coverage_test.py`): the suffix (`'' / _coverage`), the gcovr command builder (root/html, `--gcov-executable llvm-cov gcov` only for Clang), and the degradation paths (no data → no-op; gcovr missing → warn, no call).
- **Integration** (`src/test/cc_coverage_test.py` + `testdata/coverage/`): a self-contained `cc_test` (own `main`, no gtest/prebuilt) built under `--coverage` asserts the coverage build dir + `.gcda`, and the HTML report when gcovr is present. **gcovr added to the Linux integration CI** so the report path runs there.
- Full unit suite: 654 passed. Flare integration build: green, still uses `build64_release` (unchanged).

## Docs
`doc/{en,zh_CN}/test.md` — the C/C++ coverage section updated with the gcovr report + the variant-build-dir behavior.

## Follow-ups (separate)
Python (#642) and Go (#672) coverage reports reuse this build-dir + reporter scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)