### PR TITLE
feat(test): per-sanitizer runtime *_OPTIONS via sanitizer_config (#1038, phase 5)

### DIFF
--- a/doc/en/test.md
+++ b/doc/en/test.md
@@ -168,9 +168,20 @@ A sanitizer is a **per-run choice** (a flag), not project config. `--sanitizer` 
 - **Isolated build directory:** a sanitized build is ABI/codegen-incompatible with a normal one, so it gets its own sibling dir with a sanitizer tag — `build64_release_asan`. The plain `build64_release` is untouched, so the two coexist without clobbering or rebuilding each other.
 - **Per-target opt-out:** a target that must not be instrumented (intentional UB, a hot path, a wrapper around a non-instrumented prebuilt) sets `sanitize = False`. It still links (and still gets the runtime); only its own compiles drop the instrumentation. This works on MSVC too — since `cl` has no `-fno-sanitize`, Blade blanks the per-file `/fsanitize` flag for that target instead.
 
-```python
-cc_library(name = 'crc32_hw', srcs = ['crc32_hw.cc'], sanitize = False)
-```
+  ```python
+  cc_library(name = 'crc32_hw', srcs = ['crc32_hw.cc'], sanitize = False)
+  ```
+
+- **Runtime options & suppressions:** set per-sanitizer run options from BLADE_ROOT, mapped onto the matching `*_OPTIONS` environment variable. Each value is a list, one option per element. These options are appended to Blade's defaults, and take effect only when that sanitizer is in `--sanitizer`. If you've already set that sanitizer's environment variable yourself (e.g. `ASAN_OPTIONS`), Blade uses it as-is and ignores the corresponding options from the config.
+
+  To suppress a known-benign leak/race or a false positive, use the `suppressions=<file path>` option; the path is resolved relative to the workspace root and the file must exist. Suppression files use each sanitizer's **own** syntax: e.g. `leak:<name>` ([LeakSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer#suppressions)), `race:<name>` / `called_from_lib:<lib>` ([ThreadSanitizer](https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions)).
+
+  ```python
+  sanitizer_config(options = {
+      'thread': ['suppressions=etc/tsan.supp', 'history_size=7'],
+      'address': ['detect_stack_use_after_return=1'],
+  })
+  ```
 
 ## Test Exclusion
 

--- a/doc/zh_CN/test.md
+++ b/doc/zh_CN/test.md
@@ -164,9 +164,20 @@ sanitizer 是**每次运行的选择**（命令行开关），不是项目配置
 - **独立的构建目录：** sanitizer 构建与普通构建在 ABI/代码生成上不兼容，因此使用带 sanitizer 标记的独立兄弟目录——`build64_release_asan`。普通的 `build64_release` 不受影响，两者可并存、互不覆盖、互不触发重新编译。
 - **按目标退出：** 不应被插桩的目标（有意的 UB、性能热点、对未插桩预编译库的包装）可设置 `sanitize = False`。它仍参与链接（仍获得运行时），只是自身的编译不再插桩。在 MSVC 上同样有效——由于 `cl` 没有 `-fno-sanitize`，Blade 改为将该目标的 `/fsanitize` 标志置空。
 
-```python
-cc_library(name = 'crc32_hw', srcs = ['crc32_hw.cc'], sanitize = False)
-```
+  ```python
+  cc_library(name = 'crc32_hw', srcs = ['crc32_hw.cc'], sanitize = False)
+  ```
+
+- **运行时选项与抑制：** 可在 BLADE_ROOT 中为各 sanitizer 设置运行选项，映射到对应的 `*_OPTIONS` 环境变量。选项值为列表，每个列表元素为一个选项。这些选项追加到 Blade 的默认选项上，且仅当它出现在 `--sanitizer` 中时才生效。若你已自行设置了该 sanitizer 的环境变量（如 `ASAN_OPTIONS`），Blade 就会忽略配置中对应的选项。
+
+  要抑制已知良性的泄漏/竞争或者误报，可以通过 `suppressions=<抑制文件路径>` 选项，文件路径相对工作区根目录解析且文件必须存在。抑制文件采用各 sanitizer **各自**的语法：例如 `leak:<名称>`（[LeakSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer#suppressions)）、`race:<名称>` / `called_from_lib:<库>`（[ThreadSanitizer](https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions)）。
+
+  ```python
+  sanitizer_config(options = {
+      'thread': ['suppressions=etc/tsan.supp', 'history_size=7'],
+      'address': ['detect_stack_use_after_return=1'],
+  })
+  ```
 
 ## 测试排除
 

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -472,6 +472,18 @@ _CONFIG_TEMPLATE = {
         'direct_use_allowed': [],
     },
 
+    'sanitizer_config': {
+        '__help__': 'Sanitizer configuration (issue #1038)',
+        # Per-sanitizer runtime `*_OPTIONS`: {sanitizer: [option, ...]}. Keys
+        # accept the canonical name or its alias ('thread'/'tsan', ...); each
+        # value is a list of `key=value` options (a bare string also works). The
+        # options are appended to that sanitizer's options after blade's defaults
+        # (a value you set in the environment still overrides the lot). A
+        # `suppressions=<path>` option is resolved relative to the workspace root
+        # and the file must exist; every other option passes through verbatim.
+        'options': {},
+    },
+
 }
 
 
@@ -1051,6 +1063,31 @@ def vcpkg_config(append=None, **kwargs):
 def cuda_config(append=None, **kwargs):
     """cuda_config."""
     _blade_config.update_config('cuda_config', append, kwargs)
+
+
+@config_rule
+def sanitizer_config(append=None, **kwargs):
+    """Sanitizer configuration (issue #1038).
+
+    Per-sanitizer runtime ``*_OPTIONS``, one option per list element, e.g.::
+
+        sanitizer_config(
+            options = {
+                'thread': [
+                    'suppressions=etc/tsan.supp',
+                    'history_size=7',
+                ],
+                'address': ['detect_stack_use_after_return=1'],
+            },
+        )
+
+    A bare string also works for a single option. The options are appended to
+    that sanitizer's options at run time, after blade's defaults (a value you set
+    in the environment still overrides the lot). A ``suppressions=<path>`` option
+    is resolved relative to the workspace root and the file must exist; every
+    other option passes through verbatim.
+    """
+    _blade_config.update_config('sanitizer_config', append, kwargs)
 
 
 @config_rule

--- a/src/blade/sanitizer.py
+++ b/src/blade/sanitizer.py
@@ -12,7 +12,10 @@ order.
 """
 
 
+import os
+
 from blade import console
+from blade.util import var_to_list
 
 # Canonical -fsanitize= name -> short build-dir tag (also its `--sanitizer`
 # alias: `asan` etc.). This is the single source of truth for the sanitizer set.
@@ -40,6 +43,15 @@ _INCOMPATIBLE = {
     'leak': {'thread', 'memory'},
     'thread': {'address', 'leak', 'memory'},
     'memory': {'address', 'leak', 'thread'},
+}
+
+# Canonical name -> its runtime ``*_OPTIONS`` environment variable.
+_OPTIONS_VAR = {
+    'address': 'ASAN_OPTIONS',
+    'undefined': 'UBSAN_OPTIONS',
+    'leak': 'LSAN_OPTIONS',
+    'thread': 'TSAN_OPTIONS',
+    'memory': 'MSAN_OPTIONS',
 }
 
 
@@ -128,11 +140,65 @@ def msvc_link_flags(sanitizers):
     return []
 
 
-def runtime_env(sanitizers):
+def resolve_options(options, sanitizers):
+    """Resolve configured ``*_OPTIONS`` for the active sanitizer set.
+
+    ``options`` is the ``{sanitizer: str|list}`` map from
+    ``sanitizer_config.options`` (keys accept aliases; each value is one option
+    string or a list of them). Returns ``{canonical: option_string}`` joined with
+    the canonical ``:`` for the sanitizers actually active this run; a configured
+    sanitizer that isn't requested is skipped. A ``suppressions=<path>`` option is
+    resolved relative to the workspace root (the CWD blade runs from) and the file
+    must exist (fatal otherwise) -- a silently-missing file would let findings you
+    believed suppressed fire. Every other option passes through verbatim.
+    """
+    if not options:
+        return {}
+    active = set(sanitizers)
+    resolved = {}
+    for name, value in options.items():
+        canonical = _ALIASES.get(str(name).strip().lower())
+        if canonical is None:
+            console.fatal('sanitizer_config.options: unknown sanitizer "%s" '
+                          '(known: %s)' % (name, ', '.join(sorted(_ALIASES))))
+        if canonical not in active or not value:
+            continue
+        option_string = _normalize_options(value, name)
+        if option_string:
+            resolved[canonical] = option_string
+    return resolved
+
+
+def _normalize_options(value, name):
+    """Flatten a str-or-list of ``*_OPTIONS`` into one colon-joined string.
+
+    Each element is a single option; use a list for several -- the readable form
+    (the colon ``:`` separator is just an env-var artifact, joined on at the end).
+    A ``suppressions=<path>`` option is resolved to a validated abspath relative
+    to the workspace root; every other option passes through verbatim.
+    """
+    options = []
+    for item in var_to_list(value):
+        option = str(item).strip()
+        if not option:
+            continue
+        if option.startswith('suppressions='):
+            path = os.path.abspath(option[len('suppressions='):])
+            if not os.path.isfile(path):
+                console.fatal('sanitizer_config.options["%s"]: suppressions '
+                              'file not found: %s' % (name, path))
+            option = 'suppressions=' + path
+        options.append(option)
+    return ':'.join(options)
+
+
+def runtime_env(sanitizers, options=None):
     """Default ``*_OPTIONS`` env so a detection reliably fails the test.
 
     These are defaults only -- the test runner applies them without overriding
-    a value the user already set in the environment.
+    a value the user already set in the environment. ``options`` is the resolved
+    ``{canonical: option_string}`` map from ``resolve_options``; each string is
+    appended to that sanitizer's options after the defaults.
     """
     env = {}
     if 'address' in sanitizers:
@@ -145,6 +211,11 @@ def runtime_env(sanitizers):
         env['LSAN_OPTIONS'] = 'exitcode=1'
     if 'memory' in sanitizers:
         env['MSAN_OPTIONS'] = 'halt_on_error=1'
+    for canonical, option_string in (options or {}).items():
+        if not option_string:
+            continue
+        var = _OPTIONS_VAR[canonical]
+        env[var] = env[var] + ':' + option_string if var in env else option_string
     return env
 
 

--- a/src/blade/test_runner.py
+++ b/src/blade/test_runner.py
@@ -491,8 +491,15 @@ class TestRunner(binary_runner.BinaryRunner):
             sanitizers = getattr(self.options, 'sanitizers', None)
             if sanitizers:
                 # Default *_OPTIONS so a detection fails the test; a value the
-                # user already set in the environment still wins.
-                for var, value in sanitizer.runtime_env(sanitizers).items():
+                # user already set in the environment still wins. Configured
+                # sanitizer_config.options are appended to the matching
+                # sanitizer's options (a suppressions=<path> token is resolved
+                # against the workspace root; everything else is verbatim).
+                options = sanitizer.resolve_options(
+                    config.get_item('sanitizer_config', 'options'),
+                    sanitizers)
+                for var, value in sanitizer.runtime_env(
+                        sanitizers, options).items():
                     if var not in os.environ:
                         test_env[var] = value
                 # MSVC ASan links the dynamic runtime (clang_rt.asan_dynamic-*.dll),

--- a/src/tests/unit/sanitizer_test.py
+++ b/src/tests/unit/sanitizer_test.py
@@ -118,6 +118,57 @@ class SanitizerHelperTest(unittest.TestCase):
                          sanitizer.runtime_env(['memory'])['MSAN_OPTIONS'])
         self.assertEqual({}, sanitizer.runtime_env([]))
 
+    def test_runtime_env_appends_options(self):
+        # A configured option string is appended to that sanitizer's *_OPTIONS,
+        # after the default (joined with ':').
+        env = sanitizer.runtime_env(['thread'], {'thread': 'history_size=7'})
+        self.assertEqual('halt_on_error=1:history_size=7', env['TSAN_OPTIONS'])
+        # Untouched sanitizers keep their plain default; empty string is ignored.
+        env = sanitizer.runtime_env(['address', 'leak'],
+                                    {'leak': 'suppressions=/abs/l.supp', 'address': ''})
+        self.assertEqual('abort_on_error=1', env['ASAN_OPTIONS'])
+        self.assertEqual('exitcode=1:suppressions=/abs/l.supp', env['LSAN_OPTIONS'])
+
+
+class ResolveOptionsTest(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual({}, sanitizer.resolve_options(None, ['thread']))
+        self.assertEqual({}, sanitizer.resolve_options({}, ['thread']))
+
+    def test_list_form_joined_with_colon(self):
+        # The natural form: one option per list element, joined to ':' for env.
+        # Alias 'tsan' -> 'thread'; 'leak' is configured but inactive -> skipped.
+        resolved = sanitizer.resolve_options(
+            {'tsan': ['history_size=7', 'halt_on_error=0'], 'leak': ['x=1']},
+            ['thread'])
+        self.assertEqual({'thread': 'history_size=7:halt_on_error=0'}, resolved)
+
+    def test_string_form_is_a_single_option(self):
+        # A bare string is one option (use a list for several).
+        self.assertEqual(
+            {'thread': 'history_size=7'},
+            sanitizer.resolve_options({'thread': 'history_size=7'}, ['thread']))
+
+    def test_suppressions_path_resolved_among_other_options(self):
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix='.supp') as f:
+            rel = os.path.relpath(f.name, os.getcwd())
+            abspath = os.path.abspath(f.name)
+            # List form, with the suppressions path resolved in place.
+            resolved = sanitizer.resolve_options(
+                {'thread': ['suppressions=%s' % rel, 'history_size=7']}, ['thread'])
+            self.assertEqual(
+                {'thread': 'suppressions=%s:history_size=7' % abspath}, resolved)
+
+    def test_unknown_sanitizer_is_fatal(self):
+        with self.assertRaises(SystemExit):
+            sanitizer.resolve_options({'bogus': ['x=1']}, ['bogus'])
+
+    def test_missing_suppressions_file_is_fatal(self):
+        with self.assertRaises(SystemExit):
+            sanitizer.resolve_options(
+                {'thread': ['suppressions=/definitely/missing.supp']}, ['thread'])
+
     def test_check_toolchain_msvc_allows_only_address(self):
         msvc = mock.Mock()
         msvc.cc_is.side_effect = lambda v: v == 'msvc'


### PR DESCRIPTION
## What

Adds `sanitizer_config(options = {...})` to BLADE_ROOT — set arbitrary per-sanitizer runtime `*_OPTIONS` as **project config** (durable known-benign knowledge) rather than retyping them in the environment each run.

```python
sanitizer_config(options = {
    'thread': ['suppressions=etc/tsan.supp', 'history_size=7'],
    'address': ['detect_stack_use_after_return=1'],
})
```

- **Value is a list** — one option per element (a bare string works for a single option). Joined to the canonical `:` only when the env var is emitted; the separator stays an env-var artifact (Python config uses a real list).
- Keys accept aliases (`tsan`/`thread`…). Appended to Blade's `*_OPTIONS` defaults, **only** for sanitizers in the active `--sanitizer` set.
- **Precedence is per-variable, wholesale:** if you've already exported that sanitizer's variable yourself (e.g. `ASAN_OPTIONS`), Blade uses it as-is and ignores the configured options for it.

## Suppressions

The one option that needs Blade's help is `suppressions=<path>`: it's resolved relative to the **workspace root** and must exist (fatal otherwise) — the runtime would otherwise resolve it against the test's run directory and silently miss it. Every other option passes through verbatim. This covers the common case — pre-accepting a known-benign leak/race in a third-party dep **without recompiling**.

Suppression file *formats* are each sanitizer's own (LSan `leak:`, TSan `race:`/`called_from_lib:`, …), so the docs link the upstream LSan/TSan references rather than re-document them.

## Design notes

- General runtime tuning is otherwise already a per-run/env concern (Blade respects an env-set `*_OPTIONS`); this adds the **project-persistent** layer for it, with suppressions as the path-resolved special case.
- No build-graph impact — runtime only, so editing options/suppressions needs a re-run, not a rebuild.

## Implementation

- `sanitizer.resolve_options` + `_normalize_options` (str-or-list via `var_to_list`); `runtime_env(sanitizers, options=None)` appends them.
- New `sanitizer_config` config section (`config.py`); wired in `test_runner.py` beside the existing `runtime_env` defaults.
- Docs under the Sanitizers section (en + zh).

## Test

- 701 pass / 4 skip full unit suite (`ResolveOptionsTest` + `runtime_env` cases, +5); pyright clean (config.py's 4 warnings pre-existing).
- **Real Linux+clang (OrbStack, aarch64, clang 21):** an LSan leak filtered by a configured `suppressions=<path>` → test passes (`1 1024 leak_here`); missing file → `sanitizer_config.options["leak"]: suppressions file not found: …`; list and string forms both verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)