### PR TITLE
feat(cc): unified PGO across gcc/clang/MSVC as a global build mode (#1366)

### DIFF
--- a/doc/en/command_line.md
+++ b/doc/en/command_line.md
@@ -129,11 +129,11 @@ Different subcommands support different options. Run `blade <subcommand> --help`
 - `--generate-go` - Generate Go files for proto_library
 - `--gprof` - Enable GNU gprof profiling support. **Linux only** (gcc and clang): `-pg`/gprof instrumentation only works on Linux. On macOS the flag is silently ignored (Darwin clang accepts `-pg` but treats it as a no-op, and there is no gprof tool / `gmon.out`); on Windows MSVC does not understand it. Blade skips the flag and warns once on these platforms — use `--coverage`, or a native sampling profiler (Instruments/`sample` on macOS, `perf` on Linux).
 - `--coverage` - Generate code coverage reports (supports GNU gcov and Java jacoco). For C/C++ this is the gcc/clang `--coverage` instrumentation and works on **gcc and clang on every platform, including clang-cl on Windows**. Native MSVC `cl.exe` has no gcov-style instrumentation, so blade skips the flag and warns once there — on Windows use **clang-cl** (LLVM source coverage) or **OpenCppCoverage** (PDB-based, no rebuild).
-- `--profile-generate[=path]` / `--profile-use[=path]` - [Profile-Guided Optimization](#profile-guided-optimization-pgo) (gcc/clang). Phase 1 instruments, phase 2 rebuilds with the collected profile. Native MSVC is not yet wired (`/LTCG:PG*` is a separate mechanism) and is skipped with a warning — use clang-cl.
+- `--profile-generate[=path]` / `--profile-use[=path]` - [Profile-Guided Optimization](#profile-guided-optimization-pgo) (gcc, clang, and native MSVC). Phase 1 instruments, phase 2 rebuilds with the collected profile.
 
 ## Profile-Guided Optimization (PGO)
 
-PGO is a **global build mode** (not a per-target attribute): you instrument the whole build, run a representative workload, then rebuild using the collected profile. It is wired for **gcc and clang**; both phases use a dedicated `build_*_pgo` directory so they never clobber your normal `build_*` objects.
+PGO is a **global build mode** (not a per-target attribute): you instrument the whole build, run a representative workload, then rebuild using the collected profile. It is wired for **gcc, clang, and native MSVC**; both phases use a dedicated `build_*_pgo` directory so they never clobber your normal `build_*` objects.
 
 ```bash
 # Phase 1 — instrument, then run a representative workload to collect data
@@ -148,7 +148,7 @@ Toolchain differences blade handles for you:
 
 - **gcc** reads the `.gcda` files directly and adds `-fprofile-correction` (tolerates the count skew of multithreaded programs). Both phases **must** share the build dir — gcc keys its `.gcda` lookup by object path — which the dedicated `build_*_pgo` dir guarantees.
 - **clang** needs a *merged* `.profdata`: its instrumented run emits `.profraw`, and `-fprofile-use=` must point at a merged file, not a directory. Point `--profile-use` at the directory of `.profraw` (or an already-merged `.profdata`) and **blade runs `llvm-profdata merge` for you**. clang's `-fprofile-correction` does not exist, so it is not emitted.
-- **MSVC** uses a different mechanism (`/GL` + `/LTCG:PGINSTRUMENT`/`PGOPTIMIZE`) that is not yet wired; `--profile-*` is skipped with a one-time warning. Use **clang-cl** for PGO on Windows.
+- **MSVC** uses whole-program (LTCG) instrumentation: blade compiles with `/GL`, links the instrument phase with `/LTCG /GENPROFILE` and the optimize phase with `/LTCG /USEPROFILE` (and archives with `lib /LTCG`). The instrumented run writes `<binary>!N.pgc` next to the `<binary>.pgd`, and `/USEPROFILE` **auto-merges** them on the optimize link — no `pgomgr` step. The `.pgd` is keyed to the output name, so the shared `build_*_pgo` dir is what lets the optimize phase find the instrument phase's profile. The `path` argument is gcc/clang-specific and is not needed on MSVC (the profile lives next to the binary).
 
 Blade owns the build flags and the clang merge step; producing a *representative* workload (and deciding when a profile is stale) is your job. Profiles are **not** portable across compilers — instrument, run, and optimize all on one toolchain.
 

--- a/doc/en/command_line.md
+++ b/doc/en/command_line.md
@@ -129,6 +129,28 @@ Different subcommands support different options. Run `blade <subcommand> --help`
 - `--generate-go` - Generate Go files for proto_library
 - `--gprof` - Enable GNU gprof profiling support. **Linux only** (gcc and clang): `-pg`/gprof instrumentation only works on Linux. On macOS the flag is silently ignored (Darwin clang accepts `-pg` but treats it as a no-op, and there is no gprof tool / `gmon.out`); on Windows MSVC does not understand it. Blade skips the flag and warns once on these platforms — use `--coverage`, or a native sampling profiler (Instruments/`sample` on macOS, `perf` on Linux).
 - `--coverage` - Generate code coverage reports (supports GNU gcov and Java jacoco). For C/C++ this is the gcc/clang `--coverage` instrumentation and works on **gcc and clang on every platform, including clang-cl on Windows**. Native MSVC `cl.exe` has no gcov-style instrumentation, so blade skips the flag and warns once there — on Windows use **clang-cl** (LLVM source coverage) or **OpenCppCoverage** (PDB-based, no rebuild).
+- `--profile-generate[=path]` / `--profile-use[=path]` - [Profile-Guided Optimization](#profile-guided-optimization-pgo) (gcc/clang). Phase 1 instruments, phase 2 rebuilds with the collected profile. Native MSVC is not yet wired (`/LTCG:PG*` is a separate mechanism) and is skipped with a warning — use clang-cl.
+
+## Profile-Guided Optimization (PGO)
+
+PGO is a **global build mode** (not a per-target attribute): you instrument the whole build, run a representative workload, then rebuild using the collected profile. It is wired for **gcc and clang**; both phases use a dedicated `build_*_pgo` directory so they never clobber your normal `build_*` objects.
+
+```bash
+# Phase 1 — instrument, then run a representative workload to collect data
+blade build //foo:server --profile-generate=/tmp/pgo
+./build_release_pgo/foo/server   # exercise the hot paths
+
+# Phase 2 — rebuild optimized, using the profile
+blade build //foo:server --profile-use=/tmp/pgo
+```
+
+Toolchain differences blade handles for you:
+
+- **gcc** reads the `.gcda` files directly and adds `-fprofile-correction` (tolerates the count skew of multithreaded programs). Both phases **must** share the build dir — gcc keys its `.gcda` lookup by object path — which the dedicated `build_*_pgo` dir guarantees.
+- **clang** needs a *merged* `.profdata`: its instrumented run emits `.profraw`, and `-fprofile-use=` must point at a merged file, not a directory. Point `--profile-use` at the directory of `.profraw` (or an already-merged `.profdata`) and **blade runs `llvm-profdata merge` for you**. clang's `-fprofile-correction` does not exist, so it is not emitted.
+- **MSVC** uses a different mechanism (`/GL` + `/LTCG:PGINSTRUMENT`/`PGOPTIMIZE`) that is not yet wired; `--profile-*` is skipped with a one-time warning. Use **clang-cl** for PGO on Windows.
+
+Blade owns the build flags and the clang merge step; producing a *representative* workload (and deciding when a profile is stale) is your job. Profiles are **not** portable across compilers — instrument, run, and optimize all on one toolchain.
 
 ## Usage Examples
 

--- a/doc/en/command_line.md
+++ b/doc/en/command_line.md
@@ -133,6 +133,8 @@ Different subcommands support different options. Run `blade <subcommand> --help`
 
 ## Profile-Guided Optimization (PGO)
 
+Profile-Guided Optimization (PGO), also known as Feedback-Directed Optimization (FDO), is a technique that uses profile data collected from a program's real execution to guide the compiler's optimizations.
+
 PGO is a **global build mode** (not a per-target attribute): you instrument the whole build, run a representative workload, then rebuild using the collected profile. It is wired for **gcc, clang, and native MSVC**; both phases use a dedicated `build_*_pgo` directory so they never clobber your normal `build_*` objects.
 
 ```bash

--- a/doc/zh_CN/command_line.md
+++ b/doc/zh_CN/command_line.md
@@ -133,6 +133,8 @@ $ blade dump --all-tags ...
 
 ## 按性能剖析引导优化（PGO）
 
+PGO(Profile-guided optimization)又称 FDO(feedback-directed optimization) 是指利用程序真实运行过程中采集到的 profile 数据，来指导编译器优化的技术。
+
 PGO 是一个**全局构建模式**（不是 per-target 属性）：先对整个构建插桩，跑一遍代表性负载，再用采集到的 profile 重新构建。目前接入了 **gcc、clang 与原生 MSVC**；两个阶段都使用独立的 `build_*_pgo` 目录，绝不污染普通的 `build_*` 对象。
 
 ```bash

--- a/doc/zh_CN/command_line.md
+++ b/doc/zh_CN/command_line.md
@@ -129,11 +129,11 @@ $ blade dump --all-tags ...
 - `--generate-go` —— 为 `proto_library` 生成 Go 文件
 - `--gprof` —— 启用 GNU gprof 性能分析。**仅限 Linux**（gcc 与 clang）：`-pg`/gprof 插桩只在 Linux 上有效。macOS 上该标志被静默忽略（Darwin clang 接受 `-pg` 但当作空操作，且没有 gprof 工具 / `gmon.out`），Windows 上 MSVC 根本不认。在这些平台 blade 会跳过该标志并仅警告一次——请改用 `--coverage`，或原生采样分析器（macOS 用 Instruments/`sample`，Linux 用 `perf`）。
 - `--coverage` —— 生成代码覆盖率报告（支持 GNU gcov 与 Java jacoco）。C/C++ 走的是 gcc/clang 的 `--coverage` 插桩，**在所有平台的 gcc 与 clang 上均可用，含 Windows 上的 clang-cl**。原生 MSVC `cl.exe` 没有 gcov 风格插桩，因此 blade 在该工具链下跳过该标志并仅警告一次——Windows 上请使用 **clang-cl**（LLVM 源码级覆盖率）或 **OpenCppCoverage**（基于 PDB，无需重新编译）。
-- `--profile-generate[=path]` / `--profile-use[=path]` —— [按性能剖析引导优化（PGO）](#按性能剖析引导优化pgo)（gcc/clang）。第一阶段插桩，第二阶段用采集到的 profile 重新构建。原生 MSVC 尚未接入（`/LTCG:PG*` 是另一套机制），会被跳过并警告——请用 clang-cl。
+- `--profile-generate[=path]` / `--profile-use[=path]` —— [按性能剖析引导优化（PGO）](#按性能剖析引导优化pgo)（gcc、clang 与原生 MSVC）。第一阶段插桩，第二阶段用采集到的 profile 重新构建。
 
 ## 按性能剖析引导优化（PGO）
 
-PGO 是一个**全局构建模式**（不是 per-target 属性）：先对整个构建插桩，跑一遍代表性负载，再用采集到的 profile 重新构建。目前接入了 **gcc 与 clang**；两个阶段都使用独立的 `build_*_pgo` 目录，绝不污染普通的 `build_*` 对象。
+PGO 是一个**全局构建模式**（不是 per-target 属性）：先对整个构建插桩，跑一遍代表性负载，再用采集到的 profile 重新构建。目前接入了 **gcc、clang 与原生 MSVC**；两个阶段都使用独立的 `build_*_pgo` 目录，绝不污染普通的 `build_*` 对象。
 
 ```bash
 # 第一阶段——插桩，然后跑代表性负载采集数据
@@ -148,7 +148,7 @@ blade 替你处理的工具链差异：
 
 - **gcc** 直接读 `.gcda` 文件，并加 `-fprofile-correction`（容忍多线程程序的计数偏差）。两阶段**必须**共用构建目录——gcc 按对象文件路径定位 `.gcda`——独立的 `build_*_pgo` 目录正好保证了这一点。
 - **clang** 需要一个**已合并的** `.profdata`：插桩运行产出 `.profraw`，而 `-fprofile-use=` 必须指向合并后的文件而非目录。把 `--profile-use` 指向 `.profraw` 所在目录（或已合并的 `.profdata`），**blade 会替你执行 `llvm-profdata merge`**。clang 没有 `-fprofile-correction`，因此不会发出该标志。
-- **MSVC** 用的是另一套机制（`/GL` + `/LTCG:PGINSTRUMENT`/`PGOPTIMIZE`），尚未接入；`--profile-*` 会被跳过并仅警告一次。Windows 上的 PGO 请用 **clang-cl**。
+- **MSVC** 用的是全程序（LTCG）插桩：blade 用 `/GL` 编译，插桩阶段链接 `/LTCG /GENPROFILE`、优化阶段链接 `/LTCG /USEPROFILE`（静态库用 `lib /LTCG` 归档）。插桩后的程序运行时把 `<binary>!N.pgc` 写在 `<binary>.pgd` 旁边，优化链接时 `/USEPROFILE` 会**自动合并**它们——无需 `pgomgr`。`.pgd` 以输出名为键，因此共用 `build_*_pgo` 目录正是优化阶段能找到插桩阶段 profile 的关键。`path` 参数是 gcc/clang 专用的，MSVC 上无需指定（profile 就在二进制旁边）。
 
 blade 负责构建标志和 clang 的合并步骤；而产出**代表性**负载（以及判断 profile 是否过期）是你的职责。profile **不能**跨编译器复用——插桩、运行、优化都要在同一套工具链上完成。
 

--- a/doc/zh_CN/command_line.md
+++ b/doc/zh_CN/command_line.md
@@ -129,6 +129,28 @@ $ blade dump --all-tags ...
 - `--generate-go` —— 为 `proto_library` 生成 Go 文件
 - `--gprof` —— 启用 GNU gprof 性能分析。**仅限 Linux**（gcc 与 clang）：`-pg`/gprof 插桩只在 Linux 上有效。macOS 上该标志被静默忽略（Darwin clang 接受 `-pg` 但当作空操作，且没有 gprof 工具 / `gmon.out`），Windows 上 MSVC 根本不认。在这些平台 blade 会跳过该标志并仅警告一次——请改用 `--coverage`，或原生采样分析器（macOS 用 Instruments/`sample`，Linux 用 `perf`）。
 - `--coverage` —— 生成代码覆盖率报告（支持 GNU gcov 与 Java jacoco）。C/C++ 走的是 gcc/clang 的 `--coverage` 插桩，**在所有平台的 gcc 与 clang 上均可用，含 Windows 上的 clang-cl**。原生 MSVC `cl.exe` 没有 gcov 风格插桩，因此 blade 在该工具链下跳过该标志并仅警告一次——Windows 上请使用 **clang-cl**（LLVM 源码级覆盖率）或 **OpenCppCoverage**（基于 PDB，无需重新编译）。
+- `--profile-generate[=path]` / `--profile-use[=path]` —— [按性能剖析引导优化（PGO）](#按性能剖析引导优化pgo)（gcc/clang）。第一阶段插桩，第二阶段用采集到的 profile 重新构建。原生 MSVC 尚未接入（`/LTCG:PG*` 是另一套机制），会被跳过并警告——请用 clang-cl。
+
+## 按性能剖析引导优化（PGO）
+
+PGO 是一个**全局构建模式**（不是 per-target 属性）：先对整个构建插桩，跑一遍代表性负载，再用采集到的 profile 重新构建。目前接入了 **gcc 与 clang**；两个阶段都使用独立的 `build_*_pgo` 目录，绝不污染普通的 `build_*` 对象。
+
+```bash
+# 第一阶段——插桩，然后跑代表性负载采集数据
+blade build //foo:server --profile-generate=/tmp/pgo
+./build_release_pgo/foo/server   # 充分跑热点路径
+
+# 第二阶段——用 profile 做优化重建
+blade build //foo:server --profile-use=/tmp/pgo
+```
+
+blade 替你处理的工具链差异：
+
+- **gcc** 直接读 `.gcda` 文件，并加 `-fprofile-correction`（容忍多线程程序的计数偏差）。两阶段**必须**共用构建目录——gcc 按对象文件路径定位 `.gcda`——独立的 `build_*_pgo` 目录正好保证了这一点。
+- **clang** 需要一个**已合并的** `.profdata`：插桩运行产出 `.profraw`，而 `-fprofile-use=` 必须指向合并后的文件而非目录。把 `--profile-use` 指向 `.profraw` 所在目录（或已合并的 `.profdata`），**blade 会替你执行 `llvm-profdata merge`**。clang 没有 `-fprofile-correction`，因此不会发出该标志。
+- **MSVC** 用的是另一套机制（`/GL` + `/LTCG:PGINSTRUMENT`/`PGOPTIMIZE`），尚未接入；`--profile-*` 会被跳过并仅警告一次。Windows 上的 PGO 请用 **clang-cl**。
+
+blade 负责构建标志和 clang 的合并步骤；而产出**代表性**负载（以及判断 profile 是否过期）是你的职责。profile **不能**跨编译器复用——插桩、运行、优化都要在同一套工具链上完成。
 
 ## 使用示例
 

--- a/src/blade/cc_rule_support.py
+++ b/src/blade/cc_rule_support.py
@@ -261,6 +261,111 @@ def _warn_coverage_unsupported():
         'coverage, or OpenCppCoverage (PDB-based, no rebuild).')
 
 
+# --- PGO (profile-guided optimization) ---------------------------------------
+#
+# PGO is invocation-driven (a global build mode), per the design in #1366:
+# `--profile-generate` instruments, the user runs a representative workload,
+# then `--profile-use` rebuilds with the collected profile. gcc and clang share
+# the `-fprofile-*` spelling but diverge in the use phase:
+#   * gcc reads the `.gcda` files directly and wants `-fprofile-correction`
+#     to tolerate the count skew a multithreaded program produces.
+#   * clang REJECTS `-fprofile-correction`; its instrumented run emits
+#     `.profraw`, which must be `llvm-profdata merge`'d into a `.profdata` that
+#     `-fprofile-use=` then points at (a file, not a directory).
+# Native MSVC is a different flag family (/LTCG:PG*) and is gated here until the
+# Windows backend lands.
+
+_pgo_msvc_warned = False
+
+
+def _warn_pgo_msvc_unsupported(phase):
+    global _pgo_msvc_warned
+    if _pgo_msvc_warned:
+        return
+    _pgo_msvc_warned = True
+    console.warning(
+        'PGO (%s) is not yet wired for native MSVC -- cl.exe uses /LTCG:PG*, a '
+        'different mechanism; the flag is ignored. Use clang-cl, or build PGO '
+        'on a gcc/clang toolchain.' % phase)
+
+
+def _pgo_option(options, name):
+    """Value of a PGO option ('' = enabled with no path), or None if absent."""
+    return getattr(options, name, None) if hasattr(options, name) else None
+
+
+def _find_llvm_profdata(toolchain):
+    """Locate ``llvm-profdata`` for a clang toolchain: next to the compiler,
+    then PATH, then ``xcrun`` on macOS. Returns a command list or ``None``."""
+    import shutil
+    cc = getattr(toolchain, 'cc', '') or ''
+    bindir = os.path.dirname(cc)
+    if bindir:
+        cand = os.path.join(bindir, 'llvm-profdata')
+        if os.path.isfile(cand):
+            return [cand]
+    found = shutil.which('llvm-profdata')
+    if found:
+        return [found]
+    if toolchain.target_os == 'darwin' and shutil.which('xcrun'):
+        rc, out, _ = util.run_command(['xcrun', '--find', 'llvm-profdata'])
+        if rc == 0 and out.strip():
+            return [out.strip()]
+    return None
+
+
+# Merge runs at most once per build (the flag computation is invoked several
+# times); cache the resolved profdata path keyed by the source path.
+_clang_profdata_cache = {}
+
+
+def _resolve_clang_profdata(toolchain, path):
+    """Return a ``.profdata`` path for clang ``-fprofile-use=``.
+
+    - empty -> ``None`` (bare ``-fprofile-use``; clang reads ``default.profdata``)
+    - a ``.profdata`` file -> used as-is
+    - a directory (or raw ``.profraw``) -> merged once via ``llvm-profdata
+      merge`` into ``<dir>/blade-merged.profdata``.
+    On any failure, warn once and fall back to the original path so the build
+    surfaces a clear error rather than silently dropping PGO.
+    """
+    if not path:
+        return None
+    if os.path.isfile(path) and path.endswith('.profdata'):
+        return path
+    if path in _clang_profdata_cache:
+        return _clang_profdata_cache[path]
+
+    import glob
+    if os.path.isdir(path):
+        raws = glob.glob(os.path.join(path, '**', '*.profraw'), recursive=True)
+        out_dir = path
+    else:  # a glob/raw path
+        raws = glob.glob(path)
+        out_dir = os.path.dirname(path) or '.'
+    profdata = os.path.join(out_dir, 'blade-merged.profdata')
+
+    tool = _find_llvm_profdata(toolchain)
+    if not tool or not raws:
+        console.warning(
+            'PGO profile-use: clang needs a merged .profdata but could not '
+            'produce one from "%s" (llvm-profdata %s, %d .profraw found). Pass '
+            'an already-merged .profdata to --profile-use, or run: '
+            'llvm-profdata merge -o out.profdata %s/*.profraw' % (
+                path, 'not found' if not tool else 'found', len(raws), path))
+        _clang_profdata_cache[path] = path
+        return path
+
+    rc, _, err = util.run_command(tool + ['merge', '-output=' + profdata] + raws)
+    if rc != 0:
+        console.warning('PGO profile-use: llvm-profdata merge failed: %s' % err)
+        _clang_profdata_cache[path] = path
+        return path
+    console.info('PGO: merged %d .profraw into %s' % (len(raws), profdata))
+    _clang_profdata_cache[path] = profdata
+    return profdata
+
+
 class CcRuleGenerator:
     """Generate cc/cuda ninja rules from a RuleContext (see module docstring)."""
 
@@ -399,25 +504,41 @@ class CcRuleGenerator:
             # Only the link flags (which pull in the runtime) stay global.
             linkflags += sanitizer.link_flags(sanitizers)
 
-        if hasattr(self.options, 'profile-generate') and getattr(self.options, 'profile-generate') is not None:
-            pgo_gen_dir = getattr(self.options, 'profile-generate')
-            if not pgo_gen_dir:
-                cppflags.append('-fprofile-generate')
-                linkflags.append('-fprofile-generate')
+        # PGO -- see the module-level "PGO" note for the gcc/clang/MSVC split.
+        pgo_gen = _pgo_option(self.options, 'profile-generate')
+        if pgo_gen is not None:
+            if self.build_toolchain.cc_is('msvc'):
+                _warn_pgo_msvc_unsupported('profile-generate')
             else:
-                cppflags.append('-fprofile-generate=' + pgo_gen_dir)
-                linkflags.append('-fprofile-generate=' + pgo_gen_dir)
-            cppflags.append('-DPROFILE_GUIDED_OPTIMIZATION')
+                # gcc and clang share this spelling. The runtime (libgcov /
+                # clang's profile runtime) is pulled in at link, so the flag
+                # rides both cppflags and linkflags.
+                flag = '-fprofile-generate' + ('=' + pgo_gen if pgo_gen else '')
+                cppflags.append(flag)
+                linkflags.append(flag)
+                cppflags.append('-DPROFILE_GUIDED_OPTIMIZATION')
 
-        if hasattr(self.options, 'profile-use') and getattr(self.options, 'profile-use') is not None:
-            pgo_use_dir = getattr(self.options, 'profile-use')
-            if not pgo_use_dir:
-                cppflags.append('-fprofile-use')
-            else:
-                cppflags.append('-fprofile-use=' + pgo_use_dir)
-            cppflags.append('-fprofile-correction')
-            cppflags.append('-Wno-error=coverage-mismatch')
-            cppflags.append('-DPROFILE_GUIDED_OPTIMIZATION')
+        pgo_use = _pgo_option(self.options, 'profile-use')
+        if pgo_use is not None:
+            if self.build_toolchain.cc_is('msvc'):
+                _warn_pgo_msvc_unsupported('profile-use')
+            elif self.build_toolchain.cc_is('clang'):
+                # clang rejects -fprofile-correction and needs a *merged*
+                # .profdata file (blade merges the .profraw for you).
+                profdata = _resolve_clang_profdata(self.build_toolchain, pgo_use)
+                cppflags.append('-fprofile-use=' + profdata if profdata
+                                else '-fprofile-use')
+                # Tolerate stale/partial profiles as warnings, not errors --
+                # the clang analogues of gcc's -Wno-error=coverage-mismatch.
+                cppflags.append('-Wno-error=profile-instr-out-of-date')
+                cppflags.append('-Wno-error=profile-instr-unprofiled')
+                cppflags.append('-DPROFILE_GUIDED_OPTIMIZATION')
+            else:  # gcc
+                cppflags.append('-fprofile-use=' + pgo_use if pgo_use
+                                else '-fprofile-use')
+                cppflags.append('-fprofile-correction')
+                cppflags.append('-Wno-error=coverage-mismatch')
+                cppflags.append('-DPROFILE_GUIDED_OPTIMIZATION')
 
         # Recover -fPIE-level optimization under -fPIC: tell the compiler the
         # current TU's symbol definitions aren't interposable, so it can

--- a/src/blade/cc_rule_support.py
+++ b/src/blade/cc_rule_support.py
@@ -272,21 +272,9 @@ def _warn_coverage_unsupported():
 #   * clang REJECTS `-fprofile-correction`; its instrumented run emits
 #     `.profraw`, which must be `llvm-profdata merge`'d into a `.profdata` that
 #     `-fprofile-use=` then points at (a file, not a directory).
-# Native MSVC is a different flag family (/LTCG:PG*) and is gated here until the
-# Windows backend lands.
-
-_pgo_msvc_warned = False
-
-
-def _warn_pgo_msvc_unsupported(phase):
-    global _pgo_msvc_warned
-    if _pgo_msvc_warned:
-        return
-    _pgo_msvc_warned = True
-    console.warning(
-        'PGO (%s) is not yet wired for native MSVC -- cl.exe uses /LTCG:PG*, a '
-        'different mechanism; the flag is ignored. Use clang-cl, or build PGO '
-        'on a gcc/clang toolchain.' % phase)
+# Native MSVC is a different flag family (/GL + /LTCG:PG*) and is implemented in
+# the Windows compile/lib/link rules below (see the `_pgo_msvc_*` helpers); the
+# gcc/clang `-fprofile-*` path here never runs for MSVC.
 
 
 def _pgo_option(options, name):
@@ -364,6 +352,46 @@ def _resolve_clang_profdata(toolchain, path):
     console.info('PGO: merged %d .profraw into %s' % (len(raws), profdata))
     _clang_profdata_cache[path] = profdata
     return profdata
+
+
+# --- MSVC PGO (#1366 Phase 2) ------------------------------------------------
+#
+# MSVC PGO is a different flag family from gcc/clang's `-fprofile-*`: it is
+# whole-program (LTCG) instrumentation. Verified end to end on VS:
+#   instrument: compile `/GL`, link `/LTCG /GENPROFILE` -> binary + `<name>.pgd`
+#   run:        the binary writes `<name>!N.pgc` next to the `.pgd`
+#   optimize:   link `/LTCG /USEPROFILE` -- auto-merges the `.pgc` into the
+#               `.pgd` and rebuilds optimized (no separate `pgomgr` step)
+# The `.pgd` is keyed to the output name, so the instrument and optimize builds
+# share one `build_*_pgo` dir (the same dir gcc needs for `.gcda` lookup).
+
+def _pgo_msvc_active(options):
+    return (_pgo_option(options, 'profile-generate') is not None
+            or _pgo_option(options, 'profile-use') is not None)
+
+
+def _pgo_msvc_compile_flags(options):
+    """MSVC compile flags for an active PGO mode: `/GL` (whole-program info LTCG
+    PGO needs; same flag for the instrument and the optimize build) plus the
+    PROFILE_GUIDED_OPTIMIZATION define, for parity with the gcc/clang path."""
+    if _pgo_msvc_active(options):
+        return ['/GL', '/DPROFILE_GUIDED_OPTIMIZATION']
+    return []
+
+
+def _pgo_msvc_lib_flags(options):
+    """`lib.exe` needs `/LTCG` to archive the `/GL` objects a PGO build emits."""
+    return ['/LTCG'] if _pgo_msvc_active(options) else []
+
+
+def _pgo_msvc_link_flags(options):
+    """MSVC PGO link flags: `/LTCG /GENPROFILE` to instrument, `/LTCG /USEPROFILE`
+    to optimize (the latter auto-merges the run's `.pgc` into the `.pgd`)."""
+    if _pgo_option(options, 'profile-generate') is not None:
+        return ['/LTCG', '/GENPROFILE']
+    if _pgo_option(options, 'profile-use') is not None:
+        return ['/LTCG', '/USEPROFILE']
+    return []
 
 
 class CcRuleGenerator:
@@ -504,25 +532,21 @@ class CcRuleGenerator:
             # Only the link flags (which pull in the runtime) stay global.
             linkflags += sanitizer.link_flags(sanitizers)
 
-        # PGO -- see the module-level "PGO" note for the gcc/clang/MSVC split.
+        # PGO -- see the module-level "PGO" note. This is the gcc/clang path
+        # (MSVC uses /GL + /LTCG:PG* in the Windows rules and never gets here).
         pgo_gen = _pgo_option(self.options, 'profile-generate')
         if pgo_gen is not None:
-            if self.build_toolchain.cc_is('msvc'):
-                _warn_pgo_msvc_unsupported('profile-generate')
-            else:
-                # gcc and clang share this spelling. The runtime (libgcov /
-                # clang's profile runtime) is pulled in at link, so the flag
-                # rides both cppflags and linkflags.
-                flag = '-fprofile-generate' + ('=' + pgo_gen if pgo_gen else '')
-                cppflags.append(flag)
-                linkflags.append(flag)
-                cppflags.append('-DPROFILE_GUIDED_OPTIMIZATION')
+            # gcc and clang share this spelling. The runtime (libgcov /
+            # clang's profile runtime) is pulled in at link, so the flag
+            # rides both cppflags and linkflags.
+            flag = '-fprofile-generate' + ('=' + pgo_gen if pgo_gen else '')
+            cppflags.append(flag)
+            linkflags.append(flag)
+            cppflags.append('-DPROFILE_GUIDED_OPTIMIZATION')
 
         pgo_use = _pgo_option(self.options, 'profile-use')
         if pgo_use is not None:
-            if self.build_toolchain.cc_is('msvc'):
-                _warn_pgo_msvc_unsupported('profile-use')
-            elif self.build_toolchain.cc_is('clang'):
+            if self.build_toolchain.cc_is('clang'):
                 # clang rejects -fprofile-correction and needs a *merged*
                 # .profdata file (blade merges the .profraw for you).
                 profdata = _resolve_clang_profdata(self.build_toolchain, pgo_use)
@@ -683,6 +707,10 @@ class CcRuleGenerator:
         global_config = config.get_section('global_config')
         cppflags = cppflags + windows_config['debug_info_levels'][global_config['debug_info_level']]
 
+        # PGO (#1366): `/GL` on every compile when a profile mode is active, so
+        # the link can do LTCG instrumentation / optimization.
+        cppflags = cppflags + _pgo_msvc_compile_flags(self.options)
+
         # The Python stderr-tee wrapper captures /showIncludes output and tees
         # it to both stderr (for Ninja's deps=msvc) and the inclusion stack
         # file (for inclusion checking).
@@ -749,8 +777,11 @@ class CcRuleGenerator:
                             'does not support thin archives)')
         ar = self.build_accelerator.get_ar_command()
         brepro = ' /Brepro' if deterministic else ''
+        # PGO (#1366): lib.exe needs /LTCG to archive the /GL objects a PGO
+        # build emits.
+        pgo = ''.join(' ' + f for f in _pgo_msvc_lib_flags(self.options))
         self.generate_rule(name='ar',
-                           command=f'{ar} /nologo{brepro} /out:${{out}} ${{in}}',
+                           command=f'{ar} /nologo{brepro}{pgo} /out:${{out}} ${{in}}',
                            description='LIB ${out}')
 
     def _generate_windows_link_rules(self):
@@ -778,6 +809,16 @@ class CcRuleGenerator:
         sanitizers = getattr(self.options, 'sanitizers', None)
         if sanitizers:
             for flag in sanitizer.msvc_link_flags(sanitizers):
+                if flag not in linkflags:
+                    linkflags = linkflags + [flag]
+
+        # PGO (#1366): LTCG instrument (/GENPROFILE) or optimize (/USEPROFILE).
+        # LTCG is incompatible with incremental linking, so force it off (a
+        # release build already did). The .pgd is auto-named from /out, so each
+        # binary gets its own profile in the shared build_*_pgo dir.
+        pgo_link = _pgo_msvc_link_flags(self.options)
+        if pgo_link:
+            for flag in pgo_link + ['/INCREMENTAL:NO']:
                 if flag not in linkflags:
                     linkflags = linkflags + [flag]
 

--- a/src/blade/command_line.py
+++ b/src/blade/command_line.py
@@ -313,12 +313,18 @@ class CommandLineParser:
         parser.add_argument(
             '--profile-generate', dest='profile-generate', metavar='path',
             action='store', type=str, nargs='?', const='',
-            help='Add build options to support profile-generate')
+            help='PGO phase 1: instrument the build to collect a profile '
+                 '(gcc/clang; optional path is where profile data is written). '
+                 'Uses a dedicated build_*_pgo dir (shared with --profile-use).')
 
         parser.add_argument(
             '--profile-use', dest='profile-use', metavar='path',
             action='store', type=str, nargs='?', const='',
-            help='Add build options to support profile-use')
+            help='PGO phase 2: rebuild using a collected profile (gcc/clang; '
+                 'path is a .gcda dir for gcc, or a .profdata/.profraw dir for '
+                 'clang -- blade merges clang .profraw automatically). Uses the '
+                 'same build_*_pgo dir as --profile-generate so gcc finds its '
+                 '.gcda (keyed by object path).')
 
     def __add_fission_arguments(self, parser):
         """Add fission support to cc_binary."""

