### PR TITLE
feat(cc): explicit static/dynamic/import_library on foreign_cc_library (#1262)

### DIFF
--- a/doc/en/build_rules/cc.md
+++ b/doc/en/build_rules/cc.md
@@ -550,6 +550,14 @@ Attributes:
 - `install_dir`: str, The installation directory after the package is built
 - `lib_dir`: list, The subdirectory name of the library in the installation directory
 - `has_dynamic`: bool = False, Whether this library has a dynamic linked edition.
+- `static_library` / `dynamic_library` / `import_library`: str, explicit paths
+  (relative to `install_dir`) to the libraries the foreign build produces,
+  overriding the `lib_dir`/`has_dynamic` name convention. Useful when the build
+  emits names the `lib<name>.<suffix>` convention can't express (version
+  suffixes, several libs, etc.). `import_library` is the Windows import `.lib`
+  for a produced `.dll` (required on MSVC when a `dynamic_library` is given).
+  Same two-mode behaviour as `prebuilt_cc_library`; the link selection, runfiles,
+  and `check_undefined` `.syms` handling are shared between the two rules.
 
 ### Example1, zlib
 

--- a/doc/zh_CN/build_rules/cc.md
+++ b/doc/zh_CN/build_rules/cc.md
@@ -504,6 +504,7 @@ foreign_cc_library 和 prebuilt_cc_library 的主要区别是其描述的库是 
 - `install_dir` 包构建完成后的安装目录
 - `lib_dir` 库在安装目录下的子目录名
 - `has_dynamic` 是否生成了动态库
+- `static_library` / `dynamic_library` / `import_library`：str，外部构建产出的库的显式路径（相对于 `install_dir`），用于覆盖 `lib_dir`/`has_dynamic` 的命名约定。当构建产出的名字无法用 `lib<name>.<后缀>` 约定表达时（带版本后缀、多个库等）很有用。`import_library` 是 Windows 上为产出的 `.dll` 链接所需的导入库 `.lib`（在 MSVC 上给定 `dynamic_library` 时必需）。与 `prebuilt_cc_library` 行为一致的双模式；链接选择、运行期文件与 `check_undefined` 的 `.syms` 处理在两个规则间共享。
 
 ### 示例 1，zlib
 

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1286,6 +1286,45 @@ class CcTarget(Target):
                 return parts[1]
         return None
 
+    def _setup_library_link_targets(self, tc, static_source, dynamic_source,
+                                    import_source, dynamic_link_path):
+        """Wire STATIC/DYNAMIC_LIB_LABEL from resolved library sources.
+
+        Shared by ``prebuilt_cc_library`` and ``foreign_cc_library`` (#1261,
+        #1262): the link selection (which of static / dynamic / import serves
+        static- vs dynamic-linking) and the MSVC import-lib handling are identical;
+        only *where* the libraries live differs. ``dynamic_link_path`` is the path
+        registered for dynamic linking when a *shared* lib serves it -- a
+        build-tree copy for a source-tree prebuilt, or the in-place output for a
+        foreign build.
+
+        Returns the ``link_source`` -- the library that serves static linking,
+        whose ``.syms`` the caller emits for check_undefined.
+        """
+        if static_source:
+            self._add_target_file(tc.STATIC_LIB_LABEL, static_source)
+            if not dynamic_source and not import_source:
+                # Using the static library for dynamic linking too.
+                self._add_target_file(tc.DYNAMIC_LIB_LABEL, static_source)
+        if import_source:
+            # MSVC: link the import lib; record the DLL (if any) as the runtime
+            # artifact the runner flattens into runfiles (see windows_dll), like
+            # blade's own generated DLLs (see _dynamic_cc_library_windows).
+            self._add_target_file(tc.DYNAMIC_LIB_LABEL, import_source)
+            if not static_source:
+                self._add_target_file(tc.STATIC_LIB_LABEL, import_source)
+            if dynamic_source:
+                self.data['windows_dll'] = dynamic_source
+        elif dynamic_source:
+            self._add_target_file(tc.DYNAMIC_LIB_LABEL, dynamic_link_path)
+            soname = self._soname_of(dynamic_source)
+            if soname:
+                self.data['soname_and_full_path'] = (soname, dynamic_link_path)
+            if not static_source:
+                # Using the shared library for static linking too.
+                self._add_target_file(tc.STATIC_LIB_LABEL, dynamic_link_path)
+        return static_source or import_source or dynamic_source
+
     def _cc_library(self, objs, inclusion_check_result=None):
         self._static_cc_library(objs, inclusion_check_result)
         if self.attr.get('generate_dynamic'):
