### PR TITLE
feat(coverage): Python test coverage report (#642)

### DIFF
--- a/doc/en/test.md
+++ b/doc/en/test.md
@@ -113,6 +113,18 @@ blade test //foo/... --coverage
 - `go_test` binaries are built with `-cover -covermode=count` and run with `-test.coverprofile`, dropping one profile per test.
 - After the tests finish, Blade merges the profiles and runs `go tool cover -html` to produce a report at `<build_dir>/go_coverage_report/index.html`.
 
+### Python Coverage (coverage.py)
+
+Python test coverage uses [coverage.py](https://coverage.readthedocs.io/):
+
+```bash
+blade test //foo/... --coverage
+```
+
+- Each `py_test` runs under `coverage run -p`, writing a per-test data file.
+- After the tests finish, Blade combines them and runs `coverage html` to produce a report at `<build_dir>/py_coverage_report/index.html`. Install it for the test interpreter with `pip install coverage`; if it is unavailable, Blade just warns and skips the report.
+- Because the test runs from its packaged zip, file paths in the report carry a `.zip/` prefix.
+
 **Separate build directory.** A `--coverage` build is instrumented differently from a normal build, so Blade gives it its own sibling build directory with a `_coverage` suffix — e.g. `build64_release_coverage` instead of `build64_release`. The plain build directory name is unchanged, so a normal build and a coverage build coexist without clobbering or rebuilding each other, and existing workspaces/scripts are unaffected.
 
 ### Java/Scala Coverage (JaCoCo)

--- a/doc/zh_CN/test.md
+++ b/doc/zh_CN/test.md
@@ -109,6 +109,18 @@ blade test //foo/... --coverage
 - `go_test` 二进制以 `-cover -covermode=count` 编译，并以 `-test.coverprofile` 运行，每个测试产生一份 profile。
 - 测试结束后，Blade 合并这些 profile 并调用 `go tool cover -html` 在 `<build_dir>/go_coverage_report/index.html` 生成报告。
 
+### Python 覆盖率（coverage.py）
+
+Python 测试覆盖率基于 [coverage.py](https://coverage.readthedocs.io/)：
+
+```bash
+blade test //foo/... --coverage
+```
+
+- 每个 `py_test` 在 `coverage run -p` 下运行，各自产生一份数据文件。
+- 测试结束后，Blade 合并它们并调用 `coverage html` 在 `<build_dir>/py_coverage_report/index.html` 生成报告。请为测试解释器 `pip install coverage`；若未安装，Blade 只会告警并跳过报告生成。
+- 由于测试从打包的 zip 中运行，报告里的文件路径会带有 `.zip/` 前缀。
+
 **独立的构建目录。** `--coverage` 构建的插桩方式与普通构建不同，因此 Blade 为它单独使用一个带 `_coverage` 后缀的兄弟目录——例如 `build64_release_coverage` 而非 `build64_release`。普通构建目录名保持不变，普通构建与覆盖率构建可以并存、互不覆盖、互不触发重新编译，现有工作区与脚本也完全不受影响。
 
 ### Java / Scala 覆盖率（JaCoCo）

--- a/src/blade/builtin_tools.py
+++ b/src/blade/builtin_tools.py
@@ -1678,15 +1678,24 @@ def generate_python_binary(pybin, basedir, exclusions, mainentry, args):
     if os.name == 'nt':
         content = '@echo off\r\n'
         content += 'set "PYTHONPATH=%~dp0%~n0.zip;%PYTHONPATH%"\r\n'
-        content += f'python -m {mainentry} %*\r\n'
+        # Under `blade test --coverage` (BLADE_COVERAGE set), run through
+        # coverage.py in parallel mode; the runner sets COVERAGE_FILE.
+        content += 'set "COV="\r\n'
+        content += 'if defined BLADE_COVERAGE set "COV=-m coverage run -p"\r\n'
+        content += f'python %COV% -m {mainentry} %*\r\n'
         util.write_if_changed(pybin, content)
         return
 
     content = '#!/bin/sh\n'
     content += 'ZIP="$(dirname "$0")/$(basename "$0").zip"\n'
+    # Under `blade test --coverage` (BLADE_COVERAGE set), run through
+    # coverage.py in parallel mode; the runner sets COVERAGE_FILE so each test
+    # writes a distinct data file that PyCoverageReporter later combines.
+    content += 'COV=""\n'
+    content += 'if [ -n "$BLADE_COVERAGE" ]; then COV="-m coverage run -p"; fi\n'
     content += ('PYTHONPATH="$ZIP:$PYTHONPATH" '
                 'exec "${BLADE_PYTHON_INTERPRETER:-python3}" '
-                f'-m {mainentry} "$@"\n')
+                f'$COV -m {mainentry} "$@"\n')
     util.write_if_changed(pybin, content)
     os.chmod(pybin, 0o755)
 

--- a/src/blade/coverage.py
+++ b/src/blade/coverage.py
@@ -12,6 +12,7 @@ Code Test Coverage.
 import collections
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import zipfile
@@ -367,3 +368,56 @@ class GoCoverageReporter:
         console.debug(' '.join(cmd))
         if subprocess.call(cmd, shell=False, env=env) != 0:
             console.warning('Failed to generate the Go coverage report')
+
+
+class PyCoverageReporter:
+    """Generate a Python coverage report from coverage.py data.
+
+    Under ``blade test --coverage`` py_test wrappers run under
+    ``coverage run -p`` and write parallel-mode data files into
+    <build_dir>/py_coverage_data (the runner sets COVERAGE_FILE). This
+    combines them and renders an HTML report via ``coverage html``. The test
+    code runs from the test zipapp, so file paths in the report carry a
+    ``.zip/`` prefix. Degrades gracefully: a no-op when there is no data, and
+    only warns (never fails the build) when coverage.py is unavailable.
+    """
+
+    def __init__(self, build_dir, interpreter):
+        self.__build_dir = build_dir
+        self.__data_dir = os.path.join(build_dir, 'py_coverage_data')
+        # The interpreter the tests ran under -- it must have coverage.py.
+        self.__interp = shlex.split(interpreter) if interpreter else ['python3']
+
+    def _has_data(self):
+        if not os.path.isdir(self.__data_dir):
+            return False
+        return any(name.startswith('.coverage')
+                   for name in os.listdir(self.__data_dir))
+
+    def _coverage(self, *args, env=None, quiet=False):
+        out = subprocess.DEVNULL if quiet else None
+        return subprocess.call(self.__interp + ['-m', 'coverage', *args],
+                               env=env, stdout=out, stderr=out)
+
+    def generate(self):
+        """Combine per-test coverage data and render an HTML report."""
+        if not self._has_data():
+            console.debug('No Python coverage data found, '
+                          'skipping the Python coverage report')
+            return
+
+        if self._coverage('--version', quiet=True) != 0:
+            console.warning('coverage.py not available for the test interpreter, '
+                            'skipping the Python coverage report (install it '
+                            'with `pip install coverage`)')
+            return
+
+        report_dir = os.path.join(self.__build_dir, 'py_coverage_report')
+        env = dict(os.environ)
+        env['COVERAGE_FILE'] = os.path.join(self.__data_dir, '.coverage')
+        if self._coverage('combine', env=env) != 0:
+            console.warning('Failed to combine Python coverage data')
+            return
+        console.info('Generating Python coverage report `%s`' % report_dir)
+        if self._coverage('html', '-d', report_dir, env=env) != 0:
+            console.warning('Failed to generate the Python coverage report')

--- a/src/blade/test_runner.py
+++ b/src/blade/test_runner.py
@@ -337,6 +337,11 @@ class TestRunner(binary_runner.BinaryRunner):
         coverage.GoCoverageReporter(self.build_dir,
                                     config.get_item('go_config', 'go'),
                                     config.get_item('go_config', 'go_home')).generate()
+        # Python coverage: py_test wrappers run under `coverage run -p`; combine
+        # the data and render an HTML report with the test interpreter.
+        coverage.PyCoverageReporter(
+            self.build_dir,
+            os.environ.get('BLADE_PYTHON_INTERPRETER') or 'python3').generate()
 
     def _show_banner(self, text):
         pads = int((76 - len(text)) / 2)
@@ -472,6 +477,15 @@ class TestRunner(binary_runner.BinaryRunner):
                 test_env['PPROF_PATH'] = os.path.abspath(pprof_path)
             if self.options.coverage:
                 test_env['BLADE_COVERAGE'] = 'true'
+                if target.type == 'py_test':
+                    # py_test wrappers run under `coverage run -p`; point all of
+                    # them at one shared data dir so PyCoverageReporter can
+                    # combine the per-test (parallel-suffixed) data files.
+                    data_dir = os.path.abspath(
+                        os.path.join(self.build_dir, 'py_coverage_data'))
+                    if not os.path.exists(data_dir):
+                        os.makedirs(data_dir)
+                    test_env['COVERAGE_FILE'] = os.path.join(data_dir, '.coverage')
             tests_run_list.append((target, self._runfiles_dir(target), test_env, cmd))
 
         console.notice('%d tests to run' % len(tests_run_list))

--- a/src/test/blade_main_test.py
+++ b/src/test/blade_main_test.py
@@ -43,6 +43,7 @@ from root_command_test import RootCommandTest
 from deprecated_dep_test import TestDeprecatedDep
 from cc_coverage_test import TestCcCoverage
 from go_coverage_test import TestGoCoverage
+from py_coverage_test import TestPyCoverage
 
 from html_test_runner import HTMLTestRunner
 from test_target_test import TestTestRunner
@@ -80,6 +81,7 @@ def _main():
         unittest.defaultTestLoader.loadTestsFromTestCase(TestDeprecatedDep),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestCcCoverage),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestGoCoverage),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestPyCoverage),
         ])
 
     generate_html = len(sys.argv) > 1 and sys.argv[1].startswith('html')

