### PR TITLE
doc: link the VS Code extension from the install guide

### DIFF
--- a/doc/en/install.md
+++ b/doc/en/install.md
@@ -69,6 +69,12 @@ export PATH=~/bin:$PATH
 - **ccache:** For build acceleration through caching
 - **argcomplete:** Enhanced command-line completion support
 
+## Editor Integration
+
+Install the official **[Blade VS Code extension](https://marketplace.visualstudio.com/items?itemName=blade-build.vscode-blade)** ([source](https://github.com/blade-build/vscode-blade)) for a targets explorer, build/run/test, BUILD-file language features, and clangd-based C/C++ IntelliSense.
+
+See [Editor Support](editor_support.md) for details, including how to get C/C++ IntelliSense via clangd in other editors such as Vim and Emacs.
+
 ## Troubleshooting
 
 ### Common Issues

--- a/doc/zh_CN/install.md
+++ b/doc/zh_CN/install.md
@@ -72,6 +72,12 @@ export PATH=~/bin:$PATH
 - **ccache：** 通过缓存加速构建
 - **argcomplete：** 提供增强的命令行补全
 
+## 编辑器集成
+
+安装官方 **[Blade VS Code 扩展](https://marketplace.visualstudio.com/items?itemName=blade-build.vscode-blade)**（[源码](https://github.com/blade-build/vscode-blade)），即可获得目标浏览器、构建/运行/测试、BUILD 文件语言特性，以及基于 clangd 的 C/C++ 智能感知。
+
+详情，以及在 Vim、Emacs 等其他编辑器中通过 clangd 获得 C/C++ 智能感知的方法，见[编辑器支持](editor_support.md)。
+
 ## 故障排查
 
 ### 常见问题


### PR DESCRIPTION
Adds an **Editor Integration** section to the install guide (English + 简体中文), linking the official [Blade VS Code extension](https://marketplace.visualstudio.com/items?itemName=blade-build.vscode-blade) and the [Editor Support](doc/en/editor_support.md) page (which also covers clangd in other editors).

Docs-only.