### PR TITLE
feat(sanitizer): sanitizer_config(compile_flags) for per-sanitizer compile knobs

### DIFF
--- a/doc/en/test.md
+++ b/doc/en/test.md
@@ -166,7 +166,7 @@ A sanitizer is a **per-run choice** (a flag), not project config. `--sanitizer` 
 
 - **Flags:** `-fsanitize=<set> -fno-omit-frame-pointer -g` are added to compiles and links (the link pulls in the sanitizer runtime). UBSan is made **fatal** (`-fno-sanitize-recover=undefined`) so a finding fails the test rather than just printing. For tests, Blade also sets sane `*_OPTIONS` defaults (e.g. `TSAN_OPTIONS=halt_on_error=1`) so a detection reliably exits non-zero — any value you set in the environment still wins. So `blade test` reports a detection as a failure.
 - **MSVC:** the MSVC toolchain implements **only** AddressSanitizer — `--sanitizer=address` compiles with `/fsanitize=address` (plus `/Z7` for symbolized reports), links non-incrementally (`/INCREMENTAL:NO /DEBUG`; the ASan runtime is pulled in automatically), and puts the ASan runtime DLL on the test's `PATH`. Any other sanitizer on MSVC is a clear startup error.
-- **MemorySanitizer:** `--sanitizer=memory` (alias `msan`) catches reads of uninitialized memory. It is **Clang + Linux only** — GCC has no MSan and the runtime is unavailable on macOS, so requesting it elsewhere is a clear startup error. Blade adds `-fsanitize-memory-track-origins=2` so a report points back to where the uninitialized value originated. MSan reports false positives unless **every** linked translation unit is instrumented: you must build (or supply) an MSan-instrumented C++ standard library and build your dependencies under MSan too — otherwise expect spurious reports from uninstrumented system libraries.
+- **MemorySanitizer:** `--sanitizer=memory` (alias `msan`) catches reads of uninitialized memory. It is **Clang + Linux only** — GCC has no MSan and the runtime is unavailable on macOS, so requesting it elsewhere is a clear startup error. Blade adds `-fsanitize-memory-track-origins=2` so a report points back to where the uninitialized value originated (origin tracking is memory-hungry — dial it down with `sanitizer_config(compile_flags = {'memory': ['-fsanitize-memory-track-origins=1']})`, or `=0`, see below). MSan reports false positives unless **every** linked translation unit is instrumented: you must build (or supply) an MSan-instrumented C++ standard library and build your dependencies under MSan too — otherwise expect spurious reports from uninstrumented system libraries.
 - **Isolated build directory:** a sanitized build is ABI/codegen-incompatible with a normal one, so it gets its own sibling dir with a sanitizer tag — `build_release_asan`. The plain `build_release` is untouched, so the two coexist without clobbering or rebuilding each other.
 - **Per-target opt-out:** a target that must not be instrumented (intentional UB, a hot path, a wrapper around a non-instrumented prebuilt) sets `sanitize = False`. It still links (and still gets the runtime); only its own compiles drop the instrumentation. This works on MSVC too — since `cl` has no `-fno-sanitize`, Blade blanks the per-file `/fsanitize` flag for that target instead.
 