--- a/src/test/py_coverage_test.py
+++ b/src/test/py_coverage_test.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Author: CHEN Feng <chen3feng@gmail.com>
+
+"""Integration test for `blade test --coverage` Python coverage (#642).
+
+Stands up a throwaway Python workspace, runs a py_test under --coverage (so
+its wrapper executes through `coverage run -p`), and asserts the combined
+`coverage html` report. Skipped when coverage.py is unavailable.
+
+The blade subprocess is pointed at this test's own interpreter
+(BLADE_PYTHON_INTERPRETER=sys.executable) so the py_test runs under a plain
+python that has coverage.py -- not the CI's multi-word self-coverage wrapper.
+"""
+
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+def _has_coverage():
+    return subprocess.call([sys.executable, '-m', 'coverage', '--version'],
+                           stdout=subprocess.DEVNULL,
+                           stderr=subprocess.DEVNULL) == 0
+
+
+@unittest.skipUnless(_has_coverage(), 'coverage.py not available')
+class TestPyCoverage(unittest.TestCase):
+    """`blade test --coverage` produces a Python coverage report."""
+
+    def setUp(self):
+        self.cur_dir = os.getcwd()
+        here = os.path.dirname(os.path.abspath(__file__))
+        self.blade = os.path.join(here, '..', '..', 'blade')
+        self.work = tempfile.mkdtemp(prefix='blade_py_cov_')
+
+    def tearDown(self):
+        os.chdir(self.cur_dir)
+        shutil.rmtree(self.work, ignore_errors=True)
+
+    def _write(self, rel, text):
+        path = os.path.join(self.work, rel)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(text)
+
+    def testPyCoverageReport(self):
+        self._write('BLADE_ROOT', '')
+        self._write('calc/calc.py', textwrap.dedent('''\
+            def add(a, b):
+                return a + b
+            def sub(a, b):
+                return a - b
+            '''))
+        self._write('calc/calc_test.py', textwrap.dedent('''\
+            import unittest
+            from calc.calc import add
+            class T(unittest.TestCase):
+                def test_add(self):
+                    self.assertEqual(add(1, 2), 3)
+            if __name__ == '__main__':
+                unittest.main()
+            '''))
+        self._write('calc/BUILD', textwrap.dedent('''\
+            py_library(name='calc', srcs=['calc.py'])
+            py_test(name='calc_test', srcs=['calc_test.py'],
+                    main='calc_test.py', deps=[':calc'])
+            '''))
+
+        env = os.environ.copy()
+        env['BLADE_PYTHON_INTERPRETER'] = sys.executable
+        os.chdir(self.work)
+        p = subprocess.run(
+            [self.blade, 'test', 'calc:calc_test', '--coverage'],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            encoding='utf-8', env=env)
+        self.assertEqual(p.returncode, 0,
+                         'blade test --coverage (py) failed:\n%s' % p.stdout)
+        report = os.path.join('build64_release_coverage',
+                              'py_coverage_report', 'index.html')
+        self.assertTrue(os.path.exists(report),
+                        'no Python coverage report at %s\n%s' % (report, p.stdout))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/unit/py_coverage_test.py
+++ b/src/tests/unit/py_coverage_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for Python coverage support (#642).
+
+Covers PyCoverageReporter: interpreter parsing and the no-op / degradation
+paths (no data, coverage.py unavailable).
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import coverage  # noqa: E402
+
+
+class PyCoverageReporterTest(unittest.TestCase):
+    """Cover interpreter parsing and degradation."""
+
+    def test_interpreter_is_split(self):
+        # A multi-word interpreter (e.g. a coverage wrapper) is tokenized.
+        r = coverage.PyCoverageReporter('bd', 'python3 -X dev')
+        self.assertEqual(r._PyCoverageReporter__interp, ['python3', '-X', 'dev'])
+
+    def test_noop_without_data(self):
+        with tempfile.TemporaryDirectory() as d:
+            r = coverage.PyCoverageReporter(d, 'python3')  # no py_coverage_data
+            with mock.patch.object(coverage.subprocess, 'call') as call:
+                r.generate()
+                call.assert_not_called()
+
+    def test_warns_when_coverage_unavailable(self):
+        with tempfile.TemporaryDirectory() as d:
+            data_dir = os.path.join(d, 'py_coverage_data')
+            os.makedirs(data_dir)
+            open(os.path.join(data_dir, '.coverage.host.1.x'), 'w').close()
+            r = coverage.PyCoverageReporter(d, 'python3')
+            # `coverage --version` fails -> unavailable; no combine/html attempted.
+            with mock.patch.object(r, '_coverage', return_value=1) as cov:
+                r.generate()
+                # Only the version probe ran (one call), then it bailed out.
+                self.assertEqual(cov.call_count, 1)
+                self.assertEqual(cov.call_args[0][0], '--version')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #642. Completes the coverage matrix: **C/C++ (#643) + Java/Scala + Go (#672) + Python**.

## What
`blade test --coverage` now produces a Python coverage report via [coverage.py](https://coverage.readthedocs.io/):

- The `py_test` wrapper runs the test through `coverage run -p` (parallel mode) when `BLADE_COVERAGE` is set.
- The test runner points all py_tests at a shared `COVERAGE_FILE` under `<build_dir>/py_coverage_data`, so each writes a distinct data file.
- `PyCoverageReporter` combines them and renders `<build_dir>/py_coverage_report/index.html` via `coverage html`, using the test interpreter (`BLADE_PYTHON_INTERPRETER`, else `python3`).
- Reuses the `_coverage` build-dir variant from #643. Degrades gracefully: no-op without data; warns (never fails) when coverage.py is unavailable.

The test runs from its packaged zipapp, so report file paths carry a `.zip/` prefix; coverage.py reads the source straight from the zip (the report renders fully).

## Tests
- **Unit**: interpreter tokenizing + degradation (no data → no-op; coverage.py missing → warn, no combine/html).
- **Integration** (`src/test/py_coverage_test.py`): throwaway python workspace, `py_test` under `--coverage`, asserts the report — `@skipUnless(coverage.py)`. Runs blade with `BLADE_PYTHON_INTERPRETER=sys.executable` so the py_test uses a plain python with coverage (not the CI's multi-word self-coverage wrapper). `coverage` is already in the integration CI deps, so it runs there.
- Verified end-to-end locally (calc.py 75% — `add` covered, `sub` not — source rendered). Full unit suite: 665 passed. Flare build unaffected.

## Docs
`doc/{en,zh_CN}/test.md` — new "Python Coverage" subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)