### PR TITLE
fix(scm): don't crash when git/svn is absent in a versioned workspace

### DIFF
--- a/src/blade/workspace.py
+++ b/src/blade/workspace.py
@@ -70,7 +70,11 @@ def _build_dir_name(build_path_format, options, toolchain):
 
 def _generate_scm_svn():
     url = revision = 'unknown'
-    returncode, stdout, stderr = util.run_command(['svn', 'info'])
+    try:
+        returncode, stdout, stderr = util.run_command(['svn', 'info'])
+    except OSError as e:  # svn not installed / not on PATH
+        console.debug('Failed to run svn for scm info: %s' % e)
+        return url, revision
     if returncode != 0:
         console.debug('Failed to generate svn scm: %s' % stderr)
     else:
@@ -88,7 +92,11 @@ def _generate_scm_git():
     url = revision = 'unknown'
 
     def git(cmd):
-        returncode, stdout, stderr = util.run_command(cmd)
+        try:
+            returncode, stdout, stderr = util.run_command(cmd)
+        except OSError as e:  # git not installed / not on PATH
+            console.debug('Failed to run git for scm info: %s' % e)
+            return ''
         if returncode != 0:
             console.debug('Failed to generate git scm: %s' % stderr)
             return ''

--- a/src/tests/unit/scm_test.py
+++ b/src/tests/unit/scm_test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+#
+# Unit tests for SCM (git/svn) info generation in workspace.py.
+
+"""SCM info is best-effort: a workspace under `.git`/`.svn` whose VCS tool is
+not installed must degrade to 'unknown', not crash blade.
+
+Regression for the case where `git`/`svn` is absent: `util.run_command`
+raises `FileNotFoundError` (a subclass of `OSError`) when the binary is
+missing, which previously propagated out of `setup_build_dir` and aborted the
+whole build with a traceback.
+"""
+
+import os
+import sys
+import unittest
+import unittest.mock as mock
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import workspace  # noqa: E402
+
+
+class ScmMissingToolTest(unittest.TestCase):
+    """git/svn not installed => defaults, no exception."""
+
+    def test_git_missing_returns_unknown(self):
+        with mock.patch.object(workspace.util, 'run_command',
+                               side_effect=FileNotFoundError(2, 'No such file', 'git')):
+            url, revision = workspace._generate_scm_git()
+        self.assertEqual(('unknown', 'unknown'), (url, revision))
+
+    def test_svn_missing_returns_unknown(self):
+        with mock.patch.object(workspace.util, 'run_command',
+                               side_effect=FileNotFoundError(2, 'No such file', 'svn')):
+            url, revision = workspace._generate_scm_svn()
+        self.assertEqual(('unknown', 'unknown'), (url, revision))
+
+    def test_generate_scm_does_not_raise_when_git_missing(self):
+        """The end-to-end path `_generate_scm` (called from setup_build_dir)
+        must not propagate the missing-tool error."""
+        with mock.patch('os.path.isdir', side_effect=lambda p: p == '.git'), \
+             mock.patch.object(workspace.util, 'run_command',
+                               side_effect=FileNotFoundError(2, 'No such file', 'git')), \
+             mock.patch.object(workspace, 'open', mock.mock_open(), create=True):
+            # Should complete without raising.
+            workspace._generate_scm('/tmp/nonexistent_build_dir_xyz')
+
+
+class ScmSuccessTest(unittest.TestCase):
+    """Normal path still parses revision/url."""
+
+    def test_git_parses_revision_and_url(self):
+        def fake_run(cmd, **kw):
+            if cmd[:2] == ['git', 'rev-parse']:
+                return 0, 'deadbeef\n', ''
+            if cmd[:2] == ['git', 'remote']:
+                return 0, 'origin\thttps://example.com/r.git (fetch)\n', ''
+            return 1, '', 'err'
+        with mock.patch.object(workspace.util, 'run_command', side_effect=fake_run):
+            url, revision = workspace._generate_scm_git()
+        self.assertEqual('deadbeef', revision)
+        self.assertEqual('https://example.com/r.git', url)
+
+    def test_git_strips_userinfo_from_url(self):
+        def fake_run(cmd, **kw):
+            if cmd[:2] == ['git', 'rev-parse']:
+                return 0, 'abc123\n', ''
+            return 0, 'origin\thttps://user:pass@example.com/r.git (fetch)\n', ''
+        with mock.patch.object(workspace.util, 'run_command', side_effect=fake_run):
+            url, _ = workspace._generate_scm_git()
+        self.assertEqual('https://example.com/r.git', url)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

`_generate_scm_git` / `_generate_scm_svn` invoke `git` / `svn` via `util.run_command`, which raises `FileNotFoundError` (an `OSError`) when the binary isn't installed. In a workspace that has `.git` (or `.svn`) but no VCS tool on `PATH`, that exception propagated out of `Workspace.setup_build_dir` → `_generate_scm` and **aborted the whole build with a traceback** — even though SCM info is best-effort and otherwise defaults to `'unknown'`.

```
File ".../workspace.py", line 97, in _generate_scm_git
  out = git(['git', 'rev-parse', 'HEAD'])
...
File ".../subprocess.py", in _execute_child   # FileNotFoundError: 'git'
```

The `git()` helper already swallowed a non-zero exit code, but not a missing binary.

## Fix

Catch `OSError` at both SCM helpers and degrade to `'unknown'` (the same result as a non-zero exit). Localized to the SCM call sites — `run_command` keeps raising for every other caller, where a missing tool is a real error.

## Tests

`scm_test.py`: git/svn-missing degrade to `'unknown'` without raising (including the end-to-end `_generate_scm` path that previously crashed `setup_build_dir`), plus the normal revision/url parse and the userinfo-stripping path. Full suite green (769).

## How it was found

Building flare inside a minimal OrbStack image that ships no `git`. Unrelated to the PGO work that surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)