### PR TITLE
feat(cc): AddressSanitizer support via --sanitizer (#1038, phase 1)

### DIFF
--- a/doc/en/test.md
+++ b/doc/en/test.md
@@ -145,6 +145,25 @@ java_test_config(
 - Coverage reports are generated in `jacoco_coverage_report` directory under build directory
 - Line coverage requires `global_config.debug_info_level` of `mid` or higher (requires `-g:line` compilation flag)
 
+## Sanitizers
+
+Build and run an existing target tree under a sanitizer with a single command-line switch — no BUILD-file changes:
+
+```bash
+blade test //...                       # normal
+blade test //... --sanitizer=address   # AddressSanitizer (alias: asan)
+```
+
+A sanitizer is a **per-run choice** (a flag), not project config. `--sanitizer` applies to `build`, `run`, and `test`. Currently **AddressSanitizer** is supported on gcc / clang / Apple clang; more sanitizers and MSVC follow.
+
+- **Flags:** `-fsanitize=address -fno-omit-frame-pointer -g` are added to compiles and links (the link pulls in the sanitizer runtime). A sanitizer detection makes the test exit non-zero, so `blade test` reports it as a failure.
+- **Isolated build directory:** a sanitized build is ABI/codegen-incompatible with a normal one, so it gets its own sibling dir with a sanitizer tag — `build64_release_asan`. The plain `build64_release` is untouched, so the two coexist without clobbering or rebuilding each other.
+- **Per-target opt-out:** a target that must not be instrumented (intentional UB, a hot path, a wrapper around a non-instrumented prebuilt) sets `sanitize = False`. It still links (and still gets the runtime); only its own compiles drop the instrumentation.
+
+```python
+cc_library(name = 'crc32_hw', srcs = ['crc32_hw.cc'], sanitize = False)
+```
+
 ## Test Exclusion
 
 Blade supports selective test exclusion using the `--exclude-tests` parameter for batch test execution scenarios.

--- a/doc/zh_CN/test.md
+++ b/doc/zh_CN/test.md
@@ -141,6 +141,25 @@ java_test_config(
 - 覆盖率报告会生成到构建目录下的 `jacoco_coverage_report` 目录
 - 若需要行级覆盖率，`global_config.debug_info_level` 需设置为 `mid` 或更高（要求编译时带 `-g:line` 选项）
 
+## Sanitizer（消毒器）
+
+只需一个命令行开关，即可让现有目标树在 sanitizer 下构建并运行，无需改动 BUILD 文件：
+
+```bash
+blade test //...                       # 普通
+blade test //... --sanitizer=address   # AddressSanitizer（别名：asan）
+```
+
+sanitizer 是**每次运行的选择**（命令行开关），不是项目配置。`--sanitizer` 对 `build`/`run`/`test` 均生效。当前在 gcc / clang / Apple clang 上支持 **AddressSanitizer**；更多 sanitizer 及 MSVC 后续支持。
+
+- **编译选项：** 给编译和链接都加上 `-fsanitize=address -fno-omit-frame-pointer -g`（链接以引入 sanitizer 运行时）。sanitizer 检测到问题会让测试进程以非零退出，因此 `blade test` 会判为失败。
+- **独立的构建目录：** sanitizer 构建与普通构建在 ABI/代码生成上不兼容，因此使用带 sanitizer 标记的独立兄弟目录——`build64_release_asan`。普通的 `build64_release` 不受影响，两者可并存、互不覆盖、互不触发重新编译。
+- **按目标退出：** 不应被插桩的目标（有意的 UB、性能热点、对未插桩预编译库的包装）可设置 `sanitize = False`。它仍参与链接（仍获得运行时），只是自身的编译不再插桩。
+
+```python
+cc_library(name = 'crc32_hw', srcs = ['crc32_hw.cc'], sanitize = False)
+```
+
 ## 测试排除
 
 Blade 支持通过 `--exclude-tests` 参数在批量执行测试时选择性地排除部分测试。

--- a/src/blade/cc_rule_support.py
+++ b/src/blade/cc_rule_support.py
@@ -19,6 +19,7 @@ import textwrap
 
 from blade import config
 from blade import console
+from blade import sanitizer
 from blade import util
 from blade.ninja_rule import NinjaRule
 
@@ -341,6 +342,14 @@ class CcRuleGenerator:
         if getattr(self.options, 'coverage', False):
             cppflags.append('--coverage')
             linkflags.append('--coverage')
+
+        sanitizers = getattr(self.options, 'sanitizers', None)
+        if sanitizers:
+            sanitizer.check_toolchain(sanitizers, self.build_toolchain)
+            fsanitize = '-fsanitize=' + sanitizer.fsanitize_value(sanitizers)
+            # Frame pointers + debug info for readable, symbolized reports.
+            cppflags += [fsanitize, '-fno-omit-frame-pointer', '-g']
+            linkflags.append(fsanitize)  # link the sanitizer runtime
 
         if hasattr(self.options, 'profile-generate') and getattr(self.options, 'profile-generate') is not None:
             pgo_gen_dir = getattr(self.options, 'profile-generate')

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -23,6 +23,7 @@ from blade import build_manager
 from blade import build_rules
 from blade import cc_rule_support
 from blade import config  # lgtm[py/cyclic-import]
+from blade import sanitizer
 from blade import console
 from blade import inclusion_check
 from blade import rule_registry
@@ -353,6 +354,11 @@ class CcTarget(Target):
         if src_exts is None:
             src_exts = list(_SOURCE_FILE_EXTS)
 
+        # 'sanitize' (cc-only, default True) lets a target opt out of sanitizer
+        # instrumentation under `--sanitizer`. Consumed here (before the base
+        # unknown-kwargs check) so it's accepted only on cc targets.
+        sanitize = kwargs.pop('sanitize', True)
+
         super().__init__(
                 name=name,
                 type=type,
@@ -363,6 +369,7 @@ class CcTarget(Target):
                 tags=tags,
                 kwargs=kwargs)
 
+        self.attr['sanitize'] = bool(sanitize)
         self._check_defs(defs)
         self._check_incorrect_no_warning(warning)
 
@@ -630,6 +637,19 @@ class CcTarget(Target):
         defs = self.attr.get('defs', [])
         cpp_flags += [('-D' + macro) for macro in defs]
         cpp_flags += self.attr.get('extra_cppflags', [])
+
+        # Per-target sanitizer opt-out: drop instrumentation for this TU. The
+        # global -fsanitize=<set> still applies at link (keeping the runtime),
+        # so the target links fine -- it's just not instrumented. Check the
+        # (always-present) attr first so global options are only consulted for
+        # the rare opt-out target -- keeps this method usable in isolation.
+        if not self.attr.get('sanitize', True):
+            blade = getattr(self, 'blade', None)
+            options = blade.get_options() if blade else None
+            sanitizers = getattr(options, 'sanitizers', None)
+            if sanitizers:
+                cpp_flags.append(
+                    '-fno-sanitize=' + sanitizer.fsanitize_value(sanitizers))
 
         # Incs
         regular_incs, system_incs = self._get_incs_list()

--- a/src/blade/command_line.py
+++ b/src/blade/command_line.py
@@ -22,6 +22,7 @@ except ImportError:
 
 from blade import console
 from blade import constants
+from blade import sanitizer
 from blade.toolchain import BuildArchitecture
 from blade.toolchain import ToolChain
 
@@ -69,6 +70,9 @@ class CommandLineParser:
         command = options.command
         # Check the options with different sub command
         self._check_subcommand(command, options, targets)
+
+        # Canonicalize --sanitizer (off for subcommands without build args).
+        options.sanitizers = sanitizer.parse(getattr(options, 'sanitizer', ''))
 
         return command, options, targets
 
@@ -293,6 +297,12 @@ class CommandLineParser:
             action='store_true', default=False,
             help=argparse.SUPPRESS)
 
+    def __add_sanitizer_arguments(self, parser):
+        """Add sanitizer arguments."""
+        parser.add_argument(
+            '--sanitizer', dest='sanitizer', type=str, default='', metavar='SET',
+            help='Build and test under sanitizers, e.g. --sanitizer=address')
+
     def __add_pgo_arguments(self, parser):
         """Add Profile-guided Optimization arguments."""
         parser.add_argument(
@@ -400,6 +410,7 @@ class CommandLineParser:
             self.__add_build_actions_arguments(parser)
             self.__add_generate_arguments(parser)
             self.__add_coverage_arguments(parser)
+            self.__add_sanitizer_arguments(parser)
             self.__add_pgo_arguments(parser)
             self.__add_fission_arguments(parser)
 

--- a/src/blade/sanitizer.py
+++ b/src/blade/sanitizer.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Sanitizer selection: parse --sanitizer into -fsanitize flags + a build tag.
+
+A sanitizer is a per-run choice (a command-line flag), not project config.
+This first phase supports AddressSanitizer; ThreadSanitizer / UBSan / etc. are
+added in later phases (see blade-build#1038). The parsed set is canonical
+(deduplicated and sorted) so it drives both the -fsanitize= flag list and the
+build-dir tag identically regardless of argument order.
+"""
+
+
+from blade import console
+
+# Accepted --sanitizer name (and short alias) -> canonical -fsanitize= name.
+_ALIASES = {
+    'address': 'address',
+    'asan': 'address',
+}
+
+# Canonical -fsanitize= name -> short build-dir tag.
+_TAGS = {
+    'address': 'asan',
+}
+
+
+def parse(value):
+    """Parse a --sanitizer value into a sorted list of canonical names.
+
+    Empty / None -> ``[]`` (off). An unknown name is a fatal error.
+    """
+    if not value:
+        return []
+    canonical = set()
+    for name in value.split(','):
+        name = name.strip().lower()
+        if not name:
+            continue
+        if name not in _ALIASES:
+            console.fatal('Unknown --sanitizer "%s" (supported: %s)' %
+                          (name, ', '.join(sorted(_ALIASES))))
+        canonical.add(_ALIASES[name])
+    return sorted(canonical)
+
+
+def fsanitize_value(sanitizers):
+    """The value for ``-fsanitize=`` (e.g. ``address``)."""
+    return ','.join(sanitizers)
+
+
+def build_tag(sanitizers):
+    """The build-dir tag for the set (e.g. ``asan``); stable, sorted."""
+    return '+'.join(_TAGS[s] for s in sanitizers)
+
+
+def check_toolchain(sanitizers, toolchain):
+    """Fatal if the active toolchain can't provide a requested sanitizer."""
+    if not sanitizers:
+        return
+    if toolchain.cc_is('msvc'):
+        # MSVC /fsanitize=address support is a later phase (#1038 Phase 3).
+        console.fatal('--sanitizer is not supported on the MSVC toolchain yet')

--- a/src/blade/workspace.py
+++ b/src/blade/workspace.py
@@ -15,6 +15,7 @@ import string
 
 from blade import config
 from blade import console
+from blade import sanitizer
 from blade import util
 
 
@@ -29,10 +30,9 @@ def _build_variant_suffix(options):
     variants = []
     if getattr(options, 'coverage', False):
         variants.append('coverage')
-    # Future: sanitizers, e.g.
-    #   sanitizer = getattr(options, 'sanitizer', None)
-    #   if sanitizer:
-    #       variants.append(sanitizer)  # 'asan' / 'tsan' / 'ubsan'
+    sanitizers = getattr(options, 'sanitizers', None)
+    if sanitizers:
+        variants.append(sanitizer.build_tag(sanitizers))  # e.g. 'asan'
     return ''.join('_' + v for v in variants)
 
 

--- a/src/test/blade_main_test.py
+++ b/src/test/blade_main_test.py
@@ -44,6 +44,7 @@ from deprecated_dep_test import TestDeprecatedDep
 from cc_coverage_test import TestCcCoverage
 from go_coverage_test import TestGoCoverage
 from py_coverage_test import TestPyCoverage
+from sanitizer_test import TestSanitizerAsan
 
 from html_test_runner import HTMLTestRunner
 from test_target_test import TestTestRunner
@@ -82,6 +83,7 @@ def _main():
         unittest.defaultTestLoader.loadTestsFromTestCase(TestCcCoverage),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestGoCoverage),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestPyCoverage),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestSanitizerAsan),
         ])
 
     generate_html = len(sys.argv) > 1 and sys.argv[1].startswith('html')

