### PR TITLE
doc: point README Documentation link at the MkDocs site; drop FAQ

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -153,8 +153,7 @@ cc_binary(
 
 ## 文档
 
-* [完整文档](doc/zh_CN/README.md)
-* [FAQ](doc/zh_CN/FAQ.md)
+* [完整文档](https://blade-build.github.io/docs/zh/)
 
 ## 贡献者
 

--- a/README.md
+++ b/README.md
@@ -156,8 +156,7 @@ For Blade 2, use the [`v2`](https://github.com/blade-build/blade-build/tree/v2) 
 
 ## Documentation
 
-* [Full Documentation](doc/en/README.md)
-* [FAQ](doc/en/FAQ.md)
+* [Full Documentation](https://blade-build.github.io/docs/en/)
 
 ## Contributers
 


### PR DESCRIPTION
Links **Full Documentation** to the published MkDocs site (https://blade-build.github.io/docs/en/, verified live) instead of the raw GitHub markdown, and removes the separate **FAQ** link — FAQ is part of the docs-site nav.

README-only.