--- a/src/blade/workspace.py
+++ b/src/blade/workspace.py
@@ -32,6 +32,15 @@ def _build_variant_suffix(options):
     sanitizers = getattr(options, 'sanitizers', None)
     if sanitizers:
         variants.append(sanitizer.build_tag(sanitizers))  # e.g. 'asan'
+    # PGO instrument/optimize builds are codegen-incompatible with a normal
+    # build, so they get their own build dir (like coverage/asan). Both phases
+    # share ONE `_pgo` dir on purpose: gcc keys its `.gcda` lookup by the object
+    # file path, so the generate and use builds must place objects at identical
+    # paths or gcc can't find the profile (-Wmissing-profile). (clang is keyed
+    # by function, so it wouldn't care -- but a single dir is correct for both.)
+    if (getattr(options, 'profile-generate', None) is not None or
+            getattr(options, 'profile-use', None) is not None):
+        variants.append('pgo')
     return ''.join('_' + v for v in variants)
 
 

--- a/src/tests/unit/cc_library_config_test.py
+++ b/src/tests/unit/cc_library_config_test.py
@@ -108,6 +108,9 @@ class CcArchiveRulesTest(unittest.TestCase):
         from blade import cc_rule_support
         gen = cc_rule_support.CcRuleGenerator.__new__(cc_rule_support.CcRuleGenerator)
         gen._add_line = mock.Mock()
