### PR TITLE
fix(cc): exempt TSan dynamic-annotation symbols from cc_check_undefined

### DIFF
--- a/src/blade/builtin_tools.py
+++ b/src/blade/builtin_tools.py
@@ -202,6 +202,12 @@ _CHECK_UNDEFINED_RESIDUAL_BASELINE = (
     r'_*__gcov_\w*',
     r'_*__(?:a|ub|t|m|l)san_\w*',
     r'_*__sanitizer_\w*',
+    # ThreadSanitizer dynamic-annotation interface: the ANNOTATE_* macros (e.g.
+    # ANNOTATE_BENIGN_RACE_SIZED) expand to `Annotate*` / `RunningOnValgrind`
+    # calls under -fsanitize=thread, provided by the TSan runtime. These do NOT
+    # use the __tsan_ prefix.
+    r'_*Annotate\w*',
+    r'_*RunningOnValgrind',
 )
 
 

--- a/src/tests/unit/cc_check_undefined_test.py
+++ b/src/tests/unit/cc_check_undefined_test.py
@@ -135,7 +135,10 @@ class ResidualBaselineTest(unittest.TestCase):
                   '__gcov_init', '__gcov_merge_add',
                   '___ubsan_handle_type_mismatch_v1_abort', '__asan_init',
                   '___asan_report_load8', '__tsan_func_entry', '__msan_init',
-                  '__lsan_ignore_object', '__sanitizer_cov_trace_pc'):
+                  '__lsan_ignore_object', '__sanitizer_cov_trace_pc',
+                  # TSan dynamic-annotation interface (no __tsan_ prefix).
+                  '_AnnotateBenignRaceSized', 'AnnotateHappensBefore',
+                  '_RunningOnValgrind'):
             self.assertTrue(self._allowed(n), n)
 
     def test_user_namespace_symbols_not_matched(self):


### PR DESCRIPTION
Follow-up to #1364. Under `--sanitizer=thread`, `cc_check_undefined` still floods on every library that uses a race annotation:

```
cc_check_undefined: flare/io:io_basic has 1 undefined symbol(s) not covered by declared deps:
  _AnnotateBenignRaceSized
... (8 targets)
```

## Cause

ThreadSanitizer's **dynamic-annotation interface** — the `ANNOTATE_*` macros (`ANNOTATE_BENIGN_RACE_SIZED`, `ANNOTATE_HAPPENS_BEFORE`, …) expand to `AnnotateBenignRaceSized` / `AnnotateHappensBefore` / `RunningOnValgrind` calls under `-fsanitize=thread`. They're provided by the TSan runtime but do **not** use the `__tsan_` prefix, so #1364's `__tsan_*` exemption didn't cover them.

## Fix

Add `Annotate*` / `RunningOnValgrind` to the ambient baseline. Verified the pattern matches the annotation interface but not e.g. `AnnotationParser` (only `Annotate` + suffix, not `Annotation*`).

## Test

- Unit baseline test extended; full suite green; pyright clean.
- Real flare on macOS: `--sanitizer=thread` build of the 8 previously-warning targets now emits **0** `cc_check_undefined` warnings, Build success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)