@@ -1829,42 +1868,23 @@ class PrebuiltCcLibrary(CcTarget):
         if not static_source and not dynamic_source and not import_source:
             return  # error already emitted by _resolve_library_sources
 
-        # Whichever library serves static linking (STATIC_LIB_LABEL below) is the
-        # one check_undefined reads, so remember it to emit its `.syms` in
-        # generate(). Priority matches the label assignment: a real archive,
-        # else the import lib (MSVC), else the shared lib serving static-link.
-        self.attr['link_source'] = static_source or import_source or dynamic_source
-
         if static_source:
             self.attr['static_source'] = static_source
-            self._add_target_file(tc.STATIC_LIB_LABEL, static_source)
-            if not dynamic_source and not import_source:
-                # Using static library for dynamic linking
-                self._add_target_file(tc.DYNAMIC_LIB_LABEL, static_source)
-
-        if import_source:
-            # MSVC: link the import lib; record the DLL (if any) as the runtime
-            # artifact the runner flattens into runfiles (see windows_dll), like
-            # blade's own generated DLLs (see _dynamic_cc_library_windows).
-            self._add_target_file(tc.DYNAMIC_LIB_LABEL, import_source)
-            if not static_source:
-                self._add_target_file(tc.STATIC_LIB_LABEL, import_source)
-            if dynamic_source:
-                self.attr['dynamic_source'] = dynamic_source
-                self.data['windows_dll'] = dynamic_source
-        elif dynamic_source:
-            dynamic_target = self._target_file_path(os.path.basename(dynamic_source))
+        # A source-tree shared lib (not the import-lib case) is copied into the
+        # build tree so it lands in runfiles; that copy is what serves dynamic
+        # linking. The import-lib case keeps the DLL in place (windows_dll).
+        dynamic_target = None
+        if dynamic_source:
             self.attr['dynamic_source'] = dynamic_source
-            self.attr['dynamic_target'] = dynamic_target
-            self._add_target_file(tc.DYNAMIC_LIB_LABEL, dynamic_target)
+            if not import_source:
+                dynamic_target = self._target_file_path(
+                    os.path.basename(dynamic_source))
+                self.attr['dynamic_target'] = dynamic_target
 
-            soname = self._soname_of(dynamic_source)
-            if soname:
-                self.data['soname_and_full_path'] = (soname, dynamic_target)
-
-            if not static_source:
-                # Using dynamic library for static linking
-                self._add_target_file(tc.STATIC_LIB_LABEL, dynamic_target)
+        # Whichever library serves static linking is the one check_undefined
+        # reads; remember it to emit its `.syms` in generate().
+        self.attr['link_source'] = self._setup_library_link_targets(
+            tc, static_source, dynamic_source, import_source, dynamic_target)
 
     _default_libpath = None
 
@@ -2449,6 +2469,9 @@ class ForeignCcLibrary(CcTarget):
                  export_incs: 'StrOrListOpt',
                  lib_dir: str,
                  has_dynamic: bool,
+                 static_library: str | None,
+                 dynamic_library: str | None,
+                 import_library: str | None,
                  link_all_symbols: bool,
                  binary_link_only: bool,
                  deprecated: bool,
@@ -2493,6 +2516,9 @@ class ForeignCcLibrary(CcTarget):
         self.attr['deprecated'] = deprecated
         self.attr['lib_dir'] = lib_dir
         self.attr['has_dynamic'] = has_dynamic
+        self.attr['static_library'] = static_library
+        self.attr['dynamic_library'] = dynamic_library
+        self.attr['import_library'] = import_library
         self._add_tags('lang:cc', 'type:library', 'type:foreign')
 
         if hdrs:
@@ -2526,16 +2552,53 @@ class ForeignCcLibrary(CcTarget):
             self.attr['install_dir'], self.attr['lib_dir'],
             f'{tc.lib_prefix}{self.name}{suffix}'))
 
