### PR TITLE
fix(cc): gate --gprof and --coverage to where the instrumentation works

### DIFF
--- a/doc/en/command_line.md
+++ b/doc/en/command_line.md
@@ -127,8 +127,8 @@ Different subcommands support different options. Run `blade <subcommand> --help`
 - `--generate-java` - Generate Java files for proto_library and swig_library
 - `--generate-php` - Generate PHP files for proto_library and swig_library
 - `--generate-go` - Generate Go files for proto_library
-- `--gprof` - Enable GNU gprof profiling support
-- `--coverage` - Generate code coverage reports (supports GNU gcov and Java jacoco)
+- `--gprof` - Enable GNU gprof profiling support. **Linux only** (gcc and clang): `-pg`/gprof instrumentation only works on Linux. On macOS the flag is silently ignored (Darwin clang accepts `-pg` but treats it as a no-op, and there is no gprof tool / `gmon.out`); on Windows MSVC does not understand it. Blade skips the flag and warns once on these platforms — use `--coverage`, or a native sampling profiler (Instruments/`sample` on macOS, `perf` on Linux).
+- `--coverage` - Generate code coverage reports (supports GNU gcov and Java jacoco). For C/C++ this is the gcc/clang `--coverage` instrumentation and works on **gcc and clang on every platform, including clang-cl on Windows**. Native MSVC `cl.exe` has no gcov-style instrumentation, so blade skips the flag and warns once there — on Windows use **clang-cl** (LLVM source coverage) or **OpenCppCoverage** (PDB-based, no rebuild).
 
 ## Usage Examples
 