@@ -182,6 +182,15 @@ A sanitizer is a **per-run choice** (a flag), not project config. `--sanitizer` 
   sanitizer_config(options = {
       'thread': ['suppressions=etc/tsan.supp', 'history_size=7'],
       'address': ['detect_stack_use_after_return=1'],
+  })
+  ```
+
+- **Per-sanitizer compile flags:** sanitizer-specific *compile* knobs that can't live in `cc_config.cppflags` (they're only valid while that sanitizer is on). Set them in `sanitizer_config(compile_flags = {...})`, keyed by sanitizer; they are added (gcc/clang) only when that sanitizer is active, **appended after** Blade's defaults so a single-value flag wins by last occurrence. The motivating case is dialing MSan origin tracking down from the default `=2` to save memory:
+
+  ```python
+  sanitizer_config(compile_flags = {
+      'memory':  ['-fsanitize-memory-track-origins=1'],   # or =0 — cheaper than the default =2
+      'address': ['-fsanitize-address-use-after-scope'],
   })
   ```
 

--- a/doc/zh_CN/test.md
+++ b/doc/zh_CN/test.md
@@ -162,7 +162,7 @@ sanitizer 是**每次运行的选择**（命令行开关），不是项目配置
 
 - **编译选项：** 给编译和链接都加上 `-fsanitize=<集合> -fno-omit-frame-pointer -g`（链接以引入 sanitizer 运行时）。UBSan 被设为**致命**（`-fno-sanitize-recover=undefined`），使其发现问题时让测试失败，而非仅打印。对测试，Blade 还会设置合理的 `*_OPTIONS` 默认值（如 `TSAN_OPTIONS=halt_on_error=1`），使检测能可靠地以非零退出——你在环境变量中已设置的值仍然优先。因此 `blade test` 会把检测判为失败。
 - **MSVC：** MSVC 工具链**仅**支持 AddressSanitizer——`--sanitizer=address` 用 `/fsanitize=address` 编译（并加 `/Z7` 以便符号化报告），以非增量方式链接（`/INCREMENTAL:NO /DEBUG`；ASan 运行时由编译器自动引入），并把 ASan 运行时 DLL 加入测试的 `PATH`。在 MSVC 上请求其它 sanitizer 会在启动时明确报错。
-- **MemorySanitizer：** `--sanitizer=memory`（别名 `msan`）检测对未初始化内存的读取。它**仅限 Clang + Linux**——GCC 没有 MSan，运行时在 macOS 上也不可用，在其它环境请求会在启动时明确报错。Blade 会加上 `-fsanitize-memory-track-origins=2`，使报告能回溯到未初始化值的来源。MSan 只有在**所有**参与链接的代码都被插桩时才不会误报：你需要自行构建（或提供）一个经 MSan 插桩的 C++ 标准库，并让依赖项也在 MSan 下构建——否则未插桩的系统库会带来大量误报。
+- **MemorySanitizer：** `--sanitizer=memory`（别名 `msan`）检测对未初始化内存的读取。它**仅限 Clang + Linux**——GCC 没有 MSan，运行时在 macOS 上也不可用，在其它环境请求会在启动时明确报错。Blade 会加上 `-fsanitize-memory-track-origins=2`，使报告能回溯到未初始化值的来源（origin 跟踪很耗内存——可用 `sanitizer_config(compile_flags = {'memory': ['-fsanitize-memory-track-origins=1']})` 调低，或 `=0`，见下文）。MSan 只有在**所有**参与链接的代码都被插桩时才不会误报：你需要自行构建（或提供）一个经 MSan 插桩的 C++ 标准库，并让依赖项也在 MSan 下构建——否则未插桩的系统库会带来大量误报。
 - **独立的构建目录：** sanitizer 构建与普通构建在 ABI/代码生成上不兼容，因此使用带 sanitizer 标记的独立兄弟目录——`build_release_asan`。普通的 `build_release` 不受影响，两者可并存、互不覆盖、互不触发重新编译。
 - **按目标退出：** 不应被插桩的目标（有意的 UB、性能热点、对未插桩预编译库的包装）可设置 `sanitize = False`。它仍参与链接（仍获得运行时），只是自身的编译不再插桩。在 MSVC 上同样有效——由于 `cl` 没有 `-fno-sanitize`，Blade 改为将该目标的 `/fsanitize` 标志置空。
 
@@ -178,6 +178,15 @@ sanitizer 是**每次运行的选择**（命令行开关），不是项目配置
   sanitizer_config(options = {
       'thread': ['suppressions=etc/tsan.supp', 'history_size=7'],
       'address': ['detect_stack_use_after_return=1'],
+  })
+  ```
+
+- **按 sanitizer 的编译选项：** 那些不能放进 `cc_config.cppflags` 的 sanitizer 专属*编译*选项（它们只在该 sanitizer 开启时才合法）。在 `sanitizer_config(compile_flags = {...})` 里按 sanitizer 配置；它们仅在该 sanitizer 激活时（gcc/clang）加入，且**追加在** Blade 默认之后，因此单值类选项按末位生效覆盖默认。典型场景是把 MSan 的 origin 跟踪从默认 `=2` 调低以省内存：
+
+  ```python
+  sanitizer_config(compile_flags = {
+      'memory':  ['-fsanitize-memory-track-origins=1'],   # 或 =0 —— 比默认 =2 更省
+      'address': ['-fsanitize-address-use-after-scope'],
   })
   ```
 

