### PR TITLE
docs: switch the star chart from starchart.cc to star-history.com

### DIFF
--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -8,7 +8,7 @@
     { "pattern": "^https?://www\\.gnu\\.org/" },
     { "pattern": "^https?://bazel\\.build/" },
     { "pattern": "^https?://asciinema\\.org/" },
-    { "pattern": "^https?://starchart\\.cc/" },
+    { "pattern": "^https?://(www\\.|api\\.)?star-history\\.com/" },
     { "pattern": "^https?://github\\.com/blade-build/blade-build/releases/tag/" }
   ]
 }

--- a/README-zh.md
+++ b/README-zh.md
@@ -39,9 +39,15 @@ Blade 3 把项目从一个仅限 Linux、以 GCC 为中心的工具，升级为*
 
 升级细节请参考[升级到 V3 版](doc/zh_CN/upgrade-to-v3.md)。
 
-## Stargazers over time
+## Star History
 
-[![Stargazers over time](https://starchart.cc/blade-build/blade-build.svg)](https://starchart.cc/blade-build/blade-build)
+<a href="https://www.star-history.com/?repos=blade-build%2Fblade-build&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&legend=top-left" />
+ </picture>
+</a>
 
 ## 源起
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,15 @@ Blade 3 takes the project from a Linux-only, GCC-focused tool to a **three-platf
 
 See the [Upgrade to V3](doc/en/upgrade-to-v3.md) guide for details.
 
-## Stargazers over time
+## Star History
 
-[![Stargazers over time](https://starchart.cc/blade-build/blade-build.svg)](https://starchart.cc/blade-build/blade-build)
+<a href="https://www.star-history.com/?repos=blade-build%2Fblade-build&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&legend=top-left" />
+ </picture>
+</a>
 
 ## Origin
 


### PR DESCRIPTION
`starchart.cc` has been frequently rate-limited / erroring. Switch the star chart to **[star-history.com](https://star-history.com)** — the more widely-used and better-maintained alternative — using its dark-mode `<picture>` embed (renders correctly on both GitHub themes).

- `README.md` and `README-zh.md`: replace the `starchart.cc` image with the star-history.com `<picture>` block (heading → "Star History").
- `markdown-link-check-config.json`: swap the `starchart.cc` ignore for `star-history.com` / `api.star-history.com` (its anonymous API can rate-limit the same way).

No markdownlint in CI, so the inline `<picture>` HTML (the only way to get theme-aware images) is fine.