### PR TITLE
feat(build): ${os}/${arch} build-dir vars from the toolchain; deprecate -m (#1342)

### DIFF
--- a/src/blade/build_manager.py
+++ b/src/blade/build_manager.py
@@ -24,7 +24,6 @@ from blade import maven
 from blade import ninja_runner
 from blade import target_pattern
 from blade.binary_runner import BinaryRunner
-from blade.toolchain import create_toolchain
 from blade.build_accelerator import BuildAccelerator
 from blade.dependency_analyzer import analyze_deps
 from blade.load_build_files import load_targets
@@ -77,6 +76,7 @@ class Blade:
                  command,
                  options,
                  workspace,
+                 toolchain,
                  targets):
         """init method.
 
@@ -135,7 +135,9 @@ class Blade:
         # Indicate whether the deps list is expanded by expander or not
         self.__targets_expanded = False
 
-        self.__build_toolchain = create_toolchain(options.cc_toolchain)
+        # The toolchain is created once in main and threaded through (it is the
+        # source of truth for the build-dir platform triple); reuse that instance.
+        self.__build_toolchain = toolchain
         self.build_accelerator = BuildAccelerator(self.__build_toolchain)
         self.__build_jobs_num = 0
 
@@ -766,7 +768,7 @@ class Blade:
         return self.__all_rule_names
 
 
-def initialize(blade_path, command, options, workspace, targets):
+def initialize(blade_path, command, options, workspace, toolchain, targets):
     global instance
-    instance = Blade(blade_path, command, options, workspace, targets)
+    instance = Blade(blade_path, command, options, workspace, toolchain, targets)
     return instance

--- a/src/blade/command_line.py
+++ b/src/blade/command_line.py
@@ -125,6 +125,11 @@ class CommandLineParser:
             options.bits = BuildArchitecture.get_architecture_bits(arch)
             assert options.bits
         else:
+            console.warning(
+                f'"-m{m}" is deprecated: it is the legacy x86 multilib selector. '
+                'Select a toolchain whose arch is 32-/64-bit instead '
+                '(--cc-toolchain, cc_config.toolchain, or cc_toolchain_config); '
+                'the toolchain then determines ${arch}/${bits}.')
             options.bits = m
             options.arch = BuildArchitecture.get_model_architecture(arch, m)
             if options.arch is None:

--- a/src/blade/main.py
+++ b/src/blade/main.py
@@ -26,6 +26,7 @@ from blade import console
 from blade import init_command
 from blade import target_pattern
 from blade import workspace
+from blade.toolchain import BuildArchitecture, create_toolchain
 
 
 def load_config(options, root_dir):
@@ -64,9 +65,9 @@ def _check_error_log(stage):
     return 0
 
 
-def run_subcommand(blade_path, command, options, ws, targets):
+def run_subcommand(blade_path, command, options, ws, toolchain, targets):
     """Run particular subcommands."""
-    builder = build_manager.initialize(blade_path, command, options, ws, targets)
+    builder = build_manager.initialize(blade_path, command, options, ws, toolchain, targets)
 
     # The 'dump' command is special, some kind of dump items should be ran before loading.
     if command == 'dump' and options.dump_config:
@@ -101,7 +102,7 @@ def run_subcommand(blade_path, command, options, ws, targets):
     return _check_error_log(command)
 
 
-def run_subcommand_profile(blade_path, command, options, ws, targets):
+def run_subcommand_profile(blade_path, command, options, ws, toolchain, targets):
     """Run subcommand within profile."""
     pstats_file = os.path.join(ws.build_dir, 'blade.pstats')
     # NOTE: can't use an plain int variable to receive exit_code
@@ -109,8 +110,9 @@ def run_subcommand_profile(blade_path, command, options, ws, targets):
     # wll not modify the local exit_code.
     # so we use a mutable object list to obtain the return value of run_subcommand
     exit_code = [-1]
-    cProfile.runctx("exit_code[0] = run_subcommand(blade_path, command, options, ws, targets)",
-                    globals(), locals(), pstats_file)
+    cProfile.runctx(
+        "exit_code[0] = run_subcommand(blade_path, command, options, ws, toolchain, targets)",
+        globals(), locals(), pstats_file)
     p = pstats.Stats(pstats_file)
     p.sort_stats('cumulative').print_stats(20)
     p.sort_stats('time').print_stats(20)
@@ -161,12 +163,21 @@ def _main(blade_path, argv):
         targets = ['.']
     targets = target_pattern.normalize_list(targets, ws.working_dir)
 
-    ws.setup_build_dir()
+    # The selected cc toolchain is the single source of truth for the platform
+    # triple (${os}/${arch}/${bits}); create it once, here, and pass it on. When
+    # the deprecated -m flag is absent, arch/bits come from the toolchain too, so
+    # the DSL (blade.arch) and prebuilt lib${bits} paths stay consistent.
+    toolchain = create_toolchain(options.cc_toolchain)
+    if not options.m:
+        options.arch = toolchain.target_arch
+        options.bits = BuildArchitecture.get_architecture_bits(toolchain.target_arch)
+
+    ws.setup_build_dir(toolchain)
 
     lock_id = ws.lock()
     try:
         run_fn = run_subcommand_profile if options.profiling else run_subcommand
-        return run_fn(blade_path, command, options, ws, targets)
+        return run_fn(blade_path, command, options, ws, toolchain, targets)
     finally:
         ws.unlock(lock_id)
 

--- a/src/blade/workspace.py
+++ b/src/blade/workspace.py
@@ -36,6 +36,30 @@ def _build_variant_suffix(options):
     return ''.join('_' + v for v in variants)
 
 
+def _build_dir_name(build_path_format, options, toolchain):
+    """Compute the build-dir name: template substitution + variant suffix.
+
+    The selected ``toolchain`` supplies the platform triple
+    (``${os}``/``${arch}``/``${bits}``); ``${profile}`` comes from the options.
+    The sanitizer/coverage variant tag is appended afterwards -- it is never part
+    of the template, so it composes uniformly regardless of the template a
+    project chooses.
+    """
+    template = string.Template(build_path_format)
+    try:
+        name = template.substitute(
+            profile=options.profile,
+            os=toolchain.target_os,
+            arch=toolchain.target_arch,
+            bits=options.bits)
+    except KeyError as e:
+        console.fatal(
+            'global_config.build_path_template "%s" references unknown variable '
+            '%s; supported: ${profile} ${os} ${arch} ${bits} (sanitizer/coverage '
+            'variants are appended automatically)' % (build_path_format, e))
+    return name + _build_variant_suffix(options)
+
+
 def _generate_scm_svn():
     url = revision = 'unknown'
     returncode, stdout, stderr = util.run_command(['svn', 'info'])
@@ -122,16 +146,14 @@ class Workspace:
                 print("Blade: Entering directory `%s'" % self.__root_dir)
             os.chdir(self.__root_dir)
 
-    def setup_build_dir(self):
-        """Setup build dir."""
+    def setup_build_dir(self, toolchain):
+        """Setup build dir.
+
+        ``toolchain`` is the cc toolchain created in main; it is the source of
+        truth for the ``${os}``/``${arch}``/``${bits}`` build-dir variables.
+        """
         build_path_format = config.get_item('global_config', 'build_path_template')
-        s = string.Template(build_path_format)
-        build_dir = s.substitute(bits=self.__options.bits, profile=self.__options.profile)
-        # Give variant builds (coverage, and later sanitizers) their own sibling
-        # build dir so they don't clobber or force-rebuild the normal one. The
-        # plain build keeps its exact historical name (no suffix), so existing
-        # workspaces/scripts/blade-bin are unaffected.
-        build_dir += _build_variant_suffix(self.__options)
+        build_dir = _build_dir_name(build_path_format, self.__options, toolchain)
 
         if not os.path.exists(build_dir):
             os.mkdir(build_dir)

--- a/src/tests/unit/build_dir_test.py
+++ b/src/tests/unit/build_dir_test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for build-dir name composition (issue #1342).
+
+`_build_dir_name` substitutes the platform triple (${os}/${arch}/${bits}) from
+the selected toolchain into `global_config.build_path_template`, then appends the
+sanitizer/coverage variant tag (never part of the template).
+"""
+
+import os
+import sys
+import unittest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade.workspace import _build_dir_name  # noqa: E402
+
+
+class _Opts:
+    def __init__(self, profile='release', bits='64', coverage=False, sanitizers=None):
+        self.profile = profile
+        self.bits = bits
+        self.coverage = coverage
+        self.sanitizers = sanitizers
+
+
+class _TC:
+    def __init__(self, target_os='linux', target_arch='x86_64'):
+        self.target_os = target_os
+        self.target_arch = target_arch
+
+
+class BuildDirNameTest(unittest.TestCase):
+    def test_legacy_template_byte_for_byte(self):
+        # The pinned legacy template reproduces the old name exactly.
+        self.assertEqual(
+            'build64_release',
+            _build_dir_name('build${bits}_${profile}', _Opts(), _TC()))
+
+    def test_flat_v3_default(self):
+        self.assertEqual(
+            'build_release',
+            _build_dir_name('build_${profile}', _Opts(), _TC()))
+
+    def test_os_arch_template(self):
+        # os/arch come from the toolchain, not a flag.
+        self.assertEqual(
+            'build_darwin_arm64_release',
+            _build_dir_name('build_${os}_${arch}_${profile}',
+                            _Opts(), _TC('darwin', 'arm64')))
+
+    def test_variants_appended_not_templated(self):
+        # Sanitizer/coverage ride the trailing suffix regardless of template.
+        self.assertEqual(
+            'build_release_asan',
+            _build_dir_name('build_${profile}',
+                            _Opts(sanitizers=['address']), _TC()))
+        self.assertEqual(
+            'build64_release_coverage',
+            _build_dir_name('build${bits}_${profile}',
+                            _Opts(coverage=True), _TC()))
+        # Composes on top of an os/arch template too.
+        self.assertEqual(
+            'build_linux_x86_64_release_coverage_asan',
+            _build_dir_name('build_${os}_${arch}_${profile}',
+                            _Opts(coverage=True, sanitizers=['address']), _TC()))
+
+    def test_unknown_variable_is_fatal(self):
+        with self.assertRaises(SystemExit):
+            _build_dir_name('build_${bogus}_${profile}', _Opts(), _TC())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
First of two PRs for #1342 (modernize build-dir naming). This is the **non-breaking infra**; the breaking default-name flip (`build64_release` → `build_release`) + docs/testdata follow in PR-B (rides v3.0).

