### PR TITLE
feat(coverage): Go test coverage report (#672)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,6 +23,10 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Set up Go  # for the go_test coverage integration test (go_coverage_test)
+      uses: actions/setup-go@v5
+      with:
+        go-version: 'stable'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/doc/en/test.md
+++ b/doc/en/test.md
@@ -102,6 +102,17 @@ blade test //foo/... --coverage
 - After the tests finish, Blade runs [gcovr](https://gcovr.com/) to produce a directory-navigable HTML report (drill down folder by folder to per-file line views) at `<build_dir>/cc_coverage_report/index.html` (plus `coverage.xml` in Cobertura format). Install it with `pip install gcovr`; if gcovr is absent, Blade just warns and skips the report.
 - Sources under the build directory are excluded, so the report reflects your own code rather than generated sources (e.g. `*.pb.cc`) or vendored dependencies (vcpkg installs under the build dir).
 
+### Go Coverage (go test -cover)
+
+Go test coverage uses Go's built-in cover support:
+
+```bash
+blade test //foo/... --coverage
+```
+
+- `go_test` binaries are built with `-cover -covermode=count` and run with `-test.coverprofile`, dropping one profile per test.
+- After the tests finish, Blade merges the profiles and runs `go tool cover -html` to produce a report at `<build_dir>/go_coverage_report/index.html`.
+
 **Separate build directory.** A `--coverage` build is instrumented differently from a normal build, so Blade gives it its own sibling build directory with a `_coverage` suffix — e.g. `build64_release_coverage` instead of `build64_release`. The plain build directory name is unchanged, so a normal build and a coverage build coexist without clobbering or rebuilding each other, and existing workspaces/scripts are unaffected.
 
 ### Java/Scala Coverage (JaCoCo)

--- a/doc/zh_CN/test.md
+++ b/doc/zh_CN/test.md
@@ -98,6 +98,17 @@ blade test //foo/... --coverage
 - 测试结束后，Blade 调用 [gcovr](https://gcovr.com/) 在 `<build_dir>/cc_coverage_report/index.html` 生成可逐级目录下钻（目录 → 文件 → 逐行）的 HTML 报告（并附带 Cobertura 格式的 `coverage.xml`）。请先 `pip install gcovr`；若未安装，Blade 只会告警并跳过报告生成。
 - 构建目录下的源文件会被排除，报告只反映你自己的代码，而非生成代码（如 `*.pb.cc`）或第三方依赖（vcpkg 安装在构建目录下）。
 
+### Go 覆盖率（go test -cover）
+
+Go 测试覆盖率基于 Go 内置的 cover 支持：
+
+```bash
+blade test //foo/... --coverage
+```
+
+- `go_test` 二进制以 `-cover -covermode=count` 编译，并以 `-test.coverprofile` 运行，每个测试产生一份 profile。
+- 测试结束后，Blade 合并这些 profile 并调用 `go tool cover -html` 在 `<build_dir>/go_coverage_report/index.html` 生成报告。
+
 **独立的构建目录。** `--coverage` 构建的插桩方式与普通构建不同，因此 Blade 为它单独使用一个带 `_coverage` 后缀的兄弟目录——例如 `build64_release_coverage` 而非 `build64_release`。普通构建目录名保持不变，普通构建与覆盖率构建可以并存、互不覆盖、互不触发重新编译，现有工作区与脚本也完全不受影响。
 
 ### Java / Scala 覆盖率（JaCoCo）

--- a/src/blade/coverage.py
+++ b/src/blade/coverage.py
@@ -299,3 +299,71 @@ class CcCoverageReporter:
         console.debug(' '.join(cmd))
         if subprocess.call(cmd, shell=False) != 0:
             console.warning('Failed to generate the C/C++ coverage report')
+
+
+class GoCoverageReporter:
+    """Generate a Go coverage report from `go test` coverage profiles.
+
+    Under ``blade test --coverage`` go_test binaries are built with `-cover`
+    and run with `-test.coverprofile`, dropping a `<binary>.coverprofile` next
+    to each. This merges them and renders an HTML report via `go tool cover`.
+    Degrades gracefully: a no-op when go is unconfigured or no profile exists,
+    and only warns (never fails the build) on error.
+    """
+
+    def __init__(self, build_dir, go, go_home):
+        self.__build_dir = build_dir
+        self.__go = go
+        self.__go_home = go_home
+
+    def _profiles(self):
+        found = []
+        for dirpath, _dirnames, filenames in os.walk(self.__build_dir):
+            for name in filenames:
+                if name.endswith('.coverprofile'):
+                    found.append(os.path.join(dirpath, name))
+        return found
+
+    @staticmethod
+    def merge_profiles(profiles, dest):
+        """Merge Go coverprofiles into one (single `mode:` header + all rows)."""
+        mode = 'mode: count'
+        rows = []
+        for profile in profiles:
+            with open(profile, encoding='utf-8') as f:
+                for line in f:
+                    line = line.rstrip('\n')
+                    if line.startswith('mode:'):
+                        mode = line
+                    elif line:
+                        rows.append(line)
+        with open(dest, 'w', encoding='utf-8') as f:
+            f.write(mode + '\n')
+            for row in rows:
+                f.write(row + '\n')
+
+    def generate(self):
+        """Merge profiles and render `go tool cover -html`."""
+        if not self.__go:
+            return  # go toolchain not configured
+        profiles = self._profiles()
+        if not profiles:
+            console.debug('No Go coverage profiles found, '
+                          'skipping the Go coverage report')
+            return
+
+        report_dir = os.path.join(self.__build_dir, 'go_coverage_report')
+        if not os.path.exists(report_dir):
+            os.makedirs(report_dir)
+        merged = os.path.join(report_dir, 'merged.coverprofile')
+        self.merge_profiles(profiles, merged)
+        console.info('Generating Go coverage report `%s`' % report_dir)
+
+        env = dict(os.environ)
+        if self.__go_home:
+            env['GOPATH'] = os.path.abspath(self.__go_home)
+        cmd = [self.__go, 'tool', 'cover', '-html=' + merged,
+               '-o', os.path.join(report_dir, 'index.html')]
+        console.debug(' '.join(cmd))
+        if subprocess.call(cmd, shell=False, env=env) != 0:
+            console.warning('Failed to generate the Go coverage report')

--- a/src/blade/go_targets.py
+++ b/src/blade/go_targets.py
@@ -382,9 +382,12 @@ def _generate_go_rules(ctx):
         command=f'{prefix} build -o {out_relative}${{out}} ${{extra_goflags}} ${{package}}',
         description='GO BUILD ${package}',
         pool=go_pool))
+    # Under --coverage, build the test binary with coverage instrumentation;
+    # the test runner then passes -test.coverprofile to collect a profile.
+    gotest_cover = ' -cover -covermode=count' if getattr(ctx.options, 'coverage', False) else ''
     ctx.emit_rule(NinjaRule(
         name='gotest',
-        command=f'{prefix} test -c -o {out_relative}${{out}} ${{extra_goflags}} ${{package}}',
+        command=f'{prefix} test -c{gotest_cover} -o {out_relative}${{out}} ${{extra_goflags}} ${{package}}',
         description='GO TEST ${package}',
         pool=go_pool))
 

--- a/src/blade/test_runner.py
+++ b/src/blade/test_runner.py
@@ -332,6 +332,11 @@ class TestRunner(binary_runner.BinaryRunner):
         toolchain = build_manager.instance.get_build_toolchain()
         coverage.CcCoverageReporter(self.build_dir, os.getcwd(),
                                     toolchain.cc_is('clang')).generate()
+        # Go coverage: go_test binaries drop `.coverprofile` files in the build
+        # dir; merge them into one `go tool cover` HTML report.
+        coverage.GoCoverageReporter(self.build_dir,
+                                    config.get_item('go_config', 'go'),
+                                    config.get_item('go_config', 'go_home')).generate()
 
     def _show_banner(self, text):
         pads = int((76 - len(text)) / 2)
@@ -451,6 +456,11 @@ class TestRunner(binary_runner.BinaryRunner):
             test_env = self._prepare_env(target)
             cmd = [os.path.abspath(self._executable(target))]
             cmd += self.options.args
+            if self.options.coverage and target.type == 'go_test':
+                # Go test binaries (built with -cover) write a profile here;
+                # GoCoverageReporter merges all of them into one HTML report.
+                cmd.append('-test.coverprofile=%s.coverprofile'
+                           % os.path.abspath(self._executable(target)))
             if console.color_enabled():
                 test_env['GTEST_COLOR'] = 'yes'
             else:

--- a/src/test/blade_main_test.py
+++ b/src/test/blade_main_test.py
@@ -42,6 +42,7 @@ from build_from_subdir_test import BuildFromSubdirTest
 from root_command_test import RootCommandTest
 from deprecated_dep_test import TestDeprecatedDep
 from cc_coverage_test import TestCcCoverage
+from go_coverage_test import TestGoCoverage
 
 from html_test_runner import HTMLTestRunner
 from test_target_test import TestTestRunner
@@ -78,6 +79,7 @@ def _main():
         unittest.defaultTestLoader.loadTestsFromTestCase(RootCommandTest),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestDeprecatedDep),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestCcCoverage),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestGoCoverage),
         ])
 
     generate_html = len(sys.argv) > 1 and sys.argv[1].startswith('html')

