### PR TITLE
refactor(cc): unify sanitizer opt-out on the ${sanitize} var for all compilers

### DIFF
--- a/src/blade/cc_rule_support.py
+++ b/src/blade/cc_rule_support.py
@@ -347,7 +347,11 @@ class CcRuleGenerator:
         if sanitizers:
             sanitizer.check_compat(sanitizers)
             sanitizer.check_toolchain(sanitizers, self.build_toolchain)
-            cppflags += sanitizer.compile_flags(sanitizers)
+            # Compile-side instrumentation rides the overridable `${sanitize}`
+            # ninja var (emitted by _generate_cc_vars) so a per-target
+            # sanitize=False can blank it for that target's edges -- the same
+            # mechanism the MSVC path uses, instead of subtracting -fno-sanitize.
+            # Only the link flags (which pull in the runtime) stay global.
             linkflags += sanitizer.link_flags(sanitizers)
 
         if hasattr(self.options, 'profile-generate') and getattr(self.options, 'profile-generate') is not None:
@@ -674,15 +678,23 @@ class CcRuleGenerator:
         # optimize_flags is need for `always_optimize`
         optimize_flags = config.get_item('cc_config', 'optimize')
         optimize = '$optimize_flags' if self.options.profile == 'release' else ''
+        # Sanitizer instrumentation (issue #1038) as an overridable variable:
+        # the default is the active set's compile flags, and a per-target
+        # sanitize=False blanks `${sanitize}` on that target's edges (see
+        # CcTarget._get_cc_vars). The set is already validated in
+        # _get_intrinsic_cc_flags, which runs first.
+        sanitizers = getattr(self.options, 'sanitizers', None)
+        sanitize = ' '.join(sanitizer.compile_flags(sanitizers)) if sanitizers else ''
         self._add_line(textwrap.dedent('''\
                 c_warnings = %s
                 cxx_warnings = %s
                 cu_warnings = %s
                 optimize_flags = %s
                 optimize = %s
+                sanitize = %s
                 ''') % (' '.join(c_warnings), ' '.join(cxx_warnings),
                         ' '.join(cu_warnings),
-                        ' '.join(optimize_flags), optimize))
+                        ' '.join(optimize_flags), optimize, sanitize))
 
     def _generate_cc_compile_rules(self, cc, cxx, cppflags):
         self._generate_cc_vars()