--- a/doc/en/test.md
+++ b/doc/en/test.md
@@ -101,6 +101,7 @@ blade test //foo/... --coverage
 - The coverage compile/link flags are added automatically; `.gcno`/`.gcda` data is produced during the test run.
 - After the tests finish, Blade runs [gcovr](https://gcovr.com/) to produce a directory-navigable HTML report (drill down folder by folder to per-file line views) at `<build_dir>/cc_coverage_report/index.html` (plus `coverage.xml` in Cobertura format). Install it with `pip install gcovr`; if gcovr is absent, Blade just warns and skips the report.
 - Sources under the build directory are excluded, so the report reflects your own code rather than generated sources (e.g. `*.pb.cc`) or vendored dependencies (vcpkg installs under the build dir).
+- **Platform/toolchain:** `--coverage` works on gcc and clang on every platform, including **clang-cl** on Windows. Native MSVC `cl.exe` has no gcov-style instrumentation, so Blade skips the flag and warns once — on Windows compile with [clang-cl](config.md#using-clang-cl-on-windows) for LLVM source coverage, or use [OpenCppCoverage](https://github.com/OpenCppCoverage/OpenCppCoverage) (PDB-based, needs no rebuild).
 
 ### Go Coverage (go test -cover)
 

--- a/doc/zh_CN/command_line.md
+++ b/doc/zh_CN/command_line.md
@@ -127,8 +127,8 @@ $ blade dump --all-tags ...
 - `--generate-java` —— 为 `proto_library` 和 `swig_library` 生成 Java 文件
 - `--generate-php` —— 为 `proto_library` 和 `swig_library` 生成 PHP 文件
 - `--generate-go` —— 为 `proto_library` 生成 Go 文件
-- `--gprof` —— 启用 GNU gprof 性能分析
-- `--coverage` —— 生成代码覆盖率报告（支持 GNU gcov 与 Java jacoco）
+- `--gprof` —— 启用 GNU gprof 性能分析。**仅限 Linux**（gcc 与 clang）：`-pg`/gprof 插桩只在 Linux 上有效。macOS 上该标志被静默忽略（Darwin clang 接受 `-pg` 但当作空操作，且没有 gprof 工具 / `gmon.out`），Windows 上 MSVC 根本不认。在这些平台 blade 会跳过该标志并仅警告一次——请改用 `--coverage`，或原生采样分析器（macOS 用 Instruments/`sample`，Linux 用 `perf`）。
+- `--coverage` —— 生成代码覆盖率报告（支持 GNU gcov 与 Java jacoco）。C/C++ 走的是 gcc/clang 的 `--coverage` 插桩，**在所有平台的 gcc 与 clang 上均可用，含 Windows 上的 clang-cl**。原生 MSVC `cl.exe` 没有 gcov 风格插桩，因此 blade 在该工具链下跳过该标志并仅警告一次——Windows 上请使用 **clang-cl**（LLVM 源码级覆盖率）或 **OpenCppCoverage**（基于 PDB，无需重新编译）。
 
 ## 使用示例
 

--- a/doc/zh_CN/test.md
+++ b/doc/zh_CN/test.md
@@ -97,6 +97,7 @@ blade test //foo/... --coverage
 - 自动加入覆盖率相关的编译/链接选项；测试运行时产生 `.gcno`/`.gcda` 数据。
 - 测试结束后，Blade 调用 [gcovr](https://gcovr.com/) 在 `<build_dir>/cc_coverage_report/index.html` 生成可逐级目录下钻（目录 → 文件 → 逐行）的 HTML 报告（并附带 Cobertura 格式的 `coverage.xml`）。请先 `pip install gcovr`；若未安装，Blade 只会告警并跳过报告生成。
 - 构建目录下的源文件会被排除，报告只反映你自己的代码，而非生成代码（如 `*.pb.cc`）或第三方依赖（vcpkg 安装在构建目录下）。
+- **平台/工具链：** `--coverage` 在所有平台的 gcc 与 clang 上均可用，含 Windows 上的 **clang-cl**。原生 MSVC `cl.exe` 没有 gcov 风格插桩，因此 Blade 会跳过该标志并仅警告一次——Windows 上请用 [clang-cl](config.md#using-clang-cl-on-windows) 获得 LLVM 源码级覆盖率，或使用 [OpenCppCoverage](https://github.com/OpenCppCoverage/OpenCppCoverage)（基于 PDB，无需重新编译）。
 
 ### Go 覆盖率（go test -cover）
 

--- a/src/blade/cc_rule_support.py
+++ b/src/blade/cc_rule_support.py
@@ -231,6 +231,35 @@ _DARWIN_AR_WRAPPER_SH = r'''#!/bin/bash
 exec "$@" 2> >(grep -v 'table of contents is empty' >&2)
 '''
 
+# `--gprof` runs the cc flag computation per target; only complain once.
+_gprof_unsupported_warned = False
+
+
+def _warn_gprof_unsupported(target_os):
+    global _gprof_unsupported_warned
+    if _gprof_unsupported_warned:
+        return
+    _gprof_unsupported_warned = True
+    console.warning(
+        '--gprof is not supported on %s (gprof/-pg instrumentation only works '
+        'on Linux); the flag is ignored. Use --coverage, or a native profiler '
+        '(Instruments/sample on macOS).' % target_os)
+
+
+# `--coverage` runs the cc flag computation per target; only complain once.
+_coverage_unsupported_warned = False
+
+
+def _warn_coverage_unsupported():
+    global _coverage_unsupported_warned
+    if _coverage_unsupported_warned:
+        return
+    _coverage_unsupported_warned = True
+    console.warning(
+        '--coverage is not supported on MSVC (cl.exe has no gcov-style '
+        'instrumentation); the flag is ignored. Use clang-cl for LLVM source '
+        'coverage, or OpenCppCoverage (PDB-based, no rebuild).')
+
 
 class CcRuleGenerator:
     """Generate cc/cuda ninja rules from a RuleContext (see module docstring)."""
@@ -336,12 +365,28 @@ class CcRuleGenerator:
         ]
 
         if getattr(self.options, 'gprof', False):
-            cppflags.append('-pg')
-            linkflags.append('-pg')
+            # gprof's `-pg` instrumentation is only functional on Linux. Darwin
+            # clang accepts `-pg` but ignores it (spraying "argument unused"
+            # warnings, and there is no gprof tool / gmon.out on macOS); MSVC
+            # does not understand it at all. Skip the dead flag elsewhere and
+            # warn once instead of letting the toolchain complain per edge.
+            if self.build_toolchain.target_os == 'linux':
+                cppflags.append('-pg')
+                linkflags.append('-pg')
+            else:
+                _warn_gprof_unsupported(self.build_toolchain.target_os)
 
         if getattr(self.options, 'coverage', False):
-            cppflags.append('--coverage')
-            linkflags.append('--coverage')
+            # `--coverage` is the gcc/clang driver flag (-fprofile-arcs
+            # -ftest-coverage / instr-profile). Native MSVC cl.exe has no
+            # gcov-style instrumentation, so the flag is meaningless there --
+            # skip it and warn once instead of feeding cl.exe a flag it can't
+            # parse. (clang-cl reports as 'clang' and keeps the gcc-style path.)
+            if self.build_toolchain.cc_is('msvc'):
+                _warn_coverage_unsupported()
+            else:
+                cppflags.append('--coverage')
+                linkflags.append('--coverage')
 
         sanitizers = getattr(self.options, 'sanitizers', None)
         if sanitizers:

--- a/src/blade/command_line.py
+++ b/src/blade/command_line.py
@@ -289,7 +289,7 @@ class CommandLineParser:
         parser.add_argument(
             '--gprof', dest='gprof',
             action='store_true', default=False,
-            help='Add build options to support GNU gprof')
+            help='Add build options to support GNU gprof (Linux only; ignored on macOS/Windows)')
 
         parser.add_argument(
             '--coverage', dest='coverage',

--- a/src/tests/unit/cc_instrumentation_gating_test.py
+++ b/src/tests/unit/cc_instrumentation_gating_test.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+#
+# Unit tests for the instrumentation-flag platform gating in
+# _get_intrinsic_cc_flags (--gprof and --coverage).
+
+"""Tests that instrumentation flags are only emitted where they work.
+
+  * ``--gprof`` -> ``-pg`` is only functional on Linux (gcc/clang). Darwin
+    clang accepts ``-pg`` but ignores it (spraying
+    ``-Wunused-command-line-argument`` per compile, no ``gmon.out``); MSVC does
+    not understand it. Non-Linux targets skip the dead flag and warn once.
+
+  * ``--coverage`` is the gcc/clang driver flag. Native MSVC cl.exe has no
+    gcov-style instrumentation, so it is skipped (warn once) there; clang-cl
+    reports as 'clang' and keeps the gcc-style path.
+
+In both cases the warning fires once per build (the guard is module-level),
+not once per target, so a many-target build does not get spammed.
+"""
+
+import os
+import sys
+import unittest
+import unittest.mock as mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import config  # noqa: E402
+from blade import cc_rule_support  # noqa: E402
+
+
+def _make_generator(target_os, cc_vendor='gcc', gprof=False, coverage=False):
+    """A minimal CcRuleGenerator with the given instrumentation options, a
+    toolchain that reports the requested target_os/vendor and returns flags
+    verbatim, and the few `options` attrs `_get_intrinsic_cc_flags` reads."""
+    gen = cc_rule_support.CcRuleGenerator.__new__(cc_rule_support.CcRuleGenerator)
+    gen.options = mock.Mock()
+    gen.options.m = None
+    gen.options.profile = 'release'
+    gen.options.gprof = gprof
+    gen.options.coverage = coverage
+    gen.options.sanitizers = []
+    for attr in ('profile-generate', 'profile-use'):
+        try:
+            delattr(gen.options, attr)
+        except AttributeError:
+            pass
+    gen.build_toolchain = mock.Mock()
+    gen.build_toolchain.target_os = target_os
+    gen.build_toolchain.filter_cc_flags = lambda flags: list(flags)
+    gen.build_toolchain.cc_is = lambda vendor: vendor == cc_vendor
+
+    section = {
+        'fission': False,
+        'debug_info_levels': {'mid': ['-g']},
+        'no_semantic_interposition': False,
+    }
+    global_section = {'debug_info_level': 'mid'}
+
+    def fake_get_section(name):
+        return {'cc_config': section, 'global_config': global_section}[name]
+
+    return gen, fake_get_section
+
+
+def _flags(gen, fake_get_section):
+    with mock.patch.object(cc_rule_support.config, 'get_section',
+                           side_effect=fake_get_section):
+        return gen._get_intrinsic_cc_flags()
+
+
+class CcGprofGatingTest(unittest.TestCase):
+    """`--gprof` adds `-pg` only on Linux; warns once elsewhere."""
+
+    def setUp(self):
+        cc_rule_support._gprof_unsupported_warned = False
+
+    def test_linux_adds_pg_to_compile_and_link(self):
+        """On Linux gprof is real: `-pg` rides both cppflags and linkflags."""
+        gen, fake = _make_generator('linux', gprof=True)
+        with mock.patch.object(cc_rule_support.console, 'warning') as warn:
+            cppflags, linkflags = _flags(gen, fake)
+        self.assertIn('-pg', cppflags)
+        self.assertIn('-pg', linkflags)
+        warn.assert_not_called()
+
+    def test_linux_clang_also_adds_pg(self):
+        """gprof is gated on the *platform*, not the vendor: clang on Linux
+        supports `-pg` (mcount) just like gcc, so it must NOT be excluded."""
+        gen, fake = _make_generator('linux', cc_vendor='clang', gprof=True)
+        with mock.patch.object(cc_rule_support.console, 'warning') as warn:
+            cppflags, linkflags = _flags(gen, fake)
+        self.assertIn('-pg', cppflags)
+        self.assertIn('-pg', linkflags)
+        warn.assert_not_called()
+
+    def test_darwin_skips_pg_and_warns_once(self):
+        """On macOS `-pg` is a no-op; skip it and warn (once)."""
+        gen, fake = _make_generator('darwin', cc_vendor='clang', gprof=True)
+        with mock.patch.object(cc_rule_support.console, 'warning') as warn:
+            cppflags, linkflags = _flags(gen, fake)
+            # A second target's flag computation must not re-warn.
+            gen2, fake2 = _make_generator('darwin', cc_vendor='clang', gprof=True)
+            _flags(gen2, fake2)
+        self.assertNotIn('-pg', cppflags)
+        self.assertNotIn('-pg', linkflags)
+        warn.assert_called_once()
+        self.assertIn('gprof', warn.call_args[0][0])
+        self.assertIn('darwin', warn.call_args[0][0])
+
+    def test_msvc_skips_pg_and_warns(self):
+        """MSVC does not understand `-pg`; skip it and warn."""
+        gen, fake = _make_generator('windows', cc_vendor='msvc', gprof=True)
+        with mock.patch.object(cc_rule_support.console, 'warning') as warn:
+            cppflags, linkflags = _flags(gen, fake)
+        self.assertNotIn('-pg', cppflags)
+        self.assertNotIn('-pg', linkflags)
+        warn.assert_called_once()
+
+    def test_gprof_off_is_silent_everywhere(self):
+        """No gprof => no flag and no warning regardless of platform."""
+        gen, fake = _make_generator('darwin', cc_vendor='clang', gprof=False)
+        with mock.patch.object(cc_rule_support.console, 'warning') as warn:
+            cppflags, linkflags = _flags(gen, fake)
+        self.assertNotIn('-pg', cppflags)
+        self.assertNotIn('-pg', linkflags)
+        warn.assert_not_called()
+
+
+class CcCoverageGatingTest(unittest.TestCase):
+    """`--coverage` rides gcc/clang; skipped + warned once on MSVC."""
+
+    def setUp(self):
+        cc_rule_support._coverage_unsupported_warned = False
+
+    def test_gcc_adds_coverage_to_compile_and_link(self):
+        """gcc gets the driver flag on both sides, no warning."""
+        gen, fake = _make_generator('linux', cc_vendor='gcc', coverage=True)
+        with mock.patch.object(cc_rule_support.console, 'warning') as warn:
+            cppflags, linkflags = _flags(gen, fake)
+        self.assertIn('--coverage', cppflags)
+        self.assertIn('--coverage', linkflags)
+        warn.assert_not_called()
+
+    def test_clang_cl_keeps_coverage_path(self):
+        """clang-cl reports as 'clang', so it keeps the gcc-style flag (no
+        MSVC gate) -- it is the recommended Windows coverage path."""
+        gen, fake = _make_generator('windows', cc_vendor='clang', coverage=True)
+        with mock.patch.object(cc_rule_support.console, 'warning') as warn:
+            cppflags, linkflags = _flags(gen, fake)
+        self.assertIn('--coverage', cppflags)
+        self.assertIn('--coverage', linkflags)
+        warn.assert_not_called()
+
+    def test_msvc_skips_coverage_and_warns_once(self):
+        """Native MSVC cl.exe has no gcov; skip the flag and warn (once)."""
+        gen, fake = _make_generator('windows', cc_vendor='msvc', coverage=True)
+        with mock.patch.object(cc_rule_support.console, 'warning') as warn:
+            cppflags, linkflags = _flags(gen, fake)
+            gen2, fake2 = _make_generator('windows', cc_vendor='msvc', coverage=True)
+            _flags(gen2, fake2)
+        self.assertNotIn('--coverage', cppflags)
+        self.assertNotIn('--coverage', linkflags)
+        warn.assert_called_once()
+        self.assertIn('coverage', warn.call_args[0][0])
+        self.assertIn('MSVC', warn.call_args[0][0])
+
+    def test_coverage_off_is_silent_on_msvc(self):
+        """No coverage => no flag and no warning on MSVC."""
+        gen, fake = _make_generator('windows', cc_vendor='msvc', coverage=False)
+        with mock.patch.object(cc_rule_support.console, 'warning') as warn:
+            cppflags, linkflags = _flags(gen, fake)
+        self.assertNotIn('--coverage', cppflags)
+        self.assertNotIn('--coverage', linkflags)
+        warn.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

`--gprof` and `--coverage` both unconditionally append their gcc/clang driver flags in `_get_intrinsic_cc_flags`. On toolchains that don't implement the instrumentation, the flag is either a no-op that spams the compiler log, or it's handed to a compiler that can't parse it.

- **`--gprof`** on macOS: Darwin clang accepts `-pg` but ignores it → `warning: argument unused during compilation: '-pg'` on *every* file, and there's no gprof tool / `gmon.out` on macOS. On MSVC `-pg` isn't understood at all.
- **`--coverage`** on native MSVC: `--coverage` is a gcc/clang driver flag; `cl.exe` has no gcov-style instrumentation, so the flag is invalid there.

## Fix

Two gates, deliberately on **different axes** because the flags fail for different reasons:

| Flag | Works on | Gate axis | Off-target behavior |
|---|---|---|---|
| `--gprof` (`-pg`) | **Linux only** (gcc *and* clang) | platform (`target_os == 'linux'`) | skip `-pg`, warn once → use `--coverage` / Instruments / perf |
| `--coverage` | **gcc/clang** (all platforms, incl. clang-cl) | vendor (`cc_is('msvc')`) | skip on native MSVC, warn once → use clang-cl or OpenCppCoverage |

Key subtlety: gprof is gated on the **platform, not the vendor** — clang on Linux supports `-pg` just like gcc, so gating on `cc_is('gcc')` would wrongly exclude it. Coverage is the opposite: only native `cl.exe` lacks gcov, so gcc/clang/clang-cl on every platform keep the path.

Both warnings fire **once per build** (module-level guard), not once per target, so a many-target build isn't spammed.

`--gprof` help text now reads "(Linux only; ignored on macOS/Windows)".

## Tests

New `cc_instrumentation_gating_test.py` (9 cases) covering both flags across gcc / clang / clang-cl / MSVC / darwin, including:
- `test_linux_clang_also_adds_pg` — pins the platform axis (clang-on-Linux must keep `-pg`).
- once-per-build assertions for both warnings.

Full unit suite green (747 passed, 3 skipped).

## Verification

On real flare (macOS): `blade build flare/base/... --gprof` → exactly **1** blade warning, **0** clang `-Wunused-command-line-argument: '-pg'` lines, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)