### PR TITLE
doc: add Editor Support page (VS Code extension + clangd)

### DIFF
--- a/doc/en/editor_support.md
+++ b/doc/en/editor_support.md
@@ -1,0 +1,44 @@
+# Editor Support
+
+## Visual Studio Code
+
+The official **[Blade extension](https://marketplace.visualstudio.com/items?itemName=blade-build.vscode-blade)**
+([source](https://github.com/blade-build/vscode-blade)) gives first-class Blade
+support in VS Code:
+
+- a **targets explorer** (directory tree) with inline **build / run / test /
+  debug**, and recursive build/test of a directory (`//path/...`);
+- **build / run / test / clean** through the VS Code Tasks API — compiler errors
+  land in the Problems panel, and a failed build never silently runs a stale
+  binary;
+- a **build-profile** (release / debug) selector;
+- **BUILD-file language features** — syntax highlighting, an outline of targets,
+  go-to-definition on dependency labels (`//path:name`, `:name`), completion,
+  hover, and diagnostics;
+- one-click **C/C++ IntelliSense** via `compile_commands.json` and clangd.
+
+Targets are read from Blade itself (`blade dump --targets`), so every rule kind
+(C++, Java, Scala, Python, proto, …) is understood accurately.
+
+Install it from the Marketplace, open a workspace that contains a `BLADE_ROOT`,
+and (if `blade` is not on your `PATH`) set `blade.executable`.
+
+## C/C++ IntelliSense in any editor
+
+The extension's IntelliSense is built on a feature you can use from **any**
+editor: Blade can emit a
+[compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html).
+
+```bash
+blade dump --compdb --to-file compile_commands.json
+```
+
+Point [clangd](https://clangd.llvm.org/) at the resulting
+`compile_commands.json` and you get accurate completion, go-to-definition, and
+diagnostics — in Vim, Emacs, CLion, or any [LSP](https://langserver.org/)
+client. Because Blade knows the exact compile command for every translation
+unit, this is more accurate than re-deriving include paths by hand.
+
+!!! tip
+    Regenerate `compile_commands.json` after adding sources or changing deps.
+    The VS Code extension can do this automatically on every target refresh.

--- a/doc/mkdocs-en.yml
+++ b/doc/mkdocs-en.yml
@@ -40,6 +40,7 @@ nav:
       - dsl.md
       - functions.md
       - command_line.md
+      - editor_support.md
       - test.md
       - output.md
       - build_cache.md

--- a/doc/mkdocs-zh.yml
+++ b/doc/mkdocs-zh.yml
@@ -41,6 +41,7 @@ nav:
       - dsl.md
       - functions.md
       - command_line.md
+      - editor_support.md
       - test.md
       - output.md
       - build_cache.md

--- a/doc/zh_CN/editor_support.md
+++ b/doc/zh_CN/editor_support.md
@@ -1,0 +1,40 @@
+# 编辑器支持
+
+## Visual Studio Code
+
+官方 **[Blade 扩展](https://marketplace.visualstudio.com/items?itemName=blade-build.vscode-blade)**
+（[源码](https://github.com/blade-build/vscode-blade)）为 VS Code 提供一流的 Blade
+支持：
+
+- **目标浏览器**（目录树），带行内 **构建 / 运行 / 测试 / 调试**，并可递归构建/测试
+  某个目录（`//path/...`）；
+- 通过 VS Code Tasks API 的 **构建 / 运行 / 测试 / 清理** —— 编译错误会出现在“问题”
+  面板中，构建失败也不会误运行旧的可执行文件；
+- **构建配置**（release / debug）切换；
+- **BUILD 文件语言特性** —— 语法高亮、目标大纲、对依赖标签（`//path:name`、
+  `:name`）的跳转到定义、补全、悬停与诊断；
+- 借助 `compile_commands.json` 与 clangd 的一键 **C/C++ 智能感知**。
+
+目标信息读取自 Blade 本身（`blade dump --targets`），因此每一种规则（C++、Java、
+Scala、Python、proto……）都能被准确理解。
+
+从应用市场安装，打开一个包含 `BLADE_ROOT` 的工作区；若 `blade` 不在 `PATH` 中，
+设置 `blade.executable` 即可。
+
+## 在任意编辑器中获得 C/C++ 智能感知
+
+扩展的智能感知建立在一个你可以在**任意**编辑器中使用的能力之上：Blade 能生成
+[编译数据库](https://clang.llvm.org/docs/JSONCompilationDatabase.html)。
+
+```bash
+blade dump --compdb --to-file compile_commands.json
+```
+
+让 [clangd](https://clangd.llvm.org/) 指向生成的 `compile_commands.json`，即可在
+Vim、Emacs、CLion 或任意 [LSP](https://langserver.org/) 客户端中获得准确的补全、
+跳转到定义与诊断。由于 Blade 知道每个翻译单元的精确编译命令，这比手动推导 include
+路径更准确。
+
+!!! tip
+    新增源文件或改动依赖后，请重新生成 `compile_commands.json`。VS Code 扩展可在
+    每次刷新目标时自动完成这一步。


### PR DESCRIPTION
## Summary

Adds a user-facing **Editor Support** page (English + 简体中文) to the User Guide, documenting:

- the official **[Blade VS Code extension](https://marketplace.visualstudio.com/items?itemName=blade-build.vscode-blade)** ([source](https://github.com/blade-build/vscode-blade)) — targets explorer, build/run/test via the Tasks API, BUILD-file language features, and clangd-based C/C++ IntelliSense;
- the **editor-agnostic** path: `blade dump --compdb --to-file compile_commands.json` + [clangd](https://clangd.llvm.org/), usable from Vim/Emacs/CLion/any LSP client.

This is the documentation that #997 asked for ("I will update the documents to cover this feature") — now backed by a first-party extension.

## Changes
- `doc/en/editor_support.md`, `doc/zh_CN/editor_support.md` (new).
- `doc/mkdocs-en.yml`, `doc/mkdocs-zh.yml`: add the page to the User Guide nav after `command_line`.

Docs-only; both MkDocs sites build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)