### PR TITLE
fix(sanitizer): reject incompatible --sanitizer combos at the command line

### DIFF
--- a/src/blade/cc_rule_support.py
+++ b/src/blade/cc_rule_support.py
@@ -721,7 +721,8 @@ class CcRuleGenerator:
 
         sanitizers = getattr(self.options, 'sanitizers', None)
         if sanitizers:
-            sanitizer.check_compat(sanitizers)
+            # check_compat ran at the command line (toolchain-independent); only
+            # the toolchain-support check needs the resolved toolchain here.
             sanitizer.check_toolchain(sanitizers, self.build_toolchain)
             # Compile-side instrumentation rides the overridable `${sanitize}`
             # ninja var (emitted by _generate_cc_vars) so a per-target
@@ -892,11 +893,10 @@ class CcRuleGenerator:
         # global default is the active set's compile flags (/fsanitize=address),
         # and a per-target `sanitize=False` blanks it on that target's edges --
         # cl has no `-fno-sanitize` to subtract per file. The compile rules below
-        # reference `${sanitize}`. Validate the set once here.
+        # reference `${sanitize}`. (check_compat ran at the command line.)
         sanitizers = getattr(self.options, 'sanitizers', None)
         sanitize = ''
         if sanitizers:
-            sanitizer.check_compat(sanitizers)
             sanitizer.check_toolchain(sanitizers, self.build_toolchain)
             sanitize = ' '.join(sanitizer.msvc_compile_flags(sanitizers))
         self._add_line('sanitize = %s\n' % sanitize)

--- a/src/blade/command_line.py
+++ b/src/blade/command_line.py
@@ -71,8 +71,12 @@ class CommandLineParser:
         # Check the options with different sub command
         self._check_subcommand(command, options, targets)
 
-        # Canonicalize --sanitizer (off for subcommands without build args).
+        # Canonicalize --sanitizer (off for subcommands without build args) and
+        # reject an invalid combination *now* -- it's toolchain-independent, so
+        # fail at the command line instead of mid-build (after the build dir and
+        # the whole load/analyze pass are already done).
         options.sanitizers = sanitizer.parse(getattr(options, 'sanitizer', ''))
+        sanitizer.check_compat(options.sanitizers)
 
         return command, options, targets
 

--- a/src/tests/unit/sanitizer_test.py
+++ b/src/tests/unit/sanitizer_test.py
@@ -108,6 +108,18 @@ class SanitizerHelperTest(unittest.TestCase):
         with self.assertRaises(SystemExit):
             sanitizer.check_compat(['memory', 'thread'])
 
+    def test_incompatible_combo_rejected_at_command_line(self):
+        # check_compat is toolchain-independent, so the command line must reject
+        # an invalid combination up front -- before the load/analyze pass and
+        # the build dir, not mid-build.
+        from blade import command_line
+        with self.assertRaises(SystemExit):
+            command_line.parse(['build', '--sanitizer=address,thread', '//foo:bar'])
+        # A valid combo parses fine and yields the canonical set.
+        _, options, _ = command_line.parse(
+            ['build', '--sanitizer=address,undefined', '//foo:bar'])
+        self.assertEqual(['address', 'undefined'], options.sanitizers)
+
     def test_runtime_env_defaults(self):
         env = sanitizer.runtime_env(['thread'])
         self.assertEqual('halt_on_error=1', env['TSAN_OPTIONS'])


### PR DESCRIPTION
## Problem

An invalid `--sanitizer` combination (e.g. `address,thread`) is **toolchain-independent**, but `check_compat` only ran during backend code generation. So:

```
$ blade build flare/base/... --sanitizer=address,thread
Blade: Entering directory `...'
Blade(info): Loading config file ...
Blade(info): Loading BUILD files...
Blade(info): Analyzing dependency graph...
Blade(info): Generating backend build code...
Blade(error): --sanitizer: "address" cannot be combined with thread
```

The error fired only **after** config load, the full BUILD-file load, dependency analysis, and **build-dir creation** — wasted work, and a stray build dir left behind.

## Fix

Call `check_compat` right after `--sanitizer` is parsed in `CommandLineParser.parse` — it needs only the requested set, no toolchain. Now:

```
$ blade build //:x --sanitizer=address,thread
Blade(error): --sanitizer: "address" cannot be combined with thread
Blade(error): Failure
```

Immediate, no directory entered, no loading, **no build dir created**. The two now-redundant `check_compat` calls in the codegen path are dropped (`check_toolchain` stays there — it needs the resolved toolchain).

## Verified
- `--sanitizer=address,thread` → fails instantly, no build dir (confirmed on a real workspace).
- A valid single/compatible sanitizer (`address`, `address,undefined`) still builds.

## Tests
`command_line.parse(['build','--sanitizer=address,thread', ...])` raises `SystemExit`; a valid combo parses to the canonical set. Full suite 830 green, pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)