--- a/src/test/sanitizer_test.py
+++ b/src/test/sanitizer_test.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Author: CHEN Feng <chen3feng@gmail.com>
+
+"""Integration test for `--sanitizer=address` (#1038).
+
+A cc_test with a heap-buffer-overflow passes normally (the OOB read returns
+garbage) but is caught and fails under `--sanitizer=address`, which also
+builds into the isolated `build64_release_asan` sibling dir.
+"""
+
+
+import os
+import shutil
+
+import blade_test
+
+
+class TestSanitizerAsan(blade_test.TargetTest):
+    """AddressSanitizer catches a bug the normal build misses."""
+
+    ASAN_BUILD_DIR = 'build64_release_asan'
+
+    def setUp(self):
+        """setup method."""
+        self.doSetUp('sanitizer', 'oob_test')
+        shutil.rmtree(self.ASAN_BUILD_DIR, ignore_errors=True)
+
+    def doTearDown(self):
+        shutil.rmtree(self.ASAN_BUILD_DIR, ignore_errors=True)
+
+    def testAsanCatchesHeapOverflow(self):
+        # Without a sanitizer the OOB read is harmless -> the test passes.
+        self.assertTrue(self.runBlade('test'),
+                        'expected the un-sanitized test to pass')
+        # Under ASan the same test is caught -> it fails.
+        self.assertFalse(
+            self.runBlade('test', '--sanitizer=address', print_error=False),
+            'expected --sanitizer=address to catch the heap-buffer-overflow')
+        # The sanitized build went to its own isolated dir.
+        self.assertTrue(os.path.isdir(self.ASAN_BUILD_DIR),
+                        'expected the %s build dir' % self.ASAN_BUILD_DIR)
+
+
+if __name__ == '__main__':
+    blade_test.run(TestSanitizerAsan)

