### PR TITLE
doc: reorganize README (en mirrors new zh structure)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1,4 +1,4 @@
-# Blade Build System
+# Blade 构建系统
 
 [![Website](https://img.shields.io/badge/website-blade--build.github.io-1f6feb.svg)](https://blade-build.github.io/)
 [![license NewBSD](https://img.shields.io/badge/License-NewBSD-yellow.svg)](COPYING)
@@ -7,11 +7,11 @@
 
 ![Blade Build](image/blade-200x400.png "Blade Build")
 
-Blade 是一款面向大规模 monorepo 环境和主干开发（trunk-based development）的现代化、高性能构建系统。
-
 [English](README.md) | 简体中文
 
-## Build Status
+Blade 是一款面向大规模 monorepo 环境和主干开发（trunk-based development）的现代化、高性能源代码构建系统。
+
+## 构建状态
 
 [![Linux](https://img.shields.io/github/actions/workflow/status/blade-build/blade-build/python-package.yml?branch=master&logo=linux&logoColor=white&label=Linux)](https://github.com/blade-build/blade-build/actions/workflows/python-package.yml)
 [![macOS](https://img.shields.io/github/actions/workflow/status/blade-build/blade-build/macos-ci.yml?branch=master&logo=apple&logoColor=white&label=macOS)](https://github.com/blade-build/blade-build/actions/workflows/macos-ci.yml)
@@ -19,51 +19,17 @@ Blade 是一款面向大规模 monorepo 环境和主干开发（trunk-based deve
 [![Coverage](https://coveralls.io/repos/blade-build/blade-build/badge.svg?branch=master)](https://coveralls.io/github/blade-build/blade-build)
 [![Downloads](https://img.shields.io/github/downloads/blade-build/blade-build/total.svg)](https://github.com/blade-build/blade-build/releases)
 
-## 演示
+## 简介
 
-我们先来看一个简洁的演示：
-
-[![asciicast](https://asciinema.org/a/1203812.svg)](https://asciinema.org/a/1203812)
-
-## Blade 3
-
-Blade 3 把项目从一个仅限 Linux、以 GCC 为中心的工具，升级为**三平台、多工具链**的现代构建系统。主要亮点：
-
-- **三平台，一份 BUILD** —— Linux + macOS（clang）+ Windows（MSVC），通过 `cc_toolchain_config` 按构建选择。
-- **原生 [vcpkg](https://github.com/microsoft/vcpkg) 集成** —— 版本锁定、隔离的 C/C++ 第三方库，用 `vcpkg#port:lib` 引用，相当于 C++ 版的 `maven_jar`。
-- **Sanitizer 与覆盖率** —— `--sanitizer=address,…`（ASan/UBSan/LSan/TSan/MSan；MSVC 上的 ASan）与 `--coverage`（C/C++ / Go / Python 的 HTML 报告），对既有目标树生效，无需改 BUILD。
-- **性能剖析引导与链接期优化** —— 插桩式 PGO、采样式 PGO / AutoFDO，以及 LTO / ThinLTO，在 gcc / clang / MSVC / clang-cl 上统一。见 [C/C++ 优化](doc/zh_CN/optimization.md)。
-- **跨平台符号控制** —— `export_map` / `linker_script` 在 GCC / clang / MSVC 上一致翻译。
-- **更强的依赖卫生** —— 新增 `unused-deps` 检查与静态未定义符号检查，与既有的 `missing-deps` 检查并列。
-- **现代化代码库** —— 仅 Python 3.10+（移除 Python 2），全量类型标注 + pyright，完善的单元与跨仓库 E2E 测试。
-
-升级细节请参考[升级到 V3 版](doc/zh_CN/upgrade-to-v3.md)。
-
-## Star History
-
-<a href="https://www.star-history.com/?repos=blade-build%2Fblade-build&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&legend=top-left" />
- </picture>
-</a>
-
-## 源起
+2010 年时，在腾讯[「台风」云计算平台](doc/Hadoop-in-China-2011-Typhoon.mhtml)的研发过程中，我们深刻体会到 GNU Make、Autotools 等传统构建系统在大规模环境下的不足。受 [Google 工程博客上一系列文章](http://google-engtools.blogspot.hk/2011/08/build-in-cloud-how-build-system-works.html) 的启发，我们设计和实现了 Blade 构建系统。
 
 Blade 是一款现代化的高性能构建系统，既追求强大的能力，也追求良好的使用体验，目标是把程序员从繁琐的构建工作中解放出来。它原生支持 C/C++、Java、Python、Scala、Protocol Buffers 等多种语言，自动分析目标间的依赖，并将编译、链接、测试（支持增量测试与并行测试）以及静态代码分析无缝整合在一起。
 
-在设计上，Blade 在简化构建配置的同时，也为复杂项目提供足够的健壮性。
+Blade 在简化构建配置的同时，也为复杂项目的构建提供足够的灵活性，并内置集成了大量现代编译器特性，如测试覆盖率、内存错误诊断与分析、编译器优化等。
 
-Blade 主要面向大型 C++ 项目，与研发流程（单元测试、持续集成、覆盖率统计等）紧密配合；同时，像 Unix 文本处理工具一样保持相对独立，可以单独运行。Blade 将 Linux（i386/x86_64/aarch64）、macOS（clang）和 Windows（MSVC）作为一等平台支持。
-
-在腾讯[「台风」云计算平台](doc/Hadoop-in-China-2011-Typhoon.mhtml)的研发过程中，我们深刻体会到 GNU Make、Autotools 在大规模环境下的不足。受 [Google 工程博客上一系列文章](http://google-engtools.blogspot.hk/2011/08/build-in-cloud-how-build-system-works.html) 的启发，我们将 Blade 设计为一款声明式构建系统。
+Blade 主要面向大型 C++ 项目，与研发流程（单元测试、持续集成、覆盖率统计等）紧密配合；同时也奉行 Unix 哲学，可以单独运行。Blade 将 Linux（i386/x86_64/aarch64）、macOS（clang）和 Windows（MSVC）作为一等平台支持。
 
 整个系统基于若干声明式的构建脚本。在这些脚本中，开发者只需声明「构建什么」（目标、源文件、直接依赖），而不必描述「如何构建」。这种思路大幅降低了配置复杂度，也显著提升了开发效率与可维护性。
-
-2012 年，Blade 对外开源，成为腾讯公司最早的开源项目之一。此后，Blade 在腾讯技术栈中获得了广泛应用，覆盖广告平台、微信后台服务、游戏服务端、基础架构等核心场景；在腾讯之外，小米、百度、爱奇艺等多家公司也在使用 Blade。
-
-Blade 由此形成了活跃的贡献者社区，收到来自公司内外的众多 Pull Request。项目最初托管在 Google Code 上，在 Google Code 停止服务后，迁移到 chen3feng 的个人仓库继续维护与演进。
 
 借助 Blade，只需一行命令即可完成多个目标的编译、链接与测试。例如：
 
@@ -114,6 +80,12 @@ cc_binary(
 
 除了自动维护依赖关系外，Blade 在易用性上的另一大亮点是：用户只需一行命令，就能完成整个目录树的编译、链接与单元测试。
 
+## 演示
+
+我们看一个真实的演示来感受 Blade 的简洁和高效：
+
+[![asciicast](https://asciinema.org/a/1203812.svg)](https://asciinema.org/a/1203812)
+
 ## 特点
 
 * **原生集成 [vcpkg](https://github.com/microsoft/vcpkg) 管理 C/C++ 第三方库。** 长期以来在 Blade 中使用第三方库都比较麻烦；随着 vcpkg 的成熟，Blade 将它作为一等的第三方包管理工具集成进来——在 `deps` 中写 `vcpkg#<port>:<lib>`，Blade 即自动安装并链接，支持版本固定与二进制缓存。详见[使用 vcpkg 包](doc/zh_CN/build_rules/vcpkg.md)。
@@ -145,6 +117,26 @@ cc_binary(
 * 头文件已更新，但受影响的模块未能重新构建。
 * 所依赖的库需要更新，但在构建时未被同步更新（例如某子目录的依赖被遗漏）。
 
+## Blade 版本历史
+
+Blade 至今共有三个大版本。
+
+Blade 1 是早期版本，其目标是提供一个简单易用的构建系统，后端是 [Scons](https://scons.org/) 构建系统。
+
+Blade 2 把后端升级到了 [Ninja](https://ninja-build.org/) 构建系统，大幅度地提高了性能。
+
+目前最新的 Blade 是 Blade 3，其目标是提供一个现代化的构建系统。Blade 3 把项目从一个仅限 Linux、以 GCC 为中心的工具，升级为**三平台、多工具链**的现代构建系统。主要亮点：
+
+* **三平台，一份 BUILD** —— Linux + macOS（clang）+ Windows（MSVC），通过 `cc_toolchain_config` 按构建选择。
+* **原生 [vcpkg](https://github.com/microsoft/vcpkg) 集成** —— 版本锁定、隔离的 C/C++ 第三方库，用 `vcpkg#port:lib` 引用，相当于 C++ 版的 `maven_jar`。
+* **Sanitizer 与覆盖率** —— `--sanitizer=address,…`（ASan/UBSan/LSan/TSan/MSan；MSVC 上的 ASan）与 `--coverage`（C/C++ / Go / Python 的 HTML 报告），对既有目标树生效，无需改 BUILD。
+* **性能剖析引导与链接期优化** —— 插桩式 PGO、采样式 PGO / AutoFDO，以及 LTO / ThinLTO，在 gcc / clang / MSVC / clang-cl 上统一。见 [C/C++ 优化](doc/zh_CN/optimization.md)。
+* **跨平台符号控制** —— `export_map` / `linker_script` 在 GCC / clang / MSVC 上一致翻译。
+* **更强的依赖卫生** —— 新增 `unused-deps` 检查与静态未定义符号检查，与既有的 `missing-deps` 检查并列。
+* **现代化代码库** —— 仅 Python 3.10+（移除 Python 2），全量类型标注 + pyright，完善的单元与跨仓库 E2E 测试。
+
+升级细节请参考[升级到 V3 版](doc/zh_CN/upgrade-to-v3.md)。
+
 ## 版本发布
 
 当前最新的稳定发布是 [`v3.0.0`](https://github.com/blade-build/blade-build/releases/tag/v3.0.0)；`master` 分支是 Blade 3 的开发主线。完整列表见 [Releases](https://github.com/blade-build/blade-build/releases)，升级细节请参考[升级到 V3 版](doc/zh_CN/upgrade-to-v3.md)。
@@ -157,7 +149,23 @@ cc_binary(
 
 ## 贡献者
 
+2012 年，Blade 对外开源，成为腾讯公司最早的开源项目之一。此后，Blade 在腾讯技术栈中获得了广泛应用，覆盖广告平台、微信后台服务、游戏服务端、基础架构等核心场景；在腾讯之外，小米、百度、爱奇艺等多家公司也在使用 Blade。
+
+Blade 由此形成了活跃的贡献者社区，收到来自公司内外的众多 Pull Request。项目最初托管在 Google Code 上，在 Google Code 停止服务后，迁移到 chen3feng 的个人仓库继续维护与演进，并最终迁移到这里。
+
 [![Contributers](https://contrib.rocks/image?repo=blade-build/blade-build)](https://github.com/blade-build/blade-build/graphs/contributors)
+
+## Star History
+
+即使您没有时间和精力贡献，也热烈欢迎 star。
+
+<a href="https://www.star-history.com/?repos=blade-build%2Fblade-build&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&legend=top-left" />
+ </picture>
+</a>
 
 ## 致谢
 
@@ -167,13 +175,6 @@ cc_binary(
 
 * Blade 在内部生成 [Ninja](https://ninja-build.org/) 脚本来驱动构建，因此运行时依赖 Ninja。
 * [Python](http://www.python.org) 是一门简单易用而又强大的语言，我们非常喜欢。
-
-Google 开源的一些库好用又强大，我们将对这些库的支持集成进了 Blade 中，既方便了库的使用，也增强了 Blade：
-
-- [glog](https://google.github.io/glog/stable/)
-- [protobuf](https://github.com/protocolbuffers/protobuf)
-- [gtest](https://github.com/google/googletest)
-- [gperftools](https://github.com/gperftools/gperftools)
 
 我们的理念：解放程序员，提升生产力，用工具解决非创造性的技术问题。
 

--- a/README.md
+++ b/README.md
@@ -19,68 +19,33 @@ A modern, high-performance build system optimized for trunk-based development in
 [![Coverage](https://coveralls.io/repos/blade-build/blade-build/badge.svg?branch=master)](https://coveralls.io/github/blade-build/blade-build)
 [![Downloads](https://img.shields.io/github/downloads/blade-build/blade-build/total.svg)](https://github.com/blade-build/blade-build/releases)
 
-## Demo
+## Introduction
 
-First, let's see a cool demo:
+In 2010, during the development of [Tencent's "Typhoon" cloud computing platform](doc/Hadoop-in-China-2011-Typhoon.mhtml), we experienced first-hand the limitations of traditional build systems such as GNU Make and Autotools at large scale. Inspired by a [series of articles on Google's engineering blog](http://google-engtools.blogspot.hk/2011/08/build-in-cloud-how-build-system-works.html), we designed and built the Blade build system.
 
-[![asciicast](https://asciinema.org/a/1203812.svg)](https://asciinema.org/a/1203812)
+Blade is a modern, high-performance build system that pursues both power and a good user experience, with the goal of freeing programmers from tedious build chores. It provides native support for many languages including C/C++, Java, Python, Scala, and Protocol Buffers, automatically analyzes the dependencies between targets, and seamlessly integrates compilation, linking, testing (with incremental and parallel testing), and static code analysis.
 
-## Blade 3
+While simplifying build configuration, Blade also provides enough flexibility for complex projects, with extensive built-in integration of modern compiler features such as test coverage, memory-error diagnosis and analysis, and compiler optimization.
 
-Blade 3 takes the project from a Linux-only, GCC-focused tool to a **three-platform, multi-toolchain** modern build system. Highlights:
+Blade is primarily aimed at large C++ projects and integrates closely with development workflows such as unit testing, continuous integration, and coverage statistics; at the same time, it follows the Unix philosophy and can run standalone. Blade treats Linux (i386/x86_64/aarch64), macOS (clang), and Windows (MSVC) as first-class platforms.
 
-- **Three platforms, one BUILD file** — Linux + macOS (clang) + Windows (MSVC), selectable per build via `cc_toolchain_config`.
-- **Native [vcpkg](https://github.com/microsoft/vcpkg) integration** — version-pinned, hermetic C/C++ third-party libraries via `vcpkg#port:lib`, the `maven_jar` analog for C++.
-- **Sanitizers & coverage** — `--sanitizer=address,…` (ASan/UBSan/LSan/TSan/MSan; ASan on MSVC) and `--coverage` (C/C++ / Go / Python HTML reports) on an existing target tree, no BUILD changes.
-- **Profile-guided & link-time optimization** — instrumentation PGO, sample-based PGO / AutoFDO, and LTO / ThinLTO, unified across gcc / clang / MSVC / clang-cl. See [C/C++ Optimization](doc/en/optimization.md).
-- **Cross-platform symbol control** — `export_map` / `linker_script` translated consistently across GCC / clang / MSVC.
-- **Stronger dependency hygiene** — an `unused-deps` check and a static undefined-symbol check join the existing `missing-deps` check.
-- **Modernized codebase** — Python 3.10+ only (Python 2 removed), full type annotations with pyright, comprehensive unit + cross-repo E2E tests.
+The whole system is driven by a set of declarative build scripts. In these scripts, developers only declare *what* to build (targets, sources, and direct dependencies) rather than *how* to build it. This approach dramatically reduces configuration complexity and significantly improves development efficiency and maintainability.
 
-See the [Upgrade to V3](doc/en/upgrade-to-v3.md) guide for details.
+With Blade, a single command line compiles, links, and tests multiple targets. For example:
 
-## Star History
-
-<a href="https://www.star-history.com/?repos=blade-build%2Fblade-build&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&legend=top-left" />
- </picture>
-</a>
-
-## Origin
-
-Blade is engineered as a modern, high-performance build system that combines power with ease of use. It provides comprehensive support for multiple programming languages including C/C++, Java, Python, Scala, Protocol Buffers, and more. The system automatically analyzes target dependencies and seamlessly integrates compilation, linking, testing (with support for incremental and parallel testing), and static code analysis.
-
-Designed to enhance development productivity, Blade simplifies build configuration while maintaining robust functionality for complex projects.
-
-Blade is primarily positioned for large C++ projects, closely integrated with development workflows such as unit testing, continuous integration, and coverage statistics. Like Unix text filtering programs, it maintains relative independence and can run standalone. It supports Linux (i386/x86_64/aarch64), macOS (clang), and Windows (MSVC) as first-class platforms.
-
-During the development of [Tencent's "Typhoon" cloud computing platform](doc/Hadoop-in-China-2011-Typhoon.mhtml), we identified significant challenges with GNU Make and Autotools in large-scale environments. Inspired by insights from [Google's engineering blog](http://google-engtools.blogspot.hk/2011/08/build-in-cloud-how-build-system-works.html), we engineered Blade as a declarative build system.
-
-The system utilizes declarative build scripts where developers specify what to build (targets, sources, and direct dependencies) rather than how to build it. This approach dramatically reduces configuration complexity while significantly improving development efficiency and maintainability.
-
-Blade was open-sourced in 2012 as one of Tencent's earliest open-source initiatives. The system has achieved widespread adoption across Tencent's technology stack, including advertising platforms, WeChat backend services, gaming infrastructure, and core infrastructure systems. Beyond Tencent, Blade has been deployed at major technology companies including Xiaomi, Baidu, and iQiyi.
-
-The project has fostered an active contributor community, receiving numerous Pull Requests from both internal and external developers. Originally hosted on Google Code, the project was migrated to chen3feng's personal repository following Google Code's deprecation, where it continues to be actively maintained and developed.
-
-With Blade, you can compile, link, and test multiple targets by just inputting one simple command line.
-For example:
-
-Build and test all targets in the common directory recursively.
+Recursively build and test all targets under the `common` directory:
 
 ```bash
 blade test common...
 ```
 
-Build and test targets in debug mode
+Build and test in debug mode:
 
 ```bash
 blade test -pdebug common...
 ```
 
-Build and test with a specific sanitizer enabled:
+Build and test with a sanitizer enabled:
 
 ```bash
 blade test --sanitizer=address common...
@@ -88,9 +53,9 @@ blade test --sanitizer=address common...
 
 ## Why It Exists
 
-First and foremost, Blade solves dependency problems. When you build certain targets, if header files have changed, it will automatically rebuild them.
+First and foremost, Blade solves dependency problems. When you build certain targets, if header files have changed, it will automatically rebuild the affected code.
 
-Most conveniently, Blade can also track library file dependencies. For example, if library foo depends on library common, then in library foo's BUILD file, you list the dependency:
+Most conveniently, Blade can also track dependencies between libraries. For example, if library `foo` depends on library `common`, you just declare that dependency in `foo`'s BUILD file:
 
 ```python
 cc_library(
@@ -101,7 +66,7 @@ cc_library(
 )
 ```
 
-Then for programs using foo, if they don't directly use common, you only need to list foo, not common:
+Then a program that uses `foo`, even if it does not directly use `common`, only needs to list `foo` as a dependency, not `common`:
 
 ```python
 cc_binary(
@@ -111,42 +76,66 @@ cc_binary(
 )
 ```
 
-This way, when your library implementation changes, adding or removing libraries, you don't need to notify library users to make changes together. Blade automatically maintains this layer of indirect dependencies. When building my_app, it will also automatically check whether foo and common need to be updated.
+This way, when a library's implementation changes, or dependencies are added or removed, the library's users don't need to change anything in step. Blade automatically maintains this layer of indirect dependencies; when building `my_app`, it also automatically checks whether `foo` and `common` need to be updated.
 
-In terms of ease of use, besides automatic dependency maintenance, Blade can also achieve that users only need to type one command line to handle compilation, linking, and unit testing for the entire directory tree.
+Besides automatic dependency maintenance, another highlight of Blade's ease of use is that a single command line can compile, link, and unit-test an entire directory tree.
+
+## Demo
+
+Let's look at a real demo to get a feel for how concise and efficient Blade is:
+
+[![asciicast](https://asciinema.org/a/1203812.svg)](https://asciinema.org/a/1203812)
 
 ## Features
 
 * **Native [vcpkg](https://github.com/microsoft/vcpkg) integration for C/C++ third-party libraries.** Using third-party libraries in Blade has long been cumbersome; as vcpkg has matured, Blade now integrates it as a first-class package manager — declare `vcpkg#<port>:<lib>` in `deps` and Blade installs and links them, with version pinning and a binary cache. See [Using vcpkg packages](doc/en/build_rules/vcpkg.md).
-* Automatic analysis of header file dependencies, building affected code.
-* Incremental compilation and linking, only building code that needs to be rebuilt due to changes.
-* Automatic calculation of indirect library dependencies - library authors only need to write direct dependencies, and builds automatically check if dependent libraries need rebuilding.
-* Ability to build from any subdirectory in any code tree.
-* Support for recursive building of all targets in multiple directories at once, as well as building only specific arbitrary targets.
-* Whatever targets you build, their dependent targets are also automatically updated.
-* Built-in debug/release build types.
-* Colorful highlighting of error messages during build process.
+* Automatic analysis of header-file dependencies, rebuilding affected code.
+* Incremental compilation and linking — only rebuild what actually needs rebuilding.
+* Automatic calculation of indirect library dependencies — library authors declare only direct dependencies, and builds automatically check whether indirect dependencies need rebuilding.
+* Ability to start a build from any subdirectory of the code tree.
+* Recursively build all targets in multiple directories at once, or build only specific targets.
+* Whatever targets you build, their dependencies are automatically updated too.
+* Built-in debug / release build types.
+* Colorful highlighting of error messages during the build.
 * Support for ccache.
 * Support for distcc.
 * Support for building multi-platform targets.
-* Support for compiler selection during build (different versions of gcc, clang, etc.).
-* Support for compiling protobuf, lex, yacc, swig.
-* Support for custom rules.
-* Support for testing, running multiple tests from command line.
+* Support for compiler selection at build time (different versions of gcc, clang, etc.).
+* Support for compiling protobuf, lex, yacc, and SWIG.
+* Support for custom build rules.
+* Support for running multiple tests from the command line at once.
 * Support for parallel testing (multiple test processes running concurrently).
-* Support for incremental testing (unchanged test programs are automatically skipped).
-* Integration with gperftools for automatic memory leak detection in test programs.
+* Support for incremental testing (tests that don't need to rerun are skipped automatically).
+* Integration with gperftools for automatic memory-leak detection in test programs.
 * Vim syntax highlighting for build scripts.
-* git-style subcommand command line interface.
-* Support for bash command line completion.
-* Written in Python, no compilation needed, direct installation and use.
+* A git-style subcommand command-line interface.
+* Support for bash command-line completion.
+* Written in Python — no compilation needed, install and use directly.
 
-## Problems Avoided
+It completely avoids problems such as:
 
-Completely avoiding the following problems:
+* Header files were updated, but the affected modules were not rebuilt.
+* A dependent library needed updating but was not updated during the build (for example, a dependency in some subdirectory was missed).
 
-* Header files updated, but affected modules were not rebuilt.
-* Dependent libraries needed updates but were not updated during build, such as certain subdirectory dependencies.
+## Version History
+
+Blade has had three major versions so far.
+
+Blade 1 was the early version, aiming to provide a simple, easy-to-use build system; its backend was the [Scons](https://scons.org/) build system.
+
+Blade 2 upgraded the backend to the [Ninja](https://ninja-build.org/) build system, greatly improving performance.
+
+The latest Blade is Blade 3, which aims to be a modern build system. Blade 3 takes the project from a Linux-only, GCC-focused tool to a **three-platform, multi-toolchain** modern build system. Highlights:
+
+* **Three platforms, one BUILD file** — Linux + macOS (clang) + Windows (MSVC), selectable per build via `cc_toolchain_config`.
+* **Native [vcpkg](https://github.com/microsoft/vcpkg) integration** — version-pinned, hermetic C/C++ third-party libraries via `vcpkg#port:lib`, the `maven_jar` analog for C++.
+* **Sanitizers & coverage** — `--sanitizer=address,…` (ASan/UBSan/LSan/TSan/MSan; ASan on MSVC) and `--coverage` (C/C++ / Go / Python HTML reports) on an existing target tree, no BUILD changes.
+* **Profile-guided & link-time optimization** — instrumentation PGO, sample-based PGO / AutoFDO, and LTO / ThinLTO, unified across gcc / clang / MSVC / clang-cl. See [C/C++ Optimization](doc/en/optimization.md).
+* **Cross-platform symbol control** — `export_map` / `linker_script` translated consistently across GCC / clang / MSVC.
+* **Stronger dependency hygiene** — an `unused-deps` check and a static undefined-symbol check join the existing `missing-deps` check.
+* **Modernized codebase** — Python 3.10+ only (Python 2 removed), full type annotations with pyright, comprehensive unit + cross-repo E2E tests.
+
+See the [Upgrade to V3](doc/en/upgrade-to-v3.md) guide for details.
 
 ## Releases
 
@@ -158,29 +147,35 @@ For Blade 2, use the [`v2`](https://github.com/blade-build/blade-build/tree/v2) 
 
 * [Full Documentation](https://blade-build.github.io/docs/en/)
 
-## Contributers
+## Contributors
+
+Blade was open-sourced in 2012 as one of Tencent's earliest open-source projects. It has since seen wide adoption across Tencent's technology stack — advertising platforms, WeChat backend services, game servers, and core infrastructure — and beyond Tencent, companies such as Xiaomi, Baidu, and iQiyi use Blade as well.
+
+This has grown an active contributor community, with many Pull Requests from inside and outside the company. The project was originally hosted on Google Code; after Google Code shut down, it moved to chen3feng's personal repository for continued maintenance and evolution, and finally moved here.
 
 [![Contributers](https://contrib.rocks/image?repo=blade-build/blade-build)](https://github.com/blade-build/blade-build/graphs/contributors)
+
+## Star History
+
+Even if you don't have the time or energy to contribute, stars are warmly welcome.
+
+<a href="https://www.star-history.com/?repos=blade-build%2Fblade-build&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=blade-build/blade-build&type=date&legend=top-left" />
+ </picture>
+</a>
 
 ## Credits
 
 * Blade is inspired by Google's public information about their build system. Here is a reference article from Google's official blog:
-  [build in cloud: how build system works](http://google-engtools.blogspot.com/2011/08/build-in-cloud-how-build-system-works.html).
+  [Build in the Cloud: How the Build System Works](http://google-engtools.blogspot.com/2011/08/build-in-cloud-how-build-system-works.html).
+  Later, in 2015, Google released a partially rewritten version under the new name `bazel`.
 
-  Later in 2015, they released it with a partially rewritten version as the `bazel` open-source build system.
+* Blade generates [Ninja](https://ninja-build.org/) scripts internally to drive the build, so it depends on Ninja at runtime.
+* [Python](http://www.python.org) is a simple yet powerful language, and we like it a lot.
 
-* Blade generates [Ninja](https://ninja-build.org/) script internally, so of course it depends on Ninja.
-* [Python](http://www.python.org) is a powerful and easy-to-used language, we like python.
+Our philosophy: liberate programmers, improve productivity, and use tools to solve non-creative technical problems.
 
-Some libraries open-sourced by Google, such as:
-
-* [glog](https://google.github.io/glog/stable/)
-* [protobuf](https://github.com/protocolbuffers/protobuf)
-* [gtest](https://github.com/google/googletest)
-* [gperftools](https://github.com/gperftools/gperftools)
-
-They are handy and powerful; we have integrated these libraries.
-
-Our philosophy: Liberate programmers, improve productivity. Use tools to solve non-creative technical problems.
-
-Welcome to use and help us improve Blade, we look forward to your contributions.
+Welcome to Blade — we look forward to your contributions.


### PR DESCRIPTION
Reorganizes both top-level READMEs into a clearer narrative and brings the English README in line with the restructured Chinese one.

## New section order (both languages)

Introduction (origin + what-it-is) → Why It Exists → Demo → Features → Version History → Releases → Documentation → Contributors → Star History → Credits.

## Notable changes

- **Introduction**: leads with the 2010 Typhoon origin, then what Blade is, its flexibility / built-in compiler-feature integrations, C++/Unix positioning, the declarative model, and the one-line examples.
- **Version History** (new): Blade 1 (Scons) → Blade 2 (Ninja) → Blade 3, folding in the former top-of-page "Blade 3" highlights.
- **Demo** and **Star History** moved out of the top into their natural places; the adoption / open-source story moved into **Contributors**.
- **Problems Avoided** folded into **Features**.
- zh fixes: `灵活性性` → `灵活性`, `真实的的` → `真实的`, a redundant version-history intro tightened; list markers normalized to `*`.

README-only; section headers are 1:1 parallel between the two files.