@@ -697,7 +709,7 @@ class CcRuleGenerator:
         template = self._cc_compile_command_wrapper_template('${inclusion_stack}')
 
         cc_command = ('%s -o ${out} -MMD -MF ${out}.d -c -fPIC %s %s ${optimize} '
-                      '${c_warnings} ${cppflags} ${extra_compile_flags} %s ${includes} ${in}') % (
+                      '${c_warnings} ${cppflags} ${sanitize} ${extra_compile_flags} %s ${includes} ${in}') % (
                               cc, ' '.join(cflags), ' '.join(cppflags), includes)
         self.generate_rule(name='cc',
                            command=template % cc_command,
@@ -710,7 +722,7 @@ class CcRuleGenerator:
                            restat=True)
 
         cxx_command = ('%s -o ${out} -MMD -MF ${out}.d -c -fPIC %s %s ${optimize} '
-                       '${cxx_warnings} ${cppflags} ${extra_compile_flags} %s ${includes} ${in}') % (
+                       '${cxx_warnings} ${cppflags} ${sanitize} ${extra_compile_flags} %s ${includes} ${in}') % (
                                cxx, ' '.join(cxxflags), ' '.join(cppflags), includes)
         self.generate_rule(name='cxx',
                            command=template % cxx_command,
@@ -934,6 +946,13 @@ class CcRuleGenerator:
         cuda_config = config.get_section('cuda_config')
         cxxflags = cc_config['cxxflags']
         cppflags, _ = self._get_intrinsic_cc_flags()
+        # cc/cxx carry sanitizer instrumentation via the overridable ${sanitize}
+        # var (so per-target opt-out can blank it); the cuda rule has no such var,
+        # so fold the compile flags in here directly -- cuda has no per-target
+        # opt-out, so it just always instruments under --sanitizer (as before).
+        sanitizers = getattr(self.options, 'sanitizers', None)
+        if sanitizers:
+            cppflags = cppflags + sanitizer.compile_flags(sanitizers)
         cppflags = cc_config['cppflags'] + cppflags
         cxxflags = ['-Xcompiler %s' % flag for flag in cxxflags]
         cppflags = ['-Xcompiler %s' % flag for flag in cppflags]

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -23,7 +23,6 @@ from blade import build_manager
 from blade import build_rules
 from blade import cc_rule_support
 from blade import config  # lgtm[py/cyclic-import]
-from blade import sanitizer
 from blade import console
 from blade import inclusion_check
 from blade import rule_registry
@@ -638,21 +637,9 @@ class CcTarget(Target):
         cpp_flags += [('-D' + macro) for macro in defs]
         cpp_flags += self.attr.get('extra_cppflags', [])
 
-        # Per-target sanitizer opt-out: drop instrumentation for this TU. The
-        # global -fsanitize=<set> still applies at link (keeping the runtime),
-        # so the target links fine -- it's just not instrumented. Check the
-        # (always-present) attr first so global options are only consulted for
-        # the rare opt-out target -- keeps this method usable in isolation.
-        if not self.attr.get('sanitize', True):
-            blade = getattr(self, 'blade', None)
-            options = blade.get_options() if blade else None
-            sanitizers = getattr(options, 'sanitizers', None)
-            # cl.exe has no per-TU `/fsanitize` opt-out, so `sanitize=False`
-            # can't drop instrumentation on MSVC -- skip rather than emit a flag
-            # cl rejects. (GCC/Clang use -fno-sanitize, where the later flag wins.)
-            if sanitizers and not (blade and blade.get_build_toolchain().cc_is('msvc')):
-                cpp_flags.append(
-                    '-fno-sanitize=' + sanitizer.fsanitize_value(sanitizers))
+        # Sanitizer opt-out is handled uniformly by blanking the `${sanitize}`
+        # ninja var in _get_cc_vars (works on every compiler, including those
+        # without a -fno-sanitize), not by subtracting a flag here.
 
         # Incs
         regular_incs, system_incs = self._get_incs_list()
@@ -761,13 +748,12 @@ class CcTarget(Target):
         if optimize is not None:
             vars['optimize'] = optimize
 
-        # Per-target sanitizer opt-out on MSVC: cl has no `-fno-sanitize` to
-        # subtract per file (the GCC path uses that in _get_cc_flags), so blank
-        # the overridable `${sanitize}` var on this target's edges instead. The
-        # binary still links the runtime; only this target's compiles drop the
-        # instrumentation. (#1038 Phase 3.)
+        # Per-target sanitizer opt-out (every compiler): blank the overridable
+        # `${sanitize}` var on this target's edges so its compiles drop the
+        # instrumentation. The binary still links the runtime (a global link
+        # flag), so it links fine. Uniform across gcc/clang/MSVC -- no
+        # -fno-sanitize subtraction needed. Check the always-present attr first.
         if (not self.attr.get('sanitize', True)
-                and self.blade.get_build_toolchain().cc_is('msvc')
                 and getattr(self.blade.get_options(), 'sanitizers', None)):
             vars['sanitize'] = ''
 

--- a/src/tests/unit/sanitizer_test.py
+++ b/src/tests/unit/sanitizer_test.py
@@ -130,7 +130,7 @@ class BuildVariantSuffixSanitizerTest(unittest.TestCase):
 
 
 class PerTargetOptOutTest(unittest.TestCase):
-    """`sanitize=False` adds -fno-sanitize for that target's compiles."""
+    """`sanitize=False` blanks the ${sanitize} ninja var on every compiler."""
 
     def _cc_target(self, sanitize, sanitizers, vendor='gcc'):
         from blade import cc_targets
@@ -144,46 +144,32 @@ class PerTargetOptOutTest(unittest.TestCase):
         target._get_incs_list = mock.Mock(return_value=([], []))
         return target
 
-    def test_optout_drops_instrumentation(self):
-        target = self._cc_target(sanitize=False, sanitizers=['address'])
-        cpp_flags, _r, _s = target._get_cc_flags()
-        self.assertIn('-fno-sanitize=address', cpp_flags)
-
-    def test_instrumented_target_has_no_override(self):
-        target = self._cc_target(sanitize=True, sanitizers=['address'])
-        cpp_flags, _r, _s = target._get_cc_flags()
-        self.assertNotIn('-fno-sanitize=address', cpp_flags)
-
-    def test_no_sanitizer_no_override(self):
-        target = self._cc_target(sanitize=False, sanitizers=[])
-        cpp_flags, _r, _s = target._get_cc_flags()
-        self.assertNotIn('-fno-sanitize=address', cpp_flags)
-
-    def test_msvc_optout_emits_no_gcc_flag(self):
-        # cl.exe has no per-TU /fsanitize opt-out; sanitize=False must not emit
-        # the GCC -fno-sanitize flag (cl would reject it).
-        target = self._cc_target(sanitize=False, sanitizers=['address'], vendor='msvc')
-        cpp_flags, _r, _s = target._get_cc_flags()
-        self.assertNotIn('-fno-sanitize=address', cpp_flags)
-
     def _vars(self, target):
-        from unittest import mock as _mock
-        target._get_cc_flags = _mock.Mock(return_value=([], [], []))
-        target._get_optimize_flags = _mock.Mock(return_value=None)
+        target._get_cc_flags = mock.Mock(return_value=([], [], []))
+        target._get_optimize_flags = mock.Mock(return_value=None)
         return target._get_cc_vars()
 
-    def test_msvc_optout_blanks_sanitize_var(self):
-        # sanitize=False blanks the overridable ${sanitize} var on MSVC.
-        target = self._cc_target(sanitize=False, sanitizers=['address'], vendor='msvc')
-        self.assertEqual('', self._vars(target)['sanitize'])
+    def test_optout_blanks_var_on_every_compiler(self):
+        # The opt-out is uniform: blank ${sanitize} regardless of toolchain.
+        for vendor in ('gcc', 'clang', 'msvc'):
+            target = self._cc_target(sanitize=False, sanitizers=['address'],
+                                     vendor=vendor)
+            self.assertEqual('', self._vars(target)['sanitize'],
+                             'opt-out should blank ${sanitize} on %s' % vendor)
 
-    def test_msvc_instrumented_target_no_sanitize_override(self):
-        target = self._cc_target(sanitize=True, sanitizers=['address'], vendor='msvc')
+    def test_instrumented_target_no_var_override(self):
+        target = self._cc_target(sanitize=True, sanitizers=['address'])
         self.assertNotIn('sanitize', self._vars(target))
 
-    def test_msvc_no_sanitizer_no_override(self):
-        target = self._cc_target(sanitize=False, sanitizers=[], vendor='msvc')
+    def test_no_sanitizer_no_var_override(self):
+        target = self._cc_target(sanitize=False, sanitizers=[])
         self.assertNotIn('sanitize', self._vars(target))
+
+    def test_get_cc_flags_never_emits_fno_sanitize(self):
+        # The old per-compiler -fno-sanitize path is gone; opt-out is var-based.
+        target = self._cc_target(sanitize=False, sanitizers=['address'])
+        cpp_flags, _r, _s = target._get_cc_flags()
+        self.assertNotIn('-fno-sanitize=address', cpp_flags)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What

Per-target `sanitize = False` previously took two divergent paths:

- **gcc/clang** subtracted a `-fno-sanitize=<set>` flag in `_get_cc_flags` (relies on "later flag wins").
- **MSVC** (no per-file `-fno-sanitize`) blanked an overridable `${sanitize}` ninja var on that target's edges.

This unifies both on the **var mechanism**. Compile-side instrumentation now rides an overridable `${sanitize}` ninja variable (default = the active set's compile flags, emitted in `_generate_cc_vars`, referenced by the `cc`/`cxx` rules). A per-target opt-out simply blanks `${sanitize}` for that target — uniformly, on every compiler, including ones without a `-fno-sanitize`.

## Why

The var-override approach is strictly more general: it already solved the MSVC case (`cl` has no `-fno-sanitize`), and it applies cleanly to any current or future toolchain without per-compiler flag-subtraction logic. Folding gcc/clang onto the same path removes the divergence and the special-casing.

## Details

- Link flags (which pull in the sanitizer runtime) stay **global**, so an opted-out target still links fine — only its own compiles drop instrumentation.
- **Cuda** has no per-target opt-out var, so `_generate_cuda_rules` folds the compile flags in directly and always instruments under `--sanitizer`, exactly as before (no regression).
- Removes the gcc/clang-specific `-fno-sanitize` subtraction and the now-unused `sanitizer` import in `cc_targets.py`.

## Docs

No doc change — the override is an implementation detail and stays out of the user docs. The per-target opt-out is already documented (corrected by #1350); user-observable behavior is unchanged.

## Test

- `PerTargetOptOutTest` rewritten: asserts the blank-var path on gcc/clang/msvc and that `-fno-sanitize` is never emitted.
- 690 pass / 4 skip full unit suite; pyright clean.
- Functionally verified on clang: ASan still catches via the var; `sanitize = False` library is genuinely not instrumented; flare builds + instruments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)