### PR TITLE
feat(cc): Windows exe symbol export via export_map on cc_binary (#1201)

### DIFF
--- a/doc/en/build_rules/cc.md
+++ b/doc/en/build_rules/cc.md
@@ -688,6 +688,24 @@ cc_binary(
   This attribute tells linker to put all symbols into its dynamic symbol table. make them visible
    for loaded shared libraries. for more details, see `--export-dynamic` in man ld(1).
 
+  `export_dynamic` is an ELF (GNU-ld / ld64) feature. **It has no effect on MSVC** (Windows
+  has no "export all" mode; the option is ignored with a warning). On Windows, export symbols
+  *explicitly* with `export_map` (below).
+
+- `export_map` (on `cc_binary`): the same export-control file used by `cc_library` also lets an
+  **executable** export selected symbols, so a `LoadLibrary`'d plugin DLL can resolve them back
+  into the host (issue #1201). On GNU-ld / ld64 it is the link-time version script as usual; on
+  **MSVC** Blade turns it into a COMDAT-filtered `.def`, passes `/DEF` so the exe exports exactly
+  the listed symbols, and `link.exe` additionally emits an **import library `<name>.lib`** that a
+  plugin DLL links (e.g. via a `prebuilt_cc_library`) to call back into the host. Export is always
+  *explicit* — Windows favors a curated set over exporting everything (which would blow the PE 64K
+  export ceiling and expose internals); for a one-off symbol, `linkflags = ['/EXPORT:<symbol>']`
+  works without an export map.
+
+  ```python
+  cc_binary(name = 'host', srcs = ['host.cc'], export_map = 'host_api.map')
+  ```
+
 - `strip`: bool = False
 
   Strip the executable after linking to reduce its size (symbols/debug info are removed). Blade links to a `<name>.unstripped` sidecar and runs `strip` into the final output. Only supported on the GNU toolchain (gcc); skipped with a notice elsewhere. Compatible with DebugFission — the `.dwp` is packaged from the objects, so you can ship a stripped binary alongside a separate `.dwp` for debugging.

--- a/doc/zh_CN/build_rules/cc.md
+++ b/doc/zh_CN/build_rules/cc.md
@@ -631,6 +631,21 @@ cc_binary(
 
   详情请参考 man ld(1) 中查找 --export-dynamic 的说明。
 
+  `export_dynamic` 是 ELF（GNU-ld / ld64）特性，**在 MSVC 上无效**（Windows 没有“导出全部符号”
+  的模式，该选项会被忽略并给出告警）。在 Windows 上请用下面的 `export_map` **显式**导出符号。
+
+- `export_map`（用于 `cc_binary`）：`cc_library` 使用的同一个导出控制文件也可让**可执行文件**导出
+  选定的符号，使 `LoadLibrary` 加载的插件 DLL 能回调宿主中的这些符号（issue #1201）。在 GNU-ld / ld64
+  上它照常作为链接期 version script；在 **MSVC** 上 blade 会把它转成一个按 COMDAT 过滤的 `.def`，
+  通过 `/DEF` 让可执行文件只导出列出的符号，并让 `link.exe` 额外产出一个**导入库 `<name>.lib`**，
+  插件 DLL 链接该导入库（例如通过 `prebuilt_cc_library`）即可回调宿主。导出始终是**显式**的——Windows
+  倾向于精选集合而非全部导出（否则会触及 PE 64K 导出上限并暴露内部实现）；若只导出个别符号，用
+  `linkflags = ['/EXPORT:<symbol>']` 无需导出文件即可。
+
+  ```python
+  cc_binary(name = 'host', srcs = ['host.cc'], export_map = 'host_api.map')
+  ```
+
 - `strip`: bool = False
 
   链接后对可执行文件执行 strip 以减小体积（去除符号/调试信息）。Blade 会先链接到 `<name>.unstripped` 旁文件，再 strip 成最终输出。仅在 GNU 工具链（gcc）上支持，其它工具链会跳过并给出提示。与 DebugFission 兼容——`.dwp` 是从目标文件打包的，因此可以发布 strip 后的可执行文件，同时保留单独的 `.dwp` 用于调试。

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -2903,18 +2903,31 @@ class CcBinary(CcTarget):
                 os.path.join(self.build_dir, 'scm.cc'))
             objs.append(scm)
             order_only_deps.append(scm)
-        tc = self.blade.get_build_toolchain()
-        output = self._target_file_path(tc.executable_file_name(self.name))
+        toolchain = self.blade.get_build_toolchain()
+        output = self._target_file_path(toolchain.executable_file_name(self.name))
+        # `export_map` controls symbol export on every toolchain, but the
+        # mechanism differs: GNU-ld / ld64 take a version script at link time
+        # (handled by _cc_link via `version_scripts`); MSVC needs a `.def` +
+        # /DEF, which also makes link.exe emit an import library (#1201). So on
+        # MSVC route export_map through the Windows path and don't also pass it
+        # to _cc_link (where it would leak a bogus --version-script -> LNK4044).
+        version_scripts = self.attr.get('export_map_fullpath')
+        export_inputs, export_outputs = [], None
+        if toolchain.cc_is('msvc'):
+            export_inputs, export_outputs = self._windows_export_link_inputs(
+                toolchain, target_linkflags, objs, order_only_deps)
+            version_scripts = None
         # When stripping (#694), link to a `.unstripped` sidecar and strip it into
         # the final output; dwp packages debug from the objects, not the binary,
         # so a stripped exe + a separate `.dwp` is the intended fission workflow.
-        do_strip = self.attr['strip'] and tc.cc_is('gcc')
+        do_strip = self.attr['strip'] and toolchain.cc_is('gcc')
         link_output = '%s.unstripped' % output if do_strip else output
         self._cc_link(link_output, 'link', objs=objs, deps=usr_libs, sys_libs=sys_libs,
                       linker_scripts=self.attr.get('linker_script_fullpath'),
-                      version_scripts=self.attr.get('export_map_fullpath'),
+                      version_scripts=version_scripts,
                       target_linkflags=target_linkflags,
-                      implicit_deps=implicit_deps,
+                      implicit_deps=(implicit_deps or []) + export_inputs,
+                      implicit_outputs=export_outputs,
                       order_only_deps=order_only_deps)
         if do_strip:
             self.generate_build('strip', output, inputs=link_output,
@@ -2926,6 +2939,36 @@ class CcBinary(CcTarget):
         if is_fission() and self.attr.get("dwp"):
             self._generate_dwp(output, objs, implicit_deps, order_only_deps)
 
+    def _windows_export_link_inputs(self, tc, target_linkflags, objs, order_only_deps):
+        """Drive Windows exe symbol export from `export_map` (#1201).
+
+        On MSVC an `export_map` is turned into a COMDAT-filtered `.def` (the same
+        `cc_windef` path DLLs use), passed as `/DEF` so the exe exports exactly
+        the listed symbols, and link.exe additionally emits an import library
+        (`<name>.lib`) that a plugin DLL links to call back into the host. With
+        no export_map the exe exports nothing -- Windows favors an explicit,
+        curated set over export-all (which would blow the PE 64K ceiling).
+
+        Appends `/DEF` + `/IMPLIB` to *target_linkflags* (mutated in place) and
+        returns ``(implicit_deps, implicit_outputs)`` for the link edge.
+        """
+        export_map = self.attr.get('export_map_fullpath')
+        if not export_map:
+            return [], None
+        def_file = self._target_file_path(self.name + '.def')
+        # `<name>.lib` -- link.exe's own default name for an exe's import lib
+        # (not the DLL `import_library_name` -> `<name>.dll.lib`: there's no DLL).
+        implib = self._target_file_path(self.name + tc.static_lib_suffix)
+        self.generate_build('cc_windef', def_file, inputs=objs,
+                            implicit_deps=[export_map[0]],
+                            order_only_deps=order_only_deps,
+                            variables={'defflags': '--export_map=%s' % export_map[0]})
+        target_linkflags.append('/DEF:%s' % def_file)
+        target_linkflags.append('/IMPLIB:%s' % implib)
+        # Register the import lib so a dependent (e.g. a plugin DLL) can link it.
+        self._add_target_file(tc.DYNAMIC_LIB_LABEL, implib)
+        self.data['windows_implib'] = implib
+        return [def_file], [implib]
 
     def _generate_dwp(self, binary_path, objs, implicit_deps, order_only_deps):
         """Generate dwp file."""

--- a/src/tests/unit/cc_targets_test.py
+++ b/src/tests/unit/cc_targets_test.py
@@ -397,5 +397,57 @@ class CheckIncorrectNoWarningTest(unittest.TestCase):
         target.warning.assert_not_called()
 
 
+class WindowsExportLinkInputsTest(unittest.TestCase):
+    """cc_binary Windows symbol export (#1201): on MSVC an `export_map` drives a
+    COMDAT-filtered `.def` (cc_windef) + /DEF + /IMPLIB so the exe exports the
+    selected symbols and emits an import library dependents can link."""
+
+    def _binary(self, export_map):
+        t = cc_targets.CcBinary.__new__(cc_targets.CcBinary)
+        t.name = 'host'
+        t.attr = {'export_map_fullpath': export_map}
+        t.data = {}
+        self.tc = mock.Mock()
+        self.tc.static_lib_suffix = '.lib'
+        self.tc.DYNAMIC_LIB_LABEL = 'so'
+        t._target_file_path = lambda p: os.path.join('BD/host', p)
+        t.target_files = {}
+        t._add_target_file = lambda label, path: t.target_files.__setitem__(label, path)
+        t.generate_build_calls = []
+        t.generate_build = lambda rule, output, **kw: t.generate_build_calls.append(
+            {'rule': rule, 'output': output, **kw})
+        return t
+
+    def _call(self, t, objs=('a.o',), order_only=()):
+        return t._windows_export_link_inputs(self.tc, self.flags, list(objs), list(order_only))
+
+    def setUp(self):
+        self.flags = ['/SUBSYSTEM:CONSOLE']
+
+    def test_no_export_map_is_noop(self):
+        t = self._binary([])
+        self.assertEqual(([], None), self._call(t))
+        self.assertEqual(['/SUBSYSTEM:CONSOLE'], self.flags)
+        self.assertEqual([], t.generate_build_calls)
+
+    def test_export_map_generates_def_and_implib(self):
+        t = self._binary(['api.map'])
+        deps, outs = self._call(t, objs=['a.o', 'b.o'])
+        def_file = os.path.join('BD/host', 'host.def')
+        implib = os.path.join('BD/host', 'host.lib')
+        # cc_windef builds the filtered .def from the objs, gated by the map.
+        windef = [c for c in t.generate_build_calls if c['rule'] == 'cc_windef']
+        self.assertEqual(1, len(windef))
+        self.assertEqual(def_file, windef[0]['output'])
+        self.assertEqual(['a.o', 'b.o'], windef[0]['inputs'])
+        self.assertEqual('--export_map=api.map', windef[0]['variables']['defflags'])
+        # link gets /DEF + /IMPLIB; the def is an input, the implib an output.
+        self.assertIn('/DEF:%s' % def_file, self.flags)
+        self.assertIn('/IMPLIB:%s' % implib, self.flags)
+        self.assertEqual(([def_file], [implib]), (deps, outs))
+        self.assertEqual(implib, t.target_files['so'])     # dependents can link it
+        self.assertEqual(implib, t.data['windows_implib'])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #1201.

## What

`export_dynamic` is an ELF (GNU-ld / ld64) feature and a **no-op on MSVC** (Windows has no "export all" mode). This lets a `cc_binary` export selected symbols on Windows by **reusing the existing `export_map`** — no new attribute (per the agreed scope).

```python
cc_binary(name = 'host', srcs = ['host.cc'], export_map = 'host_api.map')
```

## How

- On **MSVC**, an `export_map` on a `cc_binary` is turned into a COMDAT-filtered `.def` (the same `cc_windef` path DLLs use), passed as `/DEF` so the exe exports **exactly the listed symbols**; `link.exe` then also emits an **import library `<name>.lib`** that a plugin DLL links (e.g. via `prebuilt_cc_library`) to call back into the host. Export stays explicit/selective — no auto-export-all (which would blow the PE 64K ceiling and expose internals).
- On **GNU-ld / ld64**, `export_map` remains the link-time version script as before. On MSVC it no longer leaks a bogus `--version-script` (LNK4044) into the link.
- The import lib is registered (`DYNAMIC_LIB_LABEL`) so a dependent can link it.
- `<name>.lib` is link.exe's own default name for an exe import lib (not the DLL `import_library_name` → `<name>.dll.lib`; there's no DLL here).

## Verification

**End-to-end on Windows/MSVC (ARM64):** a `cc_binary` with `export_map`:
- builds (the `CC WINDEF` edge filters the export set, then `LINK EXE`),
- `dumpbin /exports host.exe` shows the selected `host_api`,
- the import lib **`host.lib`** is produced,
- the exe still runs.

Unit test (`WindowsExportLinkInputsTest`) pins the `cc_windef` wiring + `/DEF`/`/IMPLIB` + implib registration, and the no-export_map no-op. Full unit suite: no new failures (30 pre-existing); bare pyright (CI config) clean. Docs (en + zh) updated.

## Also documented (works today, no code)

`linkflags = ['/EXPORT:<symbol>']` for a one-off symbol without an export map.