--- a/src/test/testdata/sanitizer/BUILD
+++ b/src/test/testdata/sanitizer/BUILD
@@ -1,0 +1,3 @@
+# Fixture for the sanitizer integration test (#1038): a cc_test whose
+# heap-buffer-overflow is caught only under --sanitizer=address.
+cc_test(name = 'oob_test', srcs = ['oob_test.cc'])

--- a/src/test/testdata/sanitizer/oob_test.cc
+++ b/src/test/testdata/sanitizer/oob_test.cc
@@ -1,0 +1,12 @@
+// Heap-buffer-overflow read. AddressSanitizer must catch it under
+// `blade test --sanitizer=address`, failing the test; a normal build reads
+// garbage and returns 0 (passes). The runtime index defeats const-folding.
+int read_at(const int* p, int i) { return p[i]; }
+
+int main(int argc, char**) {
+    int* a = new int[3];
+    volatile int x = read_at(a, argc + 4);  // OOB index >= 5
+    (void)x;
+    delete[] a;
+    return 0;
+}

--- a/src/tests/unit/cc_config_pie_test.py
+++ b/src/tests/unit/cc_config_pie_test.py
@@ -147,6 +147,7 @@ class GetIntrinsicCcFlagsInterpositionTest(unittest.TestCase):
         gen.options.profile = 'release'
         gen.options.gprof = False
         gen.options.coverage = False
