### PR TITLE
fix(cc): emit .syms for a dynamic-only / import-lib prebuilt (#1261 phase 3)

### DIFF
--- a/src/blade/builtin_tools.py
+++ b/src/blade/builtin_tools.py
@@ -254,11 +254,22 @@ def _nm_extract_externals(archive, dumpbin=None):
     data (e.g. fmt's ``basic_data<void>::left_padding_shifts``) -- and
     must be counted as defined, or downstream cc_libraries that pull
     them in transitively will fail the undefined-symbol check.
+
+    For an ELF shared object (``.so[.N]``) we add ``-D`` to read its dynamic
+    symbol table: that is the set of symbols a linker actually resolves against,
+    and -- unlike the regular table that plain ``nm`` reads -- it survives
+    stripping. A macOS ``.dylib`` keeps its exports in the regular table (plain
+    ``nm`` suffices; macOS ``nm`` has no ``-D``), and a ``.a`` has no dynamic
+    table, so the flag is ELF-shared-only (issue #1261).
     """
     if dumpbin:
         return _dumpbin_extract_externals(dumpbin, archive)
+    base = os.path.basename(archive)
+    nm_flags = ['-P', '-g']
+    if base.endswith('.so') or '.so.' in base:
+        nm_flags = ['-D'] + nm_flags
     try:
-        out = subprocess.check_output(['nm', '-P', '-g', archive], stderr=subprocess.STDOUT)
+        out = subprocess.check_output(['nm'] + nm_flags + [archive], stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         # nm exits non-zero when a static archive has no symbol table (e.g.
         # foreign_cc archives) — treat as empty. Same for missing files.

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1829,6 +1829,12 @@ class PrebuiltCcLibrary(CcTarget):
         if not static_source and not dynamic_source and not import_source:
             return  # error already emitted by _resolve_library_sources
 
+        # Whichever library serves static linking (STATIC_LIB_LABEL below) is the
+        # one check_undefined reads, so remember it to emit its `.syms` in
+        # generate(). Priority matches the label assignment: a real archive,
+        # else the import lib (MSVC), else the shared lib serving static-link.
+        self.attr['link_source'] = static_source or import_source or dynamic_source
+
         if static_source:
             self.attr['static_source'] = static_source
             self._add_target_file(tc.STATIC_LIB_LABEL, static_source)
@@ -1928,14 +1934,18 @@ class PrebuiltCcLibrary(CcTarget):
         if not self._is_depended_on():
             return
         objs, inclusion_check_result = self._cc_objects([])
-        # Emit ``ccsyms`` for the prebuilt static archive when present. Has to
+        # Emit ``ccsyms`` for whatever library serves static linking. Has to
         # happen here in generate() rather than _setup() because _setup() runs
         # at BUILD-loading time and emitting a build rule that early forces
         # __build_code initialization, which breaks the
         # ``assert __build_code is None`` invariant in ``before_generate``.
-        static_source = self.attr.get('static_source')
-        if static_source:
-            self._emit_archive_syms(static_source)
+        # A dynamic-only prebuilt (or an import lib serving static-link) must
+        # also emit its syms, or a consumer's check_undefined misses its symbols
+        # (#1261): the syms tool reads a shared lib's dynamic table (nm -D) and
+        # an import lib via dumpbin.
+        link_source = self.attr.get('link_source')
+        if link_source:
+            self._emit_archive_syms(link_source)
         dynamic_source = self.attr.get('dynamic_source')
         dynamic_target = self.attr.get('dynamic_target')
         if dynamic_source and dynamic_target:

--- a/src/tests/unit/builtin_tools_test.py
+++ b/src/tests/unit/builtin_tools_test.py
@@ -157,5 +157,34 @@ class GeneratePythonBinaryBootstrapTest(unittest.TestCase):
         self.assertTrue(mode & stat.S_IXOTH, 'other exec bit missing: %o' % mode)
 
 
+class NmDynamicTableSelectionTest(unittest.TestCase):
+    """`_nm_extract_externals` reads an ELF shared lib's dynamic table (#1261).
+
+    A stripped `.so`'s exports live only in the dynamic symbol table, so `nm`
+    needs `-D` there -- but not for a `.a` (no dynamic table) or a macOS
+    `.dylib` (regular table; macOS nm has no `-D`).
+    """
+
+    def _nm_argv_for(self, archive):
+        from unittest import mock
+        calls = []
+
+        def fake_check_output(cmd, **_kw):
+            calls.append(cmd)
+            return b''  # no symbols; we only care about the argv
+
+        with mock.patch('subprocess.check_output', side_effect=fake_check_output):
+            builtin_tools._nm_extract_externals(archive)
+        return calls[0]
+
+    def test_so_uses_dash_d(self):
+        self.assertIn('-D', self._nm_argv_for('lib/libfoo.so'))
+        self.assertIn('-D', self._nm_argv_for('lib/libfoo.so.1.2'))
+
+    def test_archive_and_dylib_do_not(self):
+        self.assertNotIn('-D', self._nm_argv_for('lib/libfoo.a'))
+        self.assertNotIn('-D', self._nm_argv_for('lib/libfoo.dylib'))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Phase 3 of #1261, stacked on **#1358** (Phase 2 `import_library`). The dynamic-only `.syms` gap that was deliberately deferred from Phase 1.

## Problem

A `prebuilt_cc_library` that serves static linking from a **shared lib** (dynamic-only) or, on MSVC, from an **import lib**, emitted no `.syms` — `generate()` only did so for `static_source`. So a consumer's `check_undefined` couldn't see those symbols and failed with a false *"missing dependency"* (or silently skipped them).

## Fix

- `_setup` records **`link_source`** — the library that serves `STATIC_LIB_LABEL` (a real archive, else the import lib on MSVC, else the shared lib serving static-link) — and `generate()` emits its `.syms` through the existing `ccsyms` rule (dumpbin on MSVC, nm otherwise).
- The syms tool reads an ELF shared object's **dynamic** symbol table (`nm -D`): a *stripped* `.so`'s exports live only there. Scoped to `.so[.N]` — a `.a` has no dynamic table, and a macOS `.dylib` keeps exports in the regular table (macOS `nm` has no `-D`).

## Test

- 721 unit tests pass (+2: `nm -D` is used for `.so[.N]`, not for `.a`/`.dylib`); pyright clean.
- **Real Linux (OrbStack):** a dynamic-only prebuilt's *stripped* `.so` now yields a `.syms` containing its exports, and a consumer with **fatal** `check_undefined` builds. Proven load-bearing: with the fix reverted the same build **fails** `CC CHECK UNDEFINED`, and plain `nm` misses the symbol that `nm -D` finds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)