--- a/src/blade/cc_rule_support.py
+++ b/src/blade/cc_rule_support.py
@@ -1413,7 +1413,17 @@ class CcRuleGenerator:
         # CcTarget._get_cc_vars). The set is already validated in
         # _get_intrinsic_cc_flags, which runs first.
         sanitizers = getattr(self.options, 'sanitizers', None)
-        sanitize = ' '.join(sanitizer.compile_flags(sanitizers)) if sanitizers else ''
+        if sanitizers:
+            # blade's defaults, then the project's per-sanitizer extra compile
+            # flags (sanitizer_config.compile_flags) -- appended last so a
+            # single-value flag like -fsanitize-memory-track-origins=N overrides
+            # blade's default by last-occurrence.
+            sanitize_flags = sanitizer.compile_flags(sanitizers) + \
+                sanitizer.resolve_compile_flags(
+                    config.get_item('sanitizer_config', 'compile_flags'), sanitizers)
+            sanitize = ' '.join(sanitize_flags)
+        else:
+            sanitize = ''
         # LTO compile flag (#1378) as an overridable variable, mirroring
         # ${sanitize}: the global default is the active mode's `-flto*`, and a
         # per-target lto=False blanks `${lto}` on that target's edges so it
@@ -1712,7 +1722,9 @@ class CcRuleGenerator:
         # opt-out, so it just always instruments under --sanitizer (as before).
         sanitizers = getattr(self.options, 'sanitizers', None)
         if sanitizers:
-            cppflags = cppflags + sanitizer.compile_flags(sanitizers)
+            cppflags = cppflags + sanitizer.compile_flags(sanitizers) + \
+                sanitizer.resolve_compile_flags(
+                    config.get_item('sanitizer_config', 'compile_flags'), sanitizers)
         cppflags = cc_config['cppflags'] + cppflags
         cxxflags = ['-Xcompiler %s' % flag for flag in cxxflags]
         cppflags = ['-Xcompiler %s' % flag for flag in cppflags]

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -501,6 +501,15 @@ _CONFIG_TEMPLATE = {
         # `suppressions=<path>` option is resolved relative to the workspace root
         # and the file must exist; every other option passes through verbatim.
         'options': {},
+        # Per-sanitizer extra *compile* flags: {sanitizer: [flag, ...]}. Keys
+        # accept the canonical name or its alias; the flags are added (gcc/clang
+        # only) when that sanitizer is active, appended AFTER blade's defaults so
+        # a single-value flag wins by last-occurrence -- e.g.
+        # {'memory': ['-fsanitize-memory-track-origins=1']} dials MSan origin
+        # tracking down from blade's default =2 to save memory. For sanitizer-
+        # specific knobs that can't go in cc_config.cppflags (they're only valid
+        # while that sanitizer is on). See doc/*/test.md.
+        'compile_flags': {},
     },
 
 }

--- a/src/blade/sanitizer.py
+++ b/src/blade/sanitizer.py
@@ -140,6 +140,31 @@ def msvc_link_flags(sanitizers):
     return []
 
 
