### PR TITLE
feat(cc): strip_options + strip on cc_binary; strip_options on cc_plugin (#694)

### DIFF
--- a/doc/en/build_rules/cc.md
+++ b/doc/en/build_rules/cc.md
@@ -688,6 +688,18 @@ cc_binary(
   This attribute tells linker to put all symbols into its dynamic symbol table. make them visible
    for loaded shared libraries. for more details, see `--export-dynamic` in man ld(1).
 
+- `strip`: bool = False
+
+  Strip the executable after linking to reduce its size (symbols/debug info are removed). Blade links to a `<name>.unstripped` sidecar and runs `strip` into the final output. Only supported on the GNU toolchain (gcc); skipped with a notice elsewhere. Compatible with DebugFission — the `.dwp` is packaged from the objects, so you can ship a stripped binary alongside a separate `.dwp` for debugging.
+
+- `strip_options`: string[] = []
+
+  Options passed to `strip` when `strip = True`. Defaults to `['--strip-unneeded']`. Use `['--strip-all']` (or `['-s']`) for the smallest binary, `['--strip-debug']` to drop only debug info, or `['-K', '<symbol>']` to keep specific symbols. See `man strip(1)`.
+
+- `extra_linkflags`: string[] = []
+
+  Extra flags passed to the linker for this target (see the common attribute above), e.g. `extra_linkflags=['-Wl,-z,now']`.
+
 ### Using dwp files
 
 When DebugFission is enabled (via [`cc_config.fission`](../config.md#cc_config)) and dwp packaging is enabled
@@ -772,7 +784,8 @@ Attributes:
 - `allow_undefined`: bool = False, whether undefined symbols are allowed when linking. Because many plug-in libraries depend on the symbol names provided by the
   host process at runtime, the definition of these symbols does not exist in the link phase.
 - `strip`: bool = False, whether to remove the debugging symbol information. If enabled, the size of the generated library can be reduced, but symbolic debugging
-  cannot be performed.
+  cannot be performed. Only supported on the GNU toolchain (gcc); skipped with a notice elsewhere.
+- `strip_options`: string[] = [], options passed to `strip` when `strip = True`. Defaults to `['--strip-unneeded']` (safe for a shared object). Use e.g. `['--strip-debug']` to drop only debug info, or `['-K', '<symbol>']` to keep specific symbols. See `man strip(1)`.
 - `linker_script`: str, a single [linker script](https://sourceware.org/binutils/docs/ld/Scripts.html) used to control the linking process.
   Its role is mainly to specify how to put the sections in the input file into the output file and to control the layout of the sections in the input file in the program address space.
   The linker has a default built-in linking script, which can be viewed with `ld --verbose`. This option will replace the system's default linking script.

--- a/doc/zh_CN/build_rules/cc.md
+++ b/doc/zh_CN/build_rules/cc.md
@@ -631,6 +631,18 @@ cc_binary(
 
   详情请参考 man ld(1) 中查找 --export-dynamic 的说明。
 
+- `strip`: bool = False
+
+  链接后对可执行文件执行 strip 以减小体积（去除符号/调试信息）。Blade 会先链接到 `<name>.unstripped` 旁文件，再 strip 成最终输出。仅在 GNU 工具链（gcc）上支持，其它工具链会跳过并给出提示。与 DebugFission 兼容——`.dwp` 是从目标文件打包的，因此可以发布 strip 后的可执行文件，同时保留单独的 `.dwp` 用于调试。
+
+- `strip_options`: string[] = []
+
+  `strip = True` 时传给 `strip` 的选项，默认为 `['--strip-unneeded']`。最小化体积可用 `['--strip-all']`（或 `['-s']`），只去调试信息用 `['--strip-debug']`，保留特定符号用 `['-K', '<symbol>']`。详见 `man strip(1)`。
+
+- `extra_linkflags`: string[] = []
+
+  传给链接器的额外选项（见上文通用属性），例如 `extra_linkflags=['-Wl,-z,now']`。
+
 ### 使用 dwp 文件
 
 当开启 DebugFission（通过 [`cc_config.fission`](../config.md#cc_config) 配置）并开启 dwp 打包
@@ -714,7 +726,8 @@ cc_plugin(
 - `prefix`: str | None, 生成的动态库的文件名前缀。默认为 `None`，表示沿用当前工具链的平台默认前缀（Linux/macOS 为 `lib`，Windows 为空）。
 - `suffix`: str | None, 生成的动态库的文件名后缀。默认为 `None`，表示沿用当前工具链的平台默认后缀（Linux 为 `.so`，macOS 为 `.dylib`，Windows 为 `.dll`）。
 - `allow_undefined`: bool, 链接时是否允许未定义的符号。因为很多插件库运行时依赖宿主进程提供的符号名，链接阶段并不存在这些符号的定义。
-- `strip`: bool, 是否去除调试符号信息，开启后可以减少生成的库的大小，但是无法进行符号化调试。
+- `strip`: bool, 是否去除调试符号信息，开启后可以减少生成的库的大小，但是无法进行符号化调试。仅在 GNU 工具链（gcc）上支持，其它工具链会跳过并给出提示。
+- `strip_options`: string[] = [], `strip = True` 时传给 `strip` 的选项，默认为 `['--strip-unneeded']`（对动态库安全）。例如只去调试信息用 `['--strip-debug']`，保留特定符号用 `['-K', '<symbol>']`。详见 `man strip(1)`。
 - `linker_script`: str，单个[链接器脚本](https://sourceware.org/binutils/docs/ld/Scripts.html)，用来控制链接过程。
   它的作用主要是规定如何把输入文件内的 section 放入输出文件内，并控制输入文件内各部分在程序地址空间内的布局。
   链接器有个默认的内置链接脚本，可用 `ld --verbose` 查看。此选项将会替换系统的默认链接脚本。

--- a/src/blade/cc_rule_support.py
+++ b/src/blade/cc_rule_support.py
@@ -431,8 +431,11 @@ class CcRuleGenerator:
             self._generate_cc_check_undefined_rule()
             self._generate_cc_ar_rules()
             self._generate_cc_link_rules(ld, linkflags)
+            # ${strip_options} is set per target (defaults to --strip-unneeded;
+            # see CcTarget._strip_command_options), so each binary/plugin can
+            # control what `strip` removes (issue #694).
             self.generate_rule(name='strip',
-                               command='strip --strip-unneeded -o ${out} ${in}',
+                               command='strip ${strip_options} -o ${out} ${in}',
                                description='STRIP ${out}')
 
     def _generate_windows_cc_rules(self):

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -1286,6 +1286,17 @@ class CcTarget(Target):
                 return parts[1]
         return None
 
+    def _strip_command_options(self):
+        """The options passed to `strip` for this target (issue #694).
+
+        `strip_options` gives full control of what is removed; when unset the
+        default is `--strip-unneeded` (the historical behavior -- safe for shared
+        objects). Use e.g. `strip_options='--strip-all'` for a smaller executable,
+        or `--strip-debug` / `-K <sym>` to keep more.
+        """
+        options = self.attr.get('strip_options')
+        return ' '.join(var_to_list(options)) if options else '--strip-unneeded'
+
     def _setup_library_link_targets(self, tc, static_source, dynamic_source,
                                     import_source, dynamic_link_path):
         """Wire STATIC/DYNAMIC_LIB_LABEL from resolved library sources.
@@ -2718,6 +2729,8 @@ class CcBinary(CcTarget):
                  export_map: str | None,
                  version_scripts: StrOrListOpt,
                  export_dynamic: bool,
+                 strip: bool,
+                 strip_options: StrOrListOpt,
                  kwargs: dict[str, object]):
         """Init method.
 
@@ -2764,6 +2777,8 @@ class CcBinary(CcTarget):
         self.attr['export_map_fullpath'] = self._resolve_linker_input_file(
             export_map, version_scripts, 'export_map', 'version_scripts')
         self.attr['export_dynamic'] = export_dynamic
+        self.attr['strip'] = strip
+        self.attr['strip_options'] = var_to_list(strip_options)
         self.attr['dwp'] = is_fission() and need_dwp()
         self._add_tags('lang:cc', 'type:binary')
 
@@ -2888,14 +2903,24 @@ class CcBinary(CcTarget):
                 os.path.join(self.build_dir, 'scm.cc'))
             objs.append(scm)
             order_only_deps.append(scm)
-        output = self._target_file_path(
-            self.blade.get_build_toolchain().executable_file_name(self.name))
-        self._cc_link(output, 'link', objs=objs, deps=usr_libs, sys_libs=sys_libs,
+        tc = self.blade.get_build_toolchain()
+        output = self._target_file_path(tc.executable_file_name(self.name))
+        # When stripping (#694), link to a `.unstripped` sidecar and strip it into
+        # the final output; dwp packages debug from the objects, not the binary,
+        # so a stripped exe + a separate `.dwp` is the intended fission workflow.
+        do_strip = self.attr['strip'] and tc.cc_is('gcc')
+        link_output = '%s.unstripped' % output if do_strip else output
+        self._cc_link(link_output, 'link', objs=objs, deps=usr_libs, sys_libs=sys_libs,
                       linker_scripts=self.attr.get('linker_script_fullpath'),
                       version_scripts=self.attr.get('export_map_fullpath'),
                       target_linkflags=target_linkflags,
                       implicit_deps=implicit_deps,
                       order_only_deps=order_only_deps)
+        if do_strip:
+            self.generate_build('strip', output, inputs=link_output,
+                                variables={'strip_options': self._strip_command_options()})
+        elif self.attr['strip']:
+            console.notice('strip is not supported on this toolchain, skipping')
         self._add_default_target_file('bin', output)
         self._remove_on_clean(self._target_file_path(self.name + '.runfiles'))
         if is_fission() and self.attr.get("dwp"):
@@ -2955,6 +2980,8 @@ def cc_binary(name: str,
               export_map: str | None = None,
               version_scripts: StrOrListOpt = None,
               export_dynamic: bool = False,
+              strip: bool = False,
+              strip_options: StrOrListOpt = None,
               **kwargs: object):
     """cc_binary target."""
     keep_deps = var_to_list(keep_deps)
@@ -2981,6 +3008,8 @@ def cc_binary(name: str,
             export_map=export_map,
             version_scripts=version_scripts,
             export_dynamic=export_dynamic,
+            strip=strip,
+            strip_options=strip_options,
             kwargs=kwargs)
     cc_binary_target.attr['keep_deps'] = [cc_binary_target._unify_dep(d) for d in keep_deps]
     build_manager.instance.register_target(cc_binary_target)
@@ -3034,6 +3063,7 @@ class CcPlugin(CcTarget):
                  version_scripts: 'StrOrListOpt',
                  allow_undefined: bool,
                  strip: bool,
+                 strip_options: 'StrOrListOpt',
                  kwargs: dict[str, object]):
         """Init method.
 
@@ -3094,6 +3124,7 @@ class CcPlugin(CcTarget):
         self.attr['suffix'] = suffix
         self.attr['allow_undefined'] = allow_undefined
         self.attr['strip'] = strip
+        self.attr['strip_options'] = var_to_list(strip_options)
         self.attr['linker_script_fullpath'] = self._resolve_linker_input_file(
             linker_script, linker_scripts, 'linker_script', 'linker_scripts')
         self.attr['export_map_fullpath'] = self._resolve_linker_input_file(
@@ -3135,7 +3166,8 @@ class CcPlugin(CcTarget):
                           implicit_deps=link_all_symbols_libs, order_only_deps=incchk_deps)
             if self.attr['strip']:
                 if self.blade.get_build_toolchain().cc_is('gcc'):
-                    self.generate_build('strip', output, inputs=link_output)
+                    self.generate_build('strip', output, inputs=link_output,
+                                        variables={'strip_options': self._strip_command_options()})
                 else:
                     console.notice('strip is not supported on this toolchain, skipping')
             self._add_default_target_file(self.blade.get_build_toolchain().DYNAMIC_LIB_LABEL, output)
@@ -3166,6 +3198,7 @@ def cc_plugin(
         version_scripts: 'StrOrListOpt' = None,
         allow_undefined: bool = True,
         strip: bool = False,
+        strip_options: 'StrOrListOpt' = None,
         **kwargs: object):
     """cc_plugin target."""
     keep_deps = var_to_list(keep_deps)
@@ -3193,6 +3226,7 @@ def cc_plugin(
             version_scripts=version_scripts,
             allow_undefined=allow_undefined,
             strip=strip,
+            strip_options=strip_options,
             kwargs=kwargs)
     target.attr['keep_deps'] = [target._unify_dep(d) for d in keep_deps]
     build_manager.instance.register_target(target)
@@ -3262,6 +3296,8 @@ class CcTest(CcBinary):
                 export_map=None,
                 version_scripts=[],
                 export_dynamic=export_dynamic,
+                strip=False,
+                strip_options=None,
                 kwargs=kwargs)
         self.type = 'cc_test'
         self.attr['testdata'] = var_to_list(testdata)

--- a/src/tests/unit/strip_options_test.py
+++ b/src/tests/unit/strip_options_test.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for cc_binary / cc_plugin strip_options (#694)."""
+
+import os
+import sys
+import unittest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import cc_targets  # noqa: E402
+
+
+def _target(strip_options):
+    # strip_options is stored normalized (var_to_list) on the attr.
+    t = cc_targets.CcBinary.__new__(cc_targets.CcBinary)
+    t.attr = {'strip_options': strip_options}
+    return t
+
+
+class StripCommandOptionsTest(unittest.TestCase):
+    def test_default_is_strip_unneeded(self):
+        # Unset -> the historical default (safe for shared objects).
+        self.assertEqual('--strip-unneeded', _target([])._strip_command_options())
+
+    def test_custom_single(self):
+        self.assertEqual('--strip-all', _target(['--strip-all'])._strip_command_options())
+
+    def test_custom_multiple_joined(self):
+        self.assertEqual(
+            '--strip-debug -K keep_me',
+            _target(['--strip-debug', '-K', 'keep_me'])._strip_command_options())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #694 ("more strip controlling").

## What

The `strip` step hardcoded `strip --strip-unneeded`. Make it controllable per target.

- The `strip` ninja rule becomes `strip ${strip_options} -o ${out} ${in}`; `CcTarget._strip_command_options` supplies the value, defaulting to `--strip-unneeded` (the historical behavior, safe for shared objects).
- **`cc_plugin`**: adds **`strip_options`** (it already had `strip`).
- **`cc_binary`**: adds **`strip` + `strip_options`** — it had no strip at all. Blade links to a `<name>.unstripped` sidecar then strips into the final output.

```python
cc_binary(name='app', srcs=['main.cc'], strip=True)                          # --strip-unneeded
cc_binary(name='app', srcs=['main.cc'], strip=True, strip_options=['--strip-all'])
cc_plugin(name='p',  srcs=['p.cc'], strip=True, strip_options=['-K','plugin_entry'])
```

## Notes
- **gcc-only** (same gating as the existing plugin strip); a notice is emitted on other toolchains.
- **DebugFission-compatible**: `_generate_dwp` packages debug from the *objects*, not the binary, so a stripped binary + a separate `.dwp` for debugging is the intended fission workflow — no conflict.
- Default is unchanged (`--strip-unneeded`), so existing `cc_plugin(strip=True)` behaves identically.
- Docs (en + zh) added for `strip` / `strip_options` / `extra_linkflags` on both rules (the issue asked for these).

## Test
- 731 unit tests (+3 `strip_options_test`); bare pyright clean.
- **Linux/gcc**: `app` (45 symbols) → `app_strip`/`app_all` (0, fully stripped); per-target `strip_options` reach the edge (`app_strip → --strip-unneeded`, `app_all → --strip-all`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)