### PR TITLE
fix(cc): exempt instrumentation runtimes from cc_check_undefined (coverage + sanitizers)

### DIFF
--- a/src/blade/builtin_tools.py
+++ b/src/blade/builtin_tools.py
@@ -189,6 +189,19 @@ _CHECK_UNDEFINED_RESIDUAL_BASELINE = (
     # implicitly because every dynamic executable runs through ld-linux.
     r'__tls_get_addr',
     r'__tls_get_offset',
+    # ---- Instrumentation runtimes (coverage / sanitizers) ----
+    # Instrumented objects call into a runtime that the corresponding *link*
+    # flag pulls in automatically -- not a `-l<alias>` user code can declare:
+    #   * `--coverage`  -> gcov runtime (`__llvm_gcov_*` / `__llvm_gcda_*` on
+    #     clang, `__gcov_*` on gcc)
+    #   * `-fsanitize=` -> ASan/UBSan/TSan/MSan/LSan runtime (`__asan_*`,
+    #     `__ubsan_*`, `__tsan_*`, `__msan_*`, `__lsan_*`, `__sanitizer_*`)
+    # These names never appear without the instrumentation, so exempting them
+    # unconditionally is safe in every build.
+    r'_*llvm_gc(?:ov|da)_\w*',
+    r'_*__gcov_\w*',
+    r'_*__(?:a|ub|t|m|l)san_\w*',
+    r'_*__sanitizer_\w*',
 )
 
 

--- a/src/tests/unit/cc_check_undefined_test.py
+++ b/src/tests/unit/cc_check_undefined_test.py
@@ -127,6 +127,17 @@ class ResidualBaselineTest(unittest.TestCase):
         for n in ('_tlv_bootstrap', '__tlv_atexit', '___tlv_bootstrap'):
             self.assertTrue(self._allowed(n), n)
 
+    def test_instrumentation_runtime_symbols(self):
+        # Coverage (gcov) and sanitizer runtimes are pulled in by the `--coverage`
+        # / `-fsanitize=` LINK flags, not by declared deps, so the undefined-symbol
+        # check must treat them as ambient.
+        for n in ('_llvm_gcda_emit_arcs', '_llvm_gcov_init', '__llvm_gcda_end_file',
+                  '__gcov_init', '__gcov_merge_add',
+                  '___ubsan_handle_type_mismatch_v1_abort', '__asan_init',
+                  '___asan_report_load8', '__tsan_func_entry', '__msan_init',
+                  '__lsan_ignore_object', '__sanitizer_cov_trace_pc'):
+            self.assertTrue(self._allowed(n), n)
+
     def test_user_namespace_symbols_not_matched(self):
         """User code (now including libc functions like _malloc) must NOT
         match the residual baseline — those come from real lib enumeration."""


### PR DESCRIPTION
Under `--coverage` or `--sanitizer=...`, `cc_check_undefined` floods warnings like:

```
cc_check_undefined: flare/net/http:types has 7 undefined symbol(s) not covered by declared deps:
  ___ubsan_handle_type_mismatch_v1_abort
  ...
cc_check_undefined: flare/rpc/binlog:dry_runner has 6 undefined symbol(s) not covered by declared deps:
  _llvm_gcda_emit_arcs
  _llvm_gcov_init
  ...
```

## Cause

Instrumented objects reference the **instrumentation runtime**, which the corresponding **link** flag pulls in automatically — it is not a `-l<alias>` user code declares:
- `--coverage` → gcov runtime: `__llvm_gcov_*` / `__llvm_gcda_*` (clang), `__gcov_*` (gcc)
- `-fsanitize=` → `__asan_*` / `__ubsan_*` / `__tsan_*` / `__msan_*` / `__lsan_*` / `__sanitizer_*`

The static check sees them undefined-and-undeclared and warns on every instrumented library.

## Fix

Add these families to the residual ambient baseline (alongside TLS / `__tls_get_addr`). They never appear without the instrumentation, so the exemption is safe in every build (verified the patterns don't match user symbols).

## Test

- 734 unit tests (+ a baseline test pinning the gcov/asan/ubsan/tsan/msan/lsan/sanitizer exemptions); pyright clean.
- Real flare on macOS: `--coverage` and `--sanitizer=address` builds now emit **0** `cc_check_undefined` warnings (was a flood).

🤖 Generated with [Claude Code](https://claude.com/claude-code)