### PR TITLE
fix(gitignore): don't ignore doc/*/build_rules (build_* was too broad)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ blade-bin
 build_*
 build32_*
 build64_*
+# ...but not the docs dir that happens to start with "build_".
+!**/build_rules/
 
 /blade.zip
 


### PR DESCRIPTION
The v3 default-name change (#1355) added `build_*` to `.gitignore` to ignore the new `build_<profile>` output dirs. But `build_*` also matches `doc/en/build_rules/` and `doc/zh_CN/build_rules/` — so a **new** file added under those docs dirs would be silently ignored (existing tracked files are unaffected).

Fix: add `!**/build_rules/` after the `build_*` rule. Verified with `git check-ignore`:
- `doc/*/build_rules/*` → **not** ignored ✓
- `build_release`, `build_release_asan`, `build_debug`, `build64_release`, nested `src/test/testdata/*/build_release` → still ignored ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)