--- a/src/test/go_coverage_test.py
+++ b/src/test/go_coverage_test.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Author: CHEN Feng <chen3feng@gmail.com>
+
+"""Integration test for `blade test --coverage` Go coverage (#672).
+
+Stands up a throwaway Go module workspace, builds a go_test under
+--coverage (so the test binary is `-cover` instrumented and run with
+-test.coverprofile), and asserts the merged `go tool cover` HTML report.
+Skipped when the go toolchain is unavailable.
+"""
+
+
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+@unittest.skipUnless(shutil.which('go'), 'go toolchain not available')
+class TestGoCoverage(unittest.TestCase):
+    """`blade test --coverage` produces a Go coverage report."""
+
+    def setUp(self):
+        self.cur_dir = os.getcwd()
+        here = os.path.dirname(os.path.abspath(__file__))
+        self.blade = os.path.join(here, '..', '..', 'blade')
+        self.work = tempfile.mkdtemp(prefix='blade_go_cov_')
+
+    def tearDown(self):
+        os.chdir(self.cur_dir)
+        shutil.rmtree(self.work, ignore_errors=True)
+
+    def _write(self, rel, text):
+        path = os.path.join(self.work, rel)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(text)
+
+    def testGoCoverageReport(self):
+        go = shutil.which('go')
+        self._write('BLADE_ROOT',
+                    "go_config(go='%s', go_home='%s', go_module_enabled=True)\n"
+                    % (go, os.path.join(self.work, 'gopath')))
+        self._write('go.mod', 'module calc\n\ngo 1.20\n')
+        self._write('calc/calc.go', textwrap.dedent('''\
+            package calc
+            func Add(a, b int) int { return a + b }
+            func Sub(a, b int) int { return a - b }
+            '''))
+        self._write('calc/calc_test.go', textwrap.dedent('''\
+            package calc
+            import "testing"
+            func TestAdd(t *testing.T) { if Add(1, 2) != 3 { t.Fatal("bad") } }
+            '''))
+        self._write('calc/BUILD', textwrap.dedent('''\
+            go_library(name='calc', srcs=['calc.go'])
+            go_test(name='calc_test', srcs=['calc_test.go'], deps=[':calc'])
+            '''))
+
+        os.chdir(self.work)
+        p = subprocess.run(
+            [self.blade, 'test', 'calc:calc_test', '--coverage'],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
+        self.assertEqual(p.returncode, 0,
+                         'blade test --coverage (go) failed:\n%s' % p.stdout)
+        report = os.path.join('build64_release_coverage',
+                              'go_coverage_report', 'index.html')
+        self.assertTrue(os.path.exists(report),
+                        'no Go coverage report at %s\n%s' % (report, p.stdout))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/unit/go_coverage_test.py
+++ b/src/tests/unit/go_coverage_test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for Go coverage support (#672).
+
+Covers GoCoverageReporter: profile merging (one `mode:` header + all rows)
+and the no-op/degradation paths.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import coverage  # noqa: E402
+
+
+class GoMergeProfilesTest(unittest.TestCase):
+    """`go tool cover` takes a single profile; we merge the per-test ones."""
+
+    def _write(self, path, text):
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(text)
+
+    def test_merge_keeps_one_mode_header_and_all_rows(self):
+        with tempfile.TemporaryDirectory() as d:
+            p1 = os.path.join(d, 'a.coverprofile')
+            p2 = os.path.join(d, 'b.coverprofile')
+            self._write(p1, 'mode: count\npkg/a.go:1.1,2.2 1 1\n')
+            self._write(p2, 'mode: count\npkg/b.go:3.3,4.4 1 0\n')
+            dest = os.path.join(d, 'merged')
+            coverage.GoCoverageReporter.merge_profiles([p1, p2], dest)
+            lines = open(dest, encoding='utf-8').read().splitlines()
+            self.assertEqual(lines[0], 'mode: count')
+            self.assertEqual(lines.count('mode: count'), 1)  # exactly one header
+            self.assertIn('pkg/a.go:1.1,2.2 1 1', lines)
+            self.assertIn('pkg/b.go:3.3,4.4 1 0', lines)
+
+
+class GoCoverageReporterTest(unittest.TestCase):
+    """Cover the degradation paths."""
+
+    def test_noop_when_go_unconfigured(self):
+        r = coverage.GoCoverageReporter('build64_release_coverage', '', '')
+        with mock.patch.object(coverage.subprocess, 'call') as call:
+            r.generate()
+            call.assert_not_called()
+
+    def test_noop_when_no_profiles(self):
+        r = coverage.GoCoverageReporter('build64_release_coverage', 'go', '')
+        with mock.patch.object(r, '_profiles', return_value=[]), \
+                mock.patch.object(coverage.subprocess, 'call') as call:
+            r.generate()
+            call.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #672. Completes the C/C++ (#643) + Java/Scala + **Go** coverage trio.

## What
`blade test --coverage` now produces a Go coverage report:

- The `gotest` rule builds the test binary with `-cover -covermode=count` under `--coverage`.
- The test runner runs each go_test with `-test.coverprofile=<bin>.coverprofile`, dropping one profile per test.
- `GoCoverageReporter` merges the per-test profiles (one `mode:` header + all rows) and renders `<build_dir>/go_coverage_report/index.html` via `go tool cover -html`.
- Reuses the `_coverage` build-dir variant from #643, so go coverage builds don't clobber the normal build.
- Degrades gracefully: no-op when go is unconfigured or no profile exists; only warns (never fails) on error.

## Tests
- **Unit**: profile merge (single header, all rows) + degradation paths.
- **Integration** (`src/test/go_coverage_test.py`): stands up a throwaway go module workspace, runs `go_test` under `--coverage`, and asserts the report — `@skipUnless(go)` so it skips where go is absent. Adds **`actions/setup-go`** to the Linux integration CI so it actually runs there.
- Verified end-to-end locally: `go test -c -cover` → run with `-test.coverprofile` → merged → `go tool cover -html` (source embedded with red/green spans).
- Full unit suite: 662 passed. Flare build unaffected.

## Docs
`doc/{en,zh_CN}/test.md` — new "Go Coverage" subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)