+def resolve_compile_flags(compile_flags_config, sanitizers):
+    """Per-sanitizer extra compile flags for the active set (gcc/clang).
+
+    ``compile_flags_config`` is the ``{sanitizer: list}`` map from
+    ``sanitizer_config.compile_flags`` (keys accept aliases). Returns a flat list
+    of the flags for the sanitizers actually active this run, in config order; a
+    configured sanitizer that isn't requested is skipped. Callers append these
+    AFTER ``compile_flags()`` so a single-value flag (e.g.
+    ``-fsanitize-memory-track-origins=N``) wins by last occurrence.
+    """
+    if not compile_flags_config:
+        return []
+    active = set(sanitizers)
+    flags = []
+    for name, value in compile_flags_config.items():
+        canonical = _ALIASES.get(str(name).strip().lower())
+        if canonical is None:
+            console.fatal('sanitizer_config.compile_flags: unknown sanitizer '
+                          '"%s" (known: %s)' % (name, ', '.join(sorted(_ALIASES))))
+        if canonical not in active or not value:
+            continue
+        flags.extend([value] if isinstance(value, str) else list(value))
+    return flags
+
+
 def resolve_options(options, sanitizers):
     """Resolve configured ``*_OPTIONS`` for the active sanitizer set.
 

--- a/src/tests/unit/sanitizer_test.py
+++ b/src/tests/unit/sanitizer_test.py
@@ -176,6 +176,47 @@ class ResolveOptionsTest(unittest.TestCase):
         with self.assertRaises(SystemExit):
             sanitizer.resolve_options({'bogus': ['x=1']}, ['bogus'])
 
+
+class ResolveCompileFlagsTest(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual([], sanitizer.resolve_compile_flags(None, ['memory']))
+        self.assertEqual([], sanitizer.resolve_compile_flags({}, ['memory']))
+
+    def test_active_sanitizer_flags(self):
+        # Alias 'msan' -> 'memory'; the flags pass through in order.
+        self.assertEqual(
+            ['-fsanitize-memory-track-origins=1'],
+            sanitizer.resolve_compile_flags(
+                {'msan': ['-fsanitize-memory-track-origins=1']}, ['memory']))
+
+    def test_string_form_is_one_flag(self):
+        self.assertEqual(
+            ['-fsanitize-memory-track-origins=0'],
+            sanitizer.resolve_compile_flags(
+                {'memory': '-fsanitize-memory-track-origins=0'}, ['memory']))
+
+    def test_inactive_sanitizer_skipped(self):
+        # Configured for memory but only address is active -> nothing.
+        self.assertEqual(
+            ['-fsanitize-address-use-after-scope'],
+            sanitizer.resolve_compile_flags(
+                {'memory': ['-fsanitize-memory-track-origins=1'],
+                 'address': ['-fsanitize-address-use-after-scope']},
+                ['address']))
+
+    def test_overrides_default_by_last_occurrence(self):
+        # The whole point: appended after blade's default =2, the user's =1 wins.
+        flags = (sanitizer.compile_flags(['memory']) +
+                 sanitizer.resolve_compile_flags(
+                     {'memory': ['-fsanitize-memory-track-origins=1']}, ['memory']))
+        origins = [f for f in flags if 'track-origins' in f]
+        self.assertEqual(['-fsanitize-memory-track-origins=2',
+                          '-fsanitize-memory-track-origins=1'], origins)
+
+    def test_unknown_sanitizer_is_fatal(self):
+        with self.assertRaises(SystemExit):
+            sanitizer.resolve_compile_flags({'bogus': ['-x']}, ['bogus'])
+
     def test_missing_suppressions_file_is_fatal(self):
         with self.assertRaises(SystemExit):
             sanitizer.resolve_options(


### PR DESCRIPTION
## Why

blade hardcodes `-fsanitize-memory-track-origins=2` — the heaviest MSan origin-tracking level — with no override, so memory-constrained MSan runs can OOM (the motivating report). Sanitizer-specific compile flags **can't** go in `cc_config.cppflags`: `-fsanitize-memory-track-origins` is only valid while `-fsanitize=memory` is active, so a static cppflag would error on every non-MSan build. They need a sanitizer-aware, gated mechanism — and `sanitizer_config` already owns per-sanitizer settings (`options`, suppressions), so this slots in.

## What

```python
sanitizer_config(compile_flags = {
    'memory':  ['-fsanitize-memory-track-origins=1'],   # or =0 — cheaper than the default =2
    'address': ['-fsanitize-address-use-after-scope'],
})
```

- Keyed by sanitizer (alias-accepting, like `options`); a flag list (a bare string is one flag).
- Added (gcc/clang) **only when that sanitizer is in `--sanitizer`** — correct gating that static config can't express.
- **Appended after blade's defaults**, so a single-value flag wins by last occurrence — the example dials MSan origins down from blade's hardcoded `=2`. blade's default is unchanged unless you opt in.
- Wired into the overridable `${sanitize}` var (so a per-target `sanitize=False` still drops it) and the cuda rule. `resolve_compile_flags` mirrors the existing `resolve_options`.

## Note vs. the reverted `lto_export_dynamic`

This is the *justified* version of "a config knob for a mode-gated flag": unlike the LTO case, there's **no** alternative (no static-cppflag or source path for a gated sanitizer compile flag), and it extends an existing per-sanitizer config rather than adding a flag-named global.

Unit tests (alias, gating, last-wins override, fatal-on-unknown) + docs (`test.md`, en+zh). Full suite green (865), pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)