+    def _resolve_library_sources(self, tc):
+        """Resolve the static/dynamic/import library paths the foreign build
+        produces (#1262), in either mode.
+
+        - **Explicit** (``static_library`` / ``dynamic_library`` /
+          ``import_library`` set): paths relative to ``install_dir``, under the
+          build tree. ``import_library`` is MSVC-only (the ``.lib`` to link a
+          produced ``.dll``); on MSVC a ``dynamic_library`` requires it.
+        - **Convention** (none set): ``<install_dir>/<lib_dir>/lib<name>.<suffix>``,
+          with the shared lib gated by ``has_dynamic``.
+
+        Unlike a prebuilt, these are GENERATED by the foreign build, so the paths
+        are declared, not probed for existence. Returns
+        ``(static_source, dynamic_source, import_source)``.
+        """
+        static_library = self.attr.get('static_library')
+        dynamic_library = self.attr.get('dynamic_library')
+        import_library = self.attr.get('import_library')
+        if static_library or dynamic_library or import_library:
+            def under_install(value):
+                return self._target_file_path(
+                    os.path.join(self.attr['install_dir'], value)) if value else None
+            static_source = under_install(static_library)
+            dynamic_source = under_install(dynamic_library)
+            import_source = None
+            if tc.cc_is('msvc'):
+                if import_library:
+                    import_source = under_install(import_library)
+                elif dynamic_library:
+                    self.error('on MSVC, dynamic_library requires import_library '
+                               '(the .lib used to link the produced .dll)')
+            return static_source, dynamic_source, import_source
+        static_source = self._library_full_path(tc.static_lib_suffix)
+        dynamic_source = (self._library_full_path(tc.dynamic_lib_suffix)
+                          if self.attr['has_dynamic'] else None)
+        return static_source, dynamic_source, None
+
     def soname_and_full_path(self):
         """Return soname and full path of the shared library, if any"""
         if 'soname_and_full_path' not in self.data:
             self.data['soname_and_full_path'] = None
-            if self.attr['has_dynamic']:
-                tc = self.blade.get_build_toolchain()
-                so_path = self._library_full_path(tc.dynamic_lib_suffix)
-                soname = self._soname_of(so_path)
+            tc = self.blade.get_build_toolchain()
+            _static, dynamic_source, _import = self._resolve_library_sources(tc)
+            if dynamic_source:
+                soname = self._soname_of(dynamic_source)
                 if soname:
-                    self.data['soname_and_full_path'] = (soname, so_path)
+                    self.data['soname_and_full_path'] = (soname, dynamic_source)
         return self.data['soname_and_full_path']
 
     def _before_generate(self):  # override
@@ -2546,12 +2609,19 @@ class ForeignCcLibrary(CcTarget):
 
     def _ninja_rules(self):
         tc = self.blade.get_build_toolchain()
-        a_path = self._library_full_path(tc.static_lib_suffix)
-        so_path = self._library_full_path(tc.dynamic_lib_suffix)
-        self._add_default_target_file(tc.STATIC_LIB_LABEL, a_path)
-        self._emit_archive_syms(a_path)
-        self._add_target_file(tc.DYNAMIC_LIB_LABEL,
-                              so_path if self.attr['has_dynamic'] else a_path)
+        static_source, dynamic_source, import_source = \
+            self._resolve_library_sources(tc)
+        if not static_source and not dynamic_source and not import_source:
+            return  # error already emitted by _resolve_library_sources
+        if static_source:
+            # The static archive is the conventional default target file.
+            self._add_default_target_file(tc.STATIC_LIB_LABEL, static_source)
+        # Foreign outputs are already in the build tree -- the shared lib is
+        # linked in place (no copy), so dynamic_link_path == dynamic_source.
+        link_source = self._setup_library_link_targets(
+            tc, static_source, dynamic_source, import_source, dynamic_source)
+        if link_source:
+            self._emit_archive_syms(link_source)
 
     def generate(self):
         """Generate build code for cc object/library."""
