### PR TITLE
doc: MkDocs (Read the Docs theme) site config + link-rewrite hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ __pycache__
 !/.agent/tools/*.sh
 !/.agent/tools/README.md
 .claude/
+
+# MkDocs build output (docs are deployed to blade-build.github.io)
+/_site/

--- a/doc/mkdocs-en.yml
+++ b/doc/mkdocs-en.yml
@@ -1,0 +1,87 @@
+# MkDocs config for the English documentation site (readthedocs theme).
+# Built and deployed to blade-build.github.io/docs/en/ by .github/workflows.
+# Page titles are taken from each file's H1 (already localized); only the
+# section headers below are spelled out.
+site_name: Blade Build
+site_description: Documentation for the Blade build system
+site_url: https://blade-build.github.io/docs/en/
+repo_url: https://github.com/blade-build/blade-build
+repo_name: blade-build/blade-build
+docs_dir: en
+site_dir: ../_site/en
+use_directory_urls: true
+
+hooks:
+  - mkdocs_hooks.py
+
+theme:
+  name: readthedocs
+  highlightjs: true
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - tables
+  - fenced_code
+
+nav:
+  - README.md
+  - Introduction:
+      - intro.md
+      - features.md
+  - Getting Started:
+      - prerequisites.md
+      - install.md
+      - quick_start.md
+  - User Guide:
+      - workspace.md
+      - build_file.md
+      - dsl.md
+      - functions.md
+      - command_line.md
+      - test.md
+      - output.md
+      - build_cache.md
+      - optimization.md
+      - config.md
+      - misc.md
+  - Build Rules:
+      - build_rules/cc.md
+      - build_rules/custom_rule.md
+      - build_rules/extension.md
+      - build_rules/gen_rule.md
+      - build_rules/go.md
+      - build_rules/idl.md
+      - build_rules/java.md
+      - build_rules/lexyacc.md
+      - build_rules/package.md
+      - build_rules/python.md
+      - build_rules/scala.md
+      - build_rules/shell.md
+      - build_rules/swig.md
+      - build_rules/vcpkg.md
+  - Upgrade:
+      - upgrade-to-v3.md
+      - upgrade-to-v2.md
+  - Development:
+      - develop.md
+      - develop/build_file_loading.md
+      - develop/cc_build.md
+      - develop/check_undefined.md
+      - develop/configuration.md
+      - develop/console.md
+      - develop/custom_rule.md
+      - develop/dependency_analysis.md
+      - develop/dsl_api.md
+      - develop/export_map.md
+      - develop/gen_rule.md
+      - develop/hdrs_check.md
+      - develop/java_scala_build.md
+      - develop/protobuf_build.md
+      - develop/python_build.md
+      - develop/self_testing.md
+      - develop/test_execution.md
+      - develop/vcpkg.md
+      - develop/visibility.md
+  - FAQ.md

--- a/doc/mkdocs-zh.yml
+++ b/doc/mkdocs-zh.yml
@@ -1,0 +1,88 @@
+# MkDocs config for the Chinese documentation site (readthedocs theme).
+# Built and deployed to blade-build.github.io/docs/zh/ by .github/workflows.
+# Page titles come from each file's H1 (already in Chinese); only the section
+# headers below are spelled out.
+site_name: Blade Build
+site_description: Blade 构建系统文档
+site_url: https://blade-build.github.io/docs/zh/
+repo_url: https://github.com/blade-build/blade-build
+repo_name: blade-build/blade-build
+docs_dir: zh_CN
+site_dir: ../_site/zh
+use_directory_urls: true
+
+hooks:
+  - mkdocs_hooks.py
+
+theme:
+  name: readthedocs
+  highlightjs: true
+  language: zh
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - tables
+  - fenced_code
+
+nav:
+  - README.md
+  - 介绍:
+      - intro.md
+      - features.md
+  - 快速开始:
+      - prerequisites.md
+      - install.md
+      - quick_start.md
+  - 用户指南:
+      - workspace.md
+      - build_file.md
+      - dsl.md
+      - functions.md
+      - command_line.md
+      - test.md
+      - output.md
+      - build_cache.md
+      - optimization.md
+      - config.md
+      - misc.md
+  - 构建规则:
+      - build_rules/cc.md
+      - build_rules/custom_rule.md
+      - build_rules/extension.md
+      - build_rules/gen_rule.md
+      - build_rules/go.md
+      - build_rules/idl.md
+      - build_rules/java.md
+      - build_rules/lexyacc.md
+      - build_rules/package.md
+      - build_rules/python.md
+      - build_rules/scala.md
+      - build_rules/shell.md
+      - build_rules/swig.md
+      - build_rules/vcpkg.md
+  - 升级:
+      - upgrade-to-v3.md
+      - upgrade-to-v2.md
+  - 开发文档:
+      - develop.md
+      - develop/build_file_loading.md
+      - develop/cc_build.md
+      - develop/check_undefined.md
+      - develop/configuration.md
+      - develop/console.md
+      - develop/custom_rule.md
+      - develop/dependency_analysis.md
+      - develop/dsl_api.md
+      - develop/export_map.md
+      - develop/gen_rule.md
+      - develop/hdrs_check.md
+      - develop/java_scala_build.md
+      - develop/protobuf_build.md
+      - develop/python_build.md
+      - develop/self_testing.md
+      - develop/test_execution.md
+      - develop/vcpkg.md
+      - develop/visibility.md
+  - FAQ.md

--- a/doc/mkdocs_hooks.py
+++ b/doc/mkdocs_hooks.py
@@ -1,0 +1,25 @@
+"""MkDocs build hooks.
+
+Rewrite repo-relative links to absolute GitHub URLs at build time, so the source
+markdown stays unchanged. The docs link to repo files/dirs with paths like
+`../../tool/x.sh` or `../../src/blade/x.py` -- correct when the markdown is viewed
+on GitHub, but they 404 on the rendered doc site (those targets aren't part of
+the docs). This hook converts them to absolute github.com URLs during the build.
+"""
+import re
+
+_BASE = 'https://github.com/blade-build/blade-build'
+
+# Markdown links pointing two levels up into the repo: `../../tool[/...]` or
+# `../../src[/...]`. A trailing sub-path means a file (blob); a bare dir is a tree.
+_LINK = re.compile(r'\(\.\./\.\./(tool|src)((?:/[^)]*)?)\)')
+
+
+def _to_github_url(match):
+    top, rest = match.group(1), match.group(2)
+    kind = 'blob' if rest else 'tree'
+    return f'({_BASE}/{kind}/master/{top}{rest})'
+
+
+def on_page_markdown(markdown, **kwargs):
+    return _LINK.sub(_to_github_url, markdown)


### PR DESCRIPTION
Adds the source-side pieces for the new documentation site at **blade-build.github.io/docs/{en,zh}** (rendered with MkDocs + the built-in Read the Docs theme, replacing the raw-GitHub-markdown "Docs" links). The built HTML + homepage link changes are published separately in the `blade-build.github.io` repo.

- **`doc/mkdocs-{en,zh}.yml`** — MkDocs configs over `doc/en` / `doc/zh_CN`. Path-only nav so each page auto-titles from its H1 (already localized); only the section headers are spelled out (localized for zh). Clean URLs (`/docs/en/intro/`).
- **`doc/mkdocs_hooks.py`** — an `on_page_markdown` build hook that rewrites the handful of in-doc links pointing at *repo* files (`../../tool/...`, `../../src/blade/...`) to absolute `github.com` URLs at build time (they'd 404 on the doc site). The **source markdown is left unchanged** — its repo-relative links stay correct when viewed on GitHub.
- **`.gitignore`** — ignore the `_site/` build output.

A follow-up will add a GitHub Action to rebuild + publish on `doc/**` changes.