## What

Source the build-dir name's platform triple from the **selected cc toolchain** (the single source of truth) instead of a host-compiler probe, so a project can opt into `${os}`/`${arch}`/`${bits}` in `global_config.build_path_template`:

```python
global_config(build_path_template = 'build_${os}_${arch}_${profile}')
# build_linux_x86_64_release, build_darwin_arm64_release, ...
```

This is the prerequisite for cross-builds (#1179) and the multi-toolchain world — without `${os}`/`${arch}`, those trees collide in one dir.

## Changes

- The cc toolchain is created **once in `main`** (config is loaded by then) and passed explicitly to `setup_build_dir(toolchain)` and down through `run_subcommand` → `build_manager.initialize` → `Blade`. The workspace no longer creates/holds the toolchain, and `build_manager` no longer creates its own — resolves the ordering gap (the build dir was computed before the toolchain existed) via plain dependency injection.
- Build-dir name computation extracted to a pure, testable **`_build_dir_name`** (substitute the platform triple + append the variant suffix; a friendly fatal lists the supported vars on an unknown `${x}`).
- `${os}`/`${arch}`/`${bits}` come from `cc_toolchain.target_os`/`target_arch`; when `-m` is absent, `options.arch`/`bits` derive from the toolchain too, so the DSL (`blade.arch`) and prebuilt `lib${bits}` paths stay consistent.
- **Deprecate `-m32`/`-m64`** (the legacy x86 multilib selector) with a warning pointing at toolchain selection; still honored when given.

## Non-breaking

The **default template is unchanged**, so the name stays `build64_release`. Sanitizer/coverage variants still **auto-append** (never part of the template), so they compose with any template a project picks.

## Test

- 706 unit tests pass (`build_dir_test.py` +5: legacy byte-for-byte, flat, os/arch, variant-append composition, unknown-var fatal); pyright clean.
- Real flare: normal build → `build64_release` (unchanged); opt-in `build_${os}_${arch}_${profile}` → `build_darwin_aarch64_release`. Default + `--profiling` paths both verified.

## Follow-up (PR-B, v3.0)

Flip the default to `build_${profile}`, update `.gitignore`/docs/testdata, one-time notice on finding a legacy `build64_*`, `upgrade-to-v3.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)