+        # spec=[] -> hasattr is False for every name, so the PGO option probes
+        # (profile-generate / profile-use) read as "not given" (PGO off).
+        gen.options = mock.Mock(spec=[])
         gen.build_toolchain = mock.Mock()
         gen.build_toolchain.target_os = target_os
         gen.build_accelerator = mock.Mock()

--- a/src/tests/unit/cc_pgo_test.py
+++ b/src/tests/unit/cc_pgo_test.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+#
+# Unit tests for PGO (profile-guided optimization) flag dispatch (#1366).
+
+"""Tests the gcc/clang/MSVC dispatch of --profile-generate / --profile-use.
+
+PGO is a global build mode (#1366). The generate phase shares the
+`-fprofile-generate` spelling on gcc and clang; the use phase diverges:
+
+  * gcc: `-fprofile-use` reads `.gcda` directly + `-fprofile-correction`.
+  * clang: rejects `-fprofile-correction`; needs a *merged* `.profdata`
+    (blade merges `.profraw` via llvm-profdata) + clang mismatch suppressions.
+  * native MSVC: a different flag family (/LTCG:PG*) -- gated with a warning
+    until the Windows backend lands.
+"""
+
+import os
+import sys
+import unittest
+import unittest.mock as mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import config  # noqa: E402
+from blade import cc_rule_support  # noqa: E402
+
+
+def _make_generator(cc_vendor='gcc', target_os='linux',
+                    profile_generate=None, profile_use=None):
+    """A minimal CcRuleGenerator with the given PGO options and a toolchain
+    that reports the requested vendor/os and returns flags verbatim."""
+    gen = cc_rule_support.CcRuleGenerator.__new__(cc_rule_support.CcRuleGenerator)
+    gen.options = mock.Mock()
+    gen.options.m = None
+    gen.options.profile = 'release'
+    gen.options.gprof = False
+    gen.options.coverage = False
+    gen.options.sanitizers = []
+    # PGO options use dashed dests; set/delete so getattr/hasattr behave like
+    # argparse (absent attr => option not given).
+    for attr, val in (('profile-generate', profile_generate),
+                      ('profile-use', profile_use)):
+        if val is None:
+            try:
+                delattr(gen.options, attr)
+            except AttributeError:
+                pass
+        else:
+            setattr(gen.options, attr, val)
+    gen.build_toolchain = mock.Mock()
+    gen.build_toolchain.target_os = target_os
+    gen.build_toolchain.cc = '/usr/bin/' + ('clang' if cc_vendor == 'clang' else cc_vendor)
+    gen.build_toolchain.filter_cc_flags = lambda flags: list(flags)
+    gen.build_toolchain.cc_is = lambda vendor: vendor == cc_vendor
+
+    section = {
+        'fission': False,
+        'debug_info_levels': {'mid': ['-g']},
+        'no_semantic_interposition': False,
+    }
+    global_section = {'debug_info_level': 'mid'}
+
+    def fake_get_section(name):
+        return {'cc_config': section, 'global_config': global_section}[name]
+
+    return gen, fake_get_section
+
+
+def _flags(gen, fake_get_section):
+    with mock.patch.object(cc_rule_support.config, 'get_section',
+                           side_effect=fake_get_section):
+        return gen._get_intrinsic_cc_flags()
+
+
+class PgoGenerateTest(unittest.TestCase):
+    """--profile-generate: same spelling on gcc/clang, both compile+link."""
+
+    def test_gcc_generate_on_compile_and_link(self):
+        gen, fake = _make_generator(cc_vendor='gcc', profile_generate='')
+        cppflags, linkflags = _flags(gen, fake)
+        self.assertIn('-fprofile-generate', cppflags)
+        self.assertIn('-fprofile-generate', linkflags)
+
+    def test_clang_generate_on_compile_and_link(self):
+        gen, fake = _make_generator(cc_vendor='clang', target_os='darwin',
+                                    profile_generate='')
+        cppflags, linkflags = _flags(gen, fake)
+        self.assertIn('-fprofile-generate', cppflags)
+        self.assertIn('-fprofile-generate', linkflags)
+
+    def test_generate_with_path(self):
+        gen, fake = _make_generator(cc_vendor='gcc', profile_generate='/tmp/p')
+        cppflags, linkflags = _flags(gen, fake)
+        self.assertIn('-fprofile-generate=/tmp/p', cppflags)
+        self.assertIn('-fprofile-generate=/tmp/p', linkflags)
+
+    def test_msvc_generate_warns_and_skips(self):
+        cc_rule_support._pgo_msvc_warned = False
+        gen, fake = _make_generator(cc_vendor='msvc', target_os='windows',
+                                    profile_generate='')
+        with mock.patch.object(cc_rule_support.console, 'warning') as warn:
+            cppflags, linkflags = _flags(gen, fake)
+        self.assertFalse([f for f in cppflags if 'profile-generate' in f])
+        warn.assert_called_once()
+
+
+class PgoUseTest(unittest.TestCase):
+    """--profile-use: gcc keeps -fprofile-correction; clang must not."""
+
+    def test_gcc_use_has_correction(self):
+        gen, fake = _make_generator(cc_vendor='gcc', profile_use='/tmp/prof')
+        cppflags, _ = _flags(gen, fake)
+        self.assertIn('-fprofile-use=/tmp/prof', cppflags)
+        self.assertIn('-fprofile-correction', cppflags)
+        self.assertIn('-Wno-error=coverage-mismatch', cppflags)
+
+    def test_clang_use_drops_correction(self):
+        # Point at a .profdata file so no merge subprocess runs.
+        gen, fake = _make_generator(cc_vendor='clang', target_os='darwin',
+                                    profile_use='/tmp/x.profdata')
+        with mock.patch('os.path.isfile', return_value=True):
+            cppflags, _ = _flags(gen, fake)
+        self.assertIn('-fprofile-use=/tmp/x.profdata', cppflags)
+        self.assertNotIn('-fprofile-correction', cppflags)
+        # clang's own mismatch suppressions instead.
+        self.assertIn('-Wno-error=profile-instr-out-of-date', cppflags)
+        self.assertIn('-Wno-error=profile-instr-unprofiled', cppflags)
+
+    def test_clang_use_merges_profraw_dir(self):
+        """A directory of .profraw is merged once via llvm-profdata, and
+        -fprofile-use points at the merged file."""
+        cc_rule_support._clang_profdata_cache.clear()
+        gen, fake = _make_generator(cc_vendor='clang', target_os='linux',
+                                    profile_use='/tmp/pgodir')
+        with mock.patch('os.path.isfile', return_value=False), \
+             mock.patch('os.path.isdir', return_value=True), \
+             mock.patch('glob.glob', return_value=['/tmp/pgodir/a.profraw']), \
+             mock.patch.object(cc_rule_support, '_find_llvm_profdata',
+                               return_value=['/usr/bin/llvm-profdata']), \
+             mock.patch.object(cc_rule_support.util, 'run_command',
+                               return_value=(0, '', '')) as run:
+            cppflags, _ = _flags(gen, fake)
+        merged = os.path.join('/tmp/pgodir', 'blade-merged.profdata')
+        self.assertIn('-fprofile-use=' + merged, cppflags)
+        self.assertNotIn('-fprofile-correction', cppflags)
+        # The merge command was invoked.
+        self.assertTrue(run.called)
+        args = run.call_args[0][0]
+        self.assertIn('merge', args)
+        self.assertIn('/tmp/pgodir/a.profraw', args)
+
+    def test_msvc_use_warns_and_skips(self):
+        cc_rule_support._pgo_msvc_warned = False
+        gen, fake = _make_generator(cc_vendor='msvc', target_os='windows',
+                                    profile_use='/tmp/prof')
+        with mock.patch.object(cc_rule_support.console, 'warning') as warn:
+            cppflags, _ = _flags(gen, fake)
+        self.assertFalse([f for f in cppflags if 'profile-use' in f])
+        self.assertNotIn('-fprofile-correction', cppflags)
+        warn.assert_called_once()
+
+
+class PgoBuildDirTest(unittest.TestCase):
+    """PGO builds get their own build dir, like coverage/asan."""
+
+    def _name(self, **opts):
+        from blade.workspace import _build_dir_name
+
+        class _TC:
+            target_os = 'linux'
+            target_arch = 'x86_64'
+
+        class _Opts:
+            profile = 'release'
+            bits = '64'
+            coverage = False
+            sanitizers = None
+            def __init__(self, **kw):
+                for k, v in kw.items():
+                    setattr(self, k, v)
+        return _build_dir_name('build_${profile}', _Opts(**opts), _TC())
+
+    def test_normal_build_unsuffixed(self):
+        self.assertEqual('build_release', self._name())
+
+    def test_generate_and_use_share_one_pgo_dir(self):
+        # Both phases use `_pgo` so object paths match across them (gcc keys
+        # its .gcda lookup by object path).
+        self.assertEqual('build_release_pgo',
+                         self._name(**{'profile-generate': ''}))
+        self.assertEqual('build_release_pgo',
+                         self._name(**{'profile-use': '/tmp/p'}))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/unit/cc_pgo_test.py
+++ b/src/tests/unit/cc_pgo_test.py
@@ -12,8 +12,9 @@ PGO is a global build mode (#1366). The generate phase shares the
   * gcc: `-fprofile-use` reads `.gcda` directly + `-fprofile-correction`.
   * clang: rejects `-fprofile-correction`; needs a *merged* `.profdata`
     (blade merges `.profraw` via llvm-profdata) + clang mismatch suppressions.
-  * native MSVC: a different flag family (/LTCG:PG*) -- gated with a warning
-    until the Windows backend lands.
+  * native MSVC: a different flag family -- `/GL` on compile, `/LTCG /GENPROFILE`
+    (instrument) or `/LTCG /USEPROFILE` (optimize, auto-merges the `.pgc`) on
+    link, `/LTCG` on lib. Wired in the Windows rules, not the gcc/clang path.
 """
 
 import os
@@ -97,16 +98,6 @@ class PgoGenerateTest(unittest.TestCase):
         self.assertIn('-fprofile-generate=/tmp/p', cppflags)
         self.assertIn('-fprofile-generate=/tmp/p', linkflags)
 
-    def test_msvc_generate_warns_and_skips(self):
-        cc_rule_support._pgo_msvc_warned = False
-        gen, fake = _make_generator(cc_vendor='msvc', target_os='windows',
-                                    profile_generate='')
-        with mock.patch.object(cc_rule_support.console, 'warning') as warn:
-            cppflags, linkflags = _flags(gen, fake)
-        self.assertFalse([f for f in cppflags if 'profile-generate' in f])
-        warn.assert_called_once()
-
-
 class PgoUseTest(unittest.TestCase):
     """--profile-use: gcc keeps -fprofile-correction; clang must not."""
 
@@ -152,15 +143,43 @@ class PgoUseTest(unittest.TestCase):
         self.assertIn('merge', args)
         self.assertIn('/tmp/pgodir/a.profraw', args)
 
-    def test_msvc_use_warns_and_skips(self):
-        cc_rule_support._pgo_msvc_warned = False
-        gen, fake = _make_generator(cc_vendor='msvc', target_os='windows',
-                                    profile_use='/tmp/prof')
-        with mock.patch.object(cc_rule_support.console, 'warning') as warn:
-            cppflags, _ = _flags(gen, fake)
-        self.assertFalse([f for f in cppflags if 'profile-use' in f])
-        self.assertNotIn('-fprofile-correction', cppflags)
-        warn.assert_called_once()
+class PgoMsvcTest(unittest.TestCase):
+    """Native MSVC PGO: /GL on compile, /LTCG + GEN/USEPROFILE on link, /LTCG on
+    lib (#1366 Phase 2). The gcc/clang `-fprofile-*` path never runs for MSVC."""
+
+    def _opts(self, generate=None, use=None):
+        opts = mock.Mock()
+        for attr, val in (('profile-generate', generate), ('profile-use', use)):
+            if val is None:
+                try:
+                    delattr(opts, attr)
+                except AttributeError:
+                    pass
+            else:
+                setattr(opts, attr, val)
+        return opts
+
+    def test_compile_flags(self):
+        # /GL (+ the parity define) under either mode; nothing when off.
+        for mode in (dict(generate=''), dict(use='/tmp/p'), dict(generate='/tmp/p')):
+            flags = cc_rule_support._pgo_msvc_compile_flags(self._opts(**mode))
+            self.assertIn('/GL', flags)
+            self.assertIn('/DPROFILE_GUIDED_OPTIMIZATION', flags)
+        self.assertEqual([], cc_rule_support._pgo_msvc_compile_flags(self._opts()))
+
+    def test_lib_flags(self):
+        self.assertEqual(['/LTCG'],
+                         cc_rule_support._pgo_msvc_lib_flags(self._opts(generate='')))
+        self.assertEqual(['/LTCG'],
+                         cc_rule_support._pgo_msvc_lib_flags(self._opts(use='/p')))
+        self.assertEqual([], cc_rule_support._pgo_msvc_lib_flags(self._opts()))
+
+    def test_link_flags_dispatch(self):
+        self.assertEqual(['/LTCG', '/GENPROFILE'],
+                         cc_rule_support._pgo_msvc_link_flags(self._opts(generate='')))
+        self.assertEqual(['/LTCG', '/USEPROFILE'],
+                         cc_rule_support._pgo_msvc_link_flags(self._opts(use='/p')))
+        self.assertEqual([], cc_rule_support._pgo_msvc_link_flags(self._opts()))
 
 
 class PgoBuildDirTest(unittest.TestCase):

--- a/src/tests/unit/msvc_default_flags_test.py
+++ b/src/tests/unit/msvc_default_flags_test.py
@@ -21,7 +21,22 @@ sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
 from blade import cc_rule_support  # noqa: E402
 
 
-def _compile_rules(profile='release', debug_info='mid', cppflags=None, cxxflags=None):
+def _set_pgo(options, profile_generate, profile_use):
+    """Set/clear the dashed PGO option attrs so the probes read them like
+    argparse (absent => not given). Default (both None) keeps PGO off."""
+    for attr, val in (('profile-generate', profile_generate),
+                      ('profile-use', profile_use)):
+        if val is None:
+            try:
+                delattr(options, attr)
+            except AttributeError:
+                pass
+        else:
+            setattr(options, attr, val)
+
+
+def _compile_rules(profile='release', debug_info='mid', cppflags=None, cxxflags=None,
+                   profile_generate=None, profile_use=None):
     gen = cc_rule_support.CcRuleGenerator.__new__(cc_rule_support.CcRuleGenerator)
     gen.build_toolchain = mock.Mock()
     gen.build_toolchain.filter_cc_flags = lambda flags, *a: list(flags)
@@ -30,6 +45,7 @@ def _compile_rules(profile='release', debug_info='mid', cppflags=None, cxxflags=
     gen.options = mock.Mock()
     gen.options.profile = profile
     gen.options.sanitizers = []
+    _set_pgo(gen.options, profile_generate, profile_use)
     gen.build_dir = 'build64_%s' % profile
     gen._msvc_tee_wrapper_py = mock.Mock(return_value='cc_wrapper.py')
     gen.generate_rule = mock.Mock()
@@ -66,7 +82,8 @@ def _cc_vars_sanitize(sanitizers):
     return next(s for s in captured if s.startswith('sanitize ='))
 
 
-def _link_flags(profile='release', debug_info='mid', sanitizers=None):
+def _link_flags(profile='release', debug_info='mid', sanitizers=None,
+                profile_generate=None, profile_use=None):
     gen = cc_rule_support.CcRuleGenerator.__new__(cc_rule_support.CcRuleGenerator)
     gen.build_accelerator = mock.Mock()
     gen.build_accelerator.get_cc_commands.return_value = ('cl', 'cl', 'link.exe')
@@ -82,6 +99,7 @@ def _link_flags(profile='release', debug_info='mid', sanitizers=None):
     gen.options = mock.Mock()
     gen.options.profile = profile
     gen.options.sanitizers = sanitizers or []
+    _set_pgo(gen.options, profile_generate, profile_use)
     section = {'msvc_config': {'linkflags': []}, 'cc_config': {'linkflags': []},
                'global_config': {'debug_info_level': debug_info}}
     with mock.patch('blade.cc_rule_support.config') as cfg:
@@ -146,6 +164,38 @@ class MsvcDefaultFlagsTest(unittest.TestCase):
         # Release already adds /INCREMENTAL:NO; ASan must not add a second.
         line = _link_flags(profile='release', sanitizers=['address'])
         self.assertEqual(1, line.split().count('/INCREMENTAL:NO'))
+
+    # --- PGO wiring, issue #1366 Phase 2 ---
+
+    def test_compile_gl_off_without_pgo(self):
+        self.assertNotIn('/GL', _compile_rules()['cc'])
+
+    def test_compile_gl_under_pgo(self):
+        for mode in (dict(profile_generate=''), dict(profile_use='/p')):
+            rules = _compile_rules(**mode)
+            for name in ('cc', 'cxx'):
+                self.assertIn('/GL', rules[name])
+
+    def test_link_pgo_generate(self):
+        line = _link_flags(profile_generate='')
+        self.assertIn('/LTCG', line)
+        self.assertIn('/GENPROFILE', line)
+        self.assertNotIn('/USEPROFILE', line)
+
+    def test_link_pgo_use(self):
+        line = _link_flags(profile_use='/p')
+        self.assertIn('/LTCG', line)
+        self.assertIn('/USEPROFILE', line)
+        self.assertNotIn('/GENPROFILE', line)
+
+    def test_link_pgo_debug_forces_incremental_off(self):
+        # LTCG is incompatible with incremental linking, so even a debug PGO
+        # build (normally incremental) gets /INCREMENTAL:NO, exactly once.
+        line = _link_flags(profile='debug', debug_info='no', profile_generate='')
+        self.assertEqual(1, line.split().count('/INCREMENTAL:NO'))
+
+    def test_link_no_pgo_no_ltcg(self):
+        self.assertNotIn('/LTCG', _link_flags())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implements **#1366** — `--profile-generate` / `--profile-use` made correct and unified across **gcc, clang, and native MSVC**, as a global build mode (per-toolchain dispatch; **not** a per-`cc_binary` attribute).

## What it does

**Generate** (gcc/clang share the spelling): `-fprofile-generate[=path]` on compile + link.

**Use** (dispatched):
| Toolchain | Behavior |
|---|---|
| gcc | `-fprofile-use[=path]` + `-fprofile-correction` + `-Wno-error=coverage-mismatch` (reads `.gcda` directly) |
| clang | merges `.profraw` → `.profdata` via `llvm-profdata` (located next to compiler / PATH / `xcrun`), `-fprofile-use=<merged>`, **no** `-fprofile-correction`, + clang mismatch suppressions |
| **MSVC** | whole-program LTCG PGO: `/GL` on compile, `/LTCG /GENPROFILE` (instrument) or `/LTCG /USEPROFILE` (optimize, auto-merges the run's `.pgc` into `.pgd` — no `pgomgr`) on link, `/LTCG` on `lib` |

**Dedicated build dir:** all phases/toolchains share **one** `build_*_pgo` dir. Deliberate — gcc keys `.gcda` lookup by object path and MSVC keys `.pgd` by output name, so the instrument and optimize builds must place outputs at identical paths. clang doesn't care, but one dir is correct for all three.

This also fixes the original GCC-shaped bug (clang was missing the merge step and wrongly got the gcc-only `-fprofile-correction`).

## Verification (end-to-end, real toolchains)

- **macOS / clang:** instrument → run → use; blade merged `.profraw` → `blade-merged.profdata`, `-fprofile-use=<merged>`, no `-fprofile-correction`. ✅ (re-verified after the MSVC merge)
- **Linux / gcc (OrbStack):** shared `build_*_pgo` dir, `.gcda` found, no `-Wmissing-profile`, `-fprofile-use` + `-fprofile-correction`. ✅ (re-verified after the MSVC merge)
- **Windows / MSVC:** instrument → run → optimize verified on VS by the author (`/GL` + `/LTCG /GENPROFILE` → `.pgc` → `/LTCG /USEPROFILE` auto-merge).

## Tests

`cc_pgo_test.py` (generate/use dispatch for gcc/clang + MSVC `/GL`+`/LTCG` flag helpers + shared build-dir suffix) and `msvc_default_flags_test.py`. Full unit suite green (764), pyright clean.

## Architecture note

MSVC never reaches the gcc/clang `_get_intrinsic_cc_flags` path — `generate_cc_rules`/`generate_cuda_rules` dispatch MSVC to the Windows rules, where the `/GL` + `/LTCG` PGO flags are wired (`_pgo_msvc_{compile,link,lib}_flags`). So the gcc/clang `-fprofile-*` flags can never leak onto cl.exe.

## Follow-up

clang-cl coverage/PGO routing and MSVC `--coverage` are tracked separately in **#1369** (deferred — needs the `is_clang_cl` predicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)