+        gen.options.sanitizers = []
         # `hasattr(self.options, '...')` on a Mock returns True by default;
         # explicitly delete the attrs so the PGO branches stay out.
         for attr in ('profile-generate', 'profile-use'):

--- a/src/tests/unit/sanitizer_test.py
+++ b/src/tests/unit/sanitizer_test.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for sanitizer support (#1038, ASan phase).
+
+Covers the sanitizer helper (parse/canonicalize/tag/toolchain check), the
+build-dir variant tag, and the per-target `sanitize=False` opt-out flag.
+"""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import sanitizer  # noqa: E402
+from blade.workspace import _build_variant_suffix  # noqa: E402
+
+
+class _Opts:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+class SanitizerHelperTest(unittest.TestCase):
+    def test_parse_canonicalizes_aliases_and_dedups(self):
+        self.assertEqual(['address'], sanitizer.parse('asan'))
+        self.assertEqual(['address'], sanitizer.parse('address'))
+        self.assertEqual(['address'], sanitizer.parse('asan,address'))  # dedup
+        self.assertEqual([], sanitizer.parse(''))
+        self.assertEqual([], sanitizer.parse(None))
+
+    def test_flag_and_tag(self):
+        s = sanitizer.parse('address')
+        self.assertEqual('address', sanitizer.fsanitize_value(s))
+        self.assertEqual('asan', sanitizer.build_tag(s))
+
+    def test_unknown_is_fatal(self):
+        # console.fatal raises SystemExit.
+        with self.assertRaises(SystemExit):
+            sanitizer.parse('bogus')
+
+    def test_check_toolchain_rejects_msvc(self):
+        msvc = mock.Mock()
+        msvc.cc_is.side_effect = lambda v: v == 'msvc'
+        with self.assertRaises(SystemExit):
+            sanitizer.check_toolchain(['address'], msvc)
+        # No sanitizer -> no check, no error.
+        sanitizer.check_toolchain([], msvc)
+
+
+class BuildVariantSuffixSanitizerTest(unittest.TestCase):
+    def test_sanitizer_tag_in_build_dir(self):
+        self.assertEqual('_asan',
+                         _build_variant_suffix(_Opts(sanitizers=['address'])))
+
+    def test_off_is_empty(self):
+        self.assertEqual('', _build_variant_suffix(_Opts(sanitizers=[])))
+        self.assertEqual('', _build_variant_suffix(_Opts()))
+
+    def test_composes_with_coverage(self):
+        self.assertEqual(
+            '_coverage_asan',
+            _build_variant_suffix(_Opts(coverage=True, sanitizers=['address'])))
+
+
+class PerTargetOptOutTest(unittest.TestCase):
+    """`sanitize=False` adds -fno-sanitize for that target's compiles."""
+
+    def _cc_target(self, sanitize, sanitizers):
+        from blade import cc_targets
+        target = cc_targets.CcTarget.__new__(cc_targets.CcTarget)
+        target.attr = {'defs': [], 'extra_cppflags': [], 'sanitize': sanitize}
+        target.blade = mock.Mock()
+        target.blade.get_options.return_value = _Opts(sanitizers=sanitizers)
+        target._get_incs_list = mock.Mock(return_value=([], []))
+        return target
+
+    def test_optout_drops_instrumentation(self):
+        target = self._cc_target(sanitize=False, sanitizers=['address'])
+        cpp_flags, _r, _s = target._get_cc_flags()
+        self.assertIn('-fno-sanitize=address', cpp_flags)
+
+    def test_instrumented_target_has_no_override(self):
+        target = self._cc_target(sanitize=True, sanitizers=['address'])
+        cpp_flags, _r, _s = target._get_cc_flags()
+        self.assertNotIn('-fno-sanitize=address', cpp_flags)
+
+    def test_no_sanitizer_no_override(self):
+        target = self._cc_target(sanitize=False, sanitizers=[])
+        cpp_flags, _r, _s = target._get_cc_flags()
+        self.assertNotIn('-fno-sanitize=address', cpp_flags)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Refs #1038. First vertical slice — **AddressSanitizer** end-to-end — of the full sanitizer design in that issue.

## What
```bash
blade test //...                       # normal
blade test //... --sanitizer=address   # AddressSanitizer (alias: asan)
```

A sanitizer is a **per-run choice** → a CLI flag (on build/run/test), not project config. The value is canonicalized to a sorted set (new `sanitizer` helper) that drives *both* the `-fsanitize=` flags and the build-dir tag identically.

- **Flags:** `-fsanitize=address -fno-omit-frame-pointer -g` on compile + link (link pulls in the runtime), gated on the active toolchain (gcc/clang/Apple clang; MSVC is a later phase, errors clearly for now). A sanitizer detection exits non-zero, so `blade test` reports it as a failure.
- **Build-dir isolation:** sanitized objects are codegen-incompatible with normal ones, so they get a sibling dir `build64_release_asan` via the existing `_build_variant_suffix` hook (from the coverage work). The plain `build64_release` is unchanged; the two coexist. Composes with the coverage variant (`_coverage_asan`).
- **Per-target opt-out:** `cc_*(sanitize=False)` drops `-fsanitize` from that target's compiles (adds `-fno-sanitize`) while still linking the runtime. `sanitize` is consumed in base `Target` like `deprecated` (default `True`).

## Tests
- **Unit**: helper (parse/canonicalize aliases+dedup, tag, fsanitize value, MSVC rejection), build-dir tag (`_asan`, composes with coverage), and the per-target opt-out (`-fno-sanitize=address` added iff `sanitize=False`).
- **Integration** (`src/test/sanitizer_test.py` + `testdata/sanitizer/`): a `cc_test` with a heap-buffer-overflow **passes normally** (harmless garbage read) but **fails under `--sanitizer=address`** (ASan catches it), in the isolated build dir.
- Verified end-to-end on **flare**: `--sanitizer=address` builds + instruments (98 ASan symbols in the string lib); normal build still `build64_release`.
- Full unit suite: 675 passed.

## Docs
New "Sanitizers" section in `doc/{en,zh_CN}/test.md`.

## Follow-ups (per #1038 phases)
UBSan/LSan + canonical set + UBSan-fatal (phase 2), TSan + timeout multiplier + injected `*_OPTIONS` (phase 2/3), MSVC `/fsanitize=address` (phase 3), MSan (phase 4), `cc_config.sanitizer_blocklist` (phase 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)