### PR TITLE
ci: skip build for doc-only changes; add Python 3.14 to macOS/Windows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,10 @@ name: "CodeQL"
 on:
   push:
     branches: [ "master" ]
+    paths-ignore: [ '**.md' ]  # doc-only changes don't affect code analysis
   pull_request:
     branches: [ "master" ]
+    paths-ignore: [ '**.md' ]
   schedule:
     - cron: "27 21 * * 0"
 

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -3,8 +3,10 @@ name: macOS CI
 on:
   push:
     branches: [master]
+    paths-ignore: [ '**.md' ]  # doc-only changes: only check-md-links runs
   pull_request:
     branches: [master]
+    paths-ignore: [ '**.md' ]
 
 jobs:
   unit-tests:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,11 @@ name: Python package
 
 on:
   push:
-    branches: [ master, v3 ]
+    branches: [ master ]
+    paths-ignore: [ '**.md' ]  # doc-only changes: only check-md-links runs
   pull_request:
-    branches: [ master, v3 ]
+    branches: [ master ]
+    paths-ignore: [ '**.md' ]
 
 jobs:
   integration-tests:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -3,8 +3,10 @@ name: Windows CI
 on:
   push:
     branches: [master]
+    paths-ignore: [ '**.md' ]  # doc-only changes: only check-md-links runs
   pull_request:
     branches: [master]
+    paths-ignore: [ '**.md' ]
 
 jobs:
   unit-tests:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

Two CI tweaks:

1. **Skip build/scan workflows for doc-only (`**.md`) changes.** Add `paths-ignore: ['**.md']` to the push/pull_request triggers of the Python, macOS, Windows, and CodeQL workflows. A markdown-only change now runs only **Check Markdown links** (which already runs on every push and self-limits to modified files) — no more burning the full test matrix + CodeQL on a typo fix.
2. **Add Python 3.14 to the macOS and Windows matrices.** Linux already tests 3.10–3.14; this brings the other two platforms to the same range.

Also drops the dangling `v3` branch from python-package's triggers — no such branch exists (3.0.x isn't a maintained line; `v3.0.0` is a tag).

## ⚠️ Branch-protection note

If any of these jobs are **required status checks** in branch protection, they must be removed from the required list — otherwise a doc-only PR will block forever on a check that intentionally never runs (a skipped required check never reports a conclusion). The `check-md-links` job is unaffected and keeps running.

## Changes
- `.github/workflows/{python-package,macos-ci,windows-ci,codeql}.yml`: `paths-ignore: ['**.md']`.
- `.github/workflows/{macos-ci,windows-ci}.yml`: add `"3.14"` to the matrix.
- `.github/workflows/python-package.yml`: drop nonexistent `v3` trigger branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)