@@ -2567,6 +2637,9 @@ def foreign_cc_library(
         export_incs: 'StrOrListOpt' = None,
         deps: 'StrOrListOpt' = None,
         has_dynamic: bool = False,
+        static_library: str | None = None,
+        dynamic_library: str | None = None,
+        import_library: str | None = None,
         link_all_symbols: bool = False,
         binary_link_only: bool = False,
         visibility: 'StrOrListOpt' = None,
@@ -2583,6 +2656,10 @@ def foreign_cc_library(
         hdr_dir: header file directory to be declared, always under the output directory
         lib_dir: str, the relative path of the lib dir under the `install_dir` dir.
         has_dynamic: bool, whether this library has a dynamic edition.
+        static_library / dynamic_library / import_library: str, explicit paths
+            (relative to `install_dir`) to the libraries the foreign build
+            produces, overriding the `lib_dir`/`has_dynamic` name convention.
+            `import_library` is the Windows import `.lib` for a produced `.dll`.
     """
     target = ForeignCcLibrary(
             name=name,
@@ -2595,6 +2672,9 @@ def foreign_cc_library(
             hdr_dir=hdr_dir,
             lib_dir=lib_dir,
             has_dynamic=has_dynamic,
+            static_library=static_library,
+            dynamic_library=dynamic_library,
+            import_library=import_library,
             link_all_symbols=link_all_symbols,
             binary_link_only=binary_link_only,
             deprecated=deprecated,

--- a/src/tests/unit/foreign_explicit_lib_test.py
+++ b/src/tests/unit/foreign_explicit_lib_test.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for foreign_cc_library explicit lib paths (#1262).
+
+`static_library` / `dynamic_library` / `import_library` give the foreign build's
+output paths (relative to install_dir, under the build tree), overriding the
+`lib_dir`/`has_dynamic` name convention. Unlike a prebuilt these are generated,
+so paths are declared, not probed.
+"""
+
+import os
+import sys
+import unittest
+from typing import cast
+from unittest import mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import cc_targets  # noqa: E402
+from blade.toolchain import ToolChain  # noqa: E402
+
+
+class _FakeToolChain:
+    static_lib_suffix = '.a'
+    dynamic_lib_suffix = '.so'
+    all_dynamic_lib_suffixes = ('.so',)
+    lib_prefix = 'lib'
+
+    def __init__(self, vendor='gcc'):
+        self._vendor = vendor
+
+    def cc_is(self, vendor):
+        return vendor == self._vendor
+
+
+def _tc(vendor='gcc') -> ToolChain:
+    return cast(ToolChain, _FakeToolChain(vendor))
+
+
+def _foreign(static=None, dynamic=None, importlib=None,
+             install_dir='inst', has_dynamic=False):
+    t = cc_targets.ForeignCcLibrary.__new__(cc_targets.ForeignCcLibrary)
+    t.name = 'foo'
+    t.attr = {
+        'install_dir': install_dir, 'lib_dir': 'lib', 'has_dynamic': has_dynamic,
+        'static_library': static, 'dynamic_library': dynamic,
+        'import_library': importlib,
+    }
+    # Outputs live under the build tree; fake the build-dir prefix.
+    t._target_file_path = lambda p: os.path.join('BD', p)
+    t.errors = []
+    t.error = t.errors.append
+    return t
+
+
+class ForeignResolveSourcesTest(unittest.TestCase):
+    def test_explicit_static_and_dynamic(self):
+        t = _foreign(static='lib/libfoo.a', dynamic='lib/libfoo.so')
+        s, d, i = t._resolve_library_sources(_tc())
+        self.assertEqual(('BD/inst/lib/libfoo.a', 'BD/inst/lib/libfoo.so', None),
+                         (s, d, i))
+        self.assertEqual([], t.errors)
+
+    def test_explicit_import_only_on_msvc(self):
+        # import_library is resolved on MSVC, ignored elsewhere.
+        t = _foreign(static='lib/foo.lib', dynamic='bin/foo.dll',
+                     importlib='lib/foo.lib')
+        _s, _d, i = t._resolve_library_sources(_tc('msvc'))
+        self.assertEqual('BD/inst/lib/foo.lib', i)
+        # Non-MSVC: import ignored, no error (the .so is the link target).
+        t2 = _foreign(static='lib/libfoo.a', importlib='lib/foo.lib')
+        _s, _d, i2 = t2._resolve_library_sources(_tc('gcc'))
+        self.assertIsNone(i2)
+
+    def test_msvc_dynamic_without_import_errors(self):
+        t = _foreign(dynamic='bin/foo.dll')
+        t._resolve_library_sources(_tc('msvc'))
+        self.assertEqual(1, len(t.errors))
+        self.assertIn('import_library', t.errors[0])
+
+    def test_convention_when_no_explicit(self):
+        # No explicit attrs -> name convention via _library_full_path.
+        t = _foreign(install_dir='inst', has_dynamic=True)
+        t.blade = mock.Mock()
+        t.blade.get_build_toolchain.return_value = _FakeToolChain()
+        s, d, i = t._resolve_library_sources(_tc())
+        self.assertEqual('BD/inst/lib/libfoo.a', s)
+        self.assertEqual('BD/inst/lib/libfoo.so', d)
+        self.assertIsNone(i)
+
+    def test_convention_static_only_when_not_has_dynamic(self):
+        t = _foreign(install_dir='inst', has_dynamic=False)
+        t.blade = mock.Mock()
+        t.blade.get_build_toolchain.return_value = _FakeToolChain()
+        s, d, _i = t._resolve_library_sources(_tc())
+        self.assertEqual('BD/inst/lib/libfoo.a', s)
+        self.assertIsNone(d)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/unit/foreign_explicit_lib_test.py
+++ b/src/tests/unit/foreign_explicit_lib_test.py
@@ -22,6 +22,8 @@ sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
 from blade import cc_targets  # noqa: E402
 from blade.toolchain import ToolChain  # noqa: E402
 
+J = os.path.join  # build expected paths with the native separator
+
 
 class _FakeToolChain:
     static_lib_suffix = '.a'
@@ -60,8 +62,9 @@ class ForeignResolveSourcesTest(unittest.TestCase):
     def test_explicit_static_and_dynamic(self):
         t = _foreign(static='lib/libfoo.a', dynamic='lib/libfoo.so')
         s, d, i = t._resolve_library_sources(_tc())
-        self.assertEqual(('BD/inst/lib/libfoo.a', 'BD/inst/lib/libfoo.so', None),
-                         (s, d, i))
+        self.assertEqual(
+            (J('BD', 'inst', 'lib/libfoo.a'), J('BD', 'inst', 'lib/libfoo.so'), None),
+            (s, d, i))
         self.assertEqual([], t.errors)
 
     def test_explicit_import_only_on_msvc(self):
@@ -69,7 +72,7 @@ class ForeignResolveSourcesTest(unittest.TestCase):
         t = _foreign(static='lib/foo.lib', dynamic='bin/foo.dll',
                      importlib='lib/foo.lib')
         _s, _d, i = t._resolve_library_sources(_tc('msvc'))
-        self.assertEqual('BD/inst/lib/foo.lib', i)
+        self.assertEqual(J('BD', 'inst', 'lib/foo.lib'), i)
         # Non-MSVC: import ignored, no error (the .so is the link target).
         t2 = _foreign(static='lib/libfoo.a', importlib='lib/foo.lib')
         _s, _d, i2 = t2._resolve_library_sources(_tc('gcc'))
@@ -87,8 +90,8 @@ class ForeignResolveSourcesTest(unittest.TestCase):
         t.blade = mock.Mock()
         t.blade.get_build_toolchain.return_value = _FakeToolChain()
         s, d, i = t._resolve_library_sources(_tc())
-        self.assertEqual('BD/inst/lib/libfoo.a', s)
-        self.assertEqual('BD/inst/lib/libfoo.so', d)
+        self.assertEqual(J('BD', 'inst', 'lib', 'libfoo.a'), s)
+        self.assertEqual(J('BD', 'inst', 'lib', 'libfoo.so'), d)
         self.assertIsNone(i)
 
     def test_convention_static_only_when_not_has_dynamic(self):
@@ -96,8 +99,74 @@ class ForeignResolveSourcesTest(unittest.TestCase):
         t.blade = mock.Mock()
         t.blade.get_build_toolchain.return_value = _FakeToolChain()
         s, d, _i = t._resolve_library_sources(_tc())
-        self.assertEqual('BD/inst/lib/libfoo.a', s)
+        self.assertEqual(J('BD', 'inst', 'lib', 'libfoo.a'), s)
         self.assertIsNone(d)
+
+
+class _NinjaTC:
+    """Toolchain stub for _ninja_rules wiring tests (MSVC)."""
+    STATIC_LIB_LABEL = 'a'
+    DYNAMIC_LIB_LABEL = 'so'
+    static_lib_suffix = '.lib'
+    dynamic_lib_suffix = '.dll'
+    all_dynamic_lib_suffixes = ('.dll',)
+    lib_prefix = ''
+
+    def __init__(self, vendor='msvc'):
+        self._vendor = vendor
+
+    def cc_is(self, vendor):
+        return vendor == self._vendor
+
+
+class ForeignNinjaRulesMsvcTest(unittest.TestCase):
+    """_ninja_rules drives the shared link helper: on MSVC the import lib is the
+    link target and the produced DLL is the runtime payload (windows_dll), linked
+    in place (no copy)."""
+
+    def _foreign(self, **attrs):
+        t = cc_targets.ForeignCcLibrary.__new__(cc_targets.ForeignCcLibrary)
+        t.name = 'foo'
+        t.attr = {'install_dir': 'inst', 'lib_dir': 'lib', 'has_dynamic': False,
+                  'static_library': None, 'dynamic_library': None,
+                  'import_library': None}
+        t.attr.update(attrs)
+        t.data = {}
+        t.errors = []
+        t.error = t.errors.append
+        t._target_file_path = lambda p: os.path.join('BD', p)
+        t.target_files = {}
+        t._add_target_file = lambda label, path: t.target_files.__setitem__(label, path)
+        t._add_default_target_file = t._add_target_file
+        t._soname_of = lambda p: None  # Windows: no soname
+        t.emitted_syms = []
+        t._emit_archive_syms = t.emitted_syms.append
+        t.blade = mock.Mock()
+        t.blade.get_build_toolchain.return_value = _NinjaTC()
+        return t
+
+    def test_import_and_dll_no_static(self):
+        # Typical Windows foreign build: a .dll + its import .lib, no archive.
+        t = self._foreign(dynamic_library='lib/foo.dll', import_library='lib/foo.lib')
+        t._ninja_rules()
+        imp = J('BD', 'inst', 'lib/foo.lib')
+        dll = J('BD', 'inst', 'lib/foo.dll')
+        self.assertEqual(imp, t.target_files['so'])   # link the import lib
+        self.assertEqual(imp, t.target_files['a'])     # serves static link too
+        self.assertEqual(dll, t.data['windows_dll'])   # DLL is the runtime payload
+        self.assertEqual([imp], t.emitted_syms)        # .syms from the link source
+        self.assertEqual([], t.errors)
+
+    def test_static_and_import_and_dll(self):
+        t = self._foreign(static_library='lib/foo_s.lib',
+                          dynamic_library='lib/foo.dll',
+                          import_library='lib/foo.lib')
+        t._ninja_rules()
+        self.assertEqual(J('BD', 'inst', 'lib/foo_s.lib'), t.target_files['a'])
+        self.assertEqual(J('BD', 'inst', 'lib/foo.lib'), t.target_files['so'])
+        self.assertEqual(J('BD', 'inst', 'lib/foo.dll'), t.data['windows_dll'])
+        # .syms come from the static archive (the static-link source).
+        self.assertEqual([J('BD', 'inst', 'lib/foo_s.lib')], t.emitted_syms)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Aligns `foreign_cc_library` with `prebuilt_cc_library`'s explicit lib paths (#1261), sharing one impl.

## What

`foreign_cc_library` accepts **`static_library` / `dynamic_library` / `import_library`** (paths relative to `install_dir`, under the build tree), overriding the `lib_dir`/`has_dynamic` name convention:

```python
foreign_cc_library(
    name = 'foo', deps = [':cmake_build'],
    install_dir = 'install',
    static_library = 'lib/libfoo.a',
    dynamic_library = 'lib/libfoo.so.1',   # names the convention can't express
    import_library = 'lib/foo.lib',        # Windows DLL's import lib
)
```

Useful when a cmake/autotools build emits libs the `lib<name>.<suffix>` convention can't name (version suffixes, several libs), and gives Windows foreign DLLs their import lib.

## Shared impl (the decided approach)

The post-resolution part of `PrebuiltCcLibrary._setup` — link selection (which of static/dynamic/import serves static- vs dynamic-linking), MSVC import-lib handling, and the `link_source`→`.syms` logic — is extracted to **`CcTarget._setup_library_link_targets`** and used by both rules.

Only **path resolution** differs, and stays per-class:
- **prebuilt**: probes source-tree files; copies a shared lib into the build tree.
- **foreign**: outputs are *generated* (declared, not probed) and linked **in place** (`dynamic_link_path == dynamic_source`).

On MSVC a `dynamic_library` requires `import_library` (same as prebuilt).

## Test

- 726 unit tests (+5 in `foreign_explicit_lib_test.py`: explicit static/dynamic, MSVC import resolution + the dynamic-without-import error, convention fallback); bare pyright clean.
- **Prebuilt regression** (the refactor is behaviour-preserving): macOS explicit-static run + Linux both link modes.
- **Foreign e2e on macOS:** a `gen_rule` produces `libfoo.a`/`libcustom.a`; both the **convention** wrapper and an **explicit `static_library`** wrapper build + run.
- The MSVC `import_library` path rides the already-Windows-validated shared helper (from #1261 phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)