### PR TITLE
doc: reorder Build Rules nav

### DIFF
--- a/doc/mkdocs-en.yml
+++ b/doc/mkdocs-en.yml
@@ -49,19 +49,19 @@ nav:
       - misc.md
   - Build Rules:
       - build_rules/cc.md
-      - build_rules/custom_rule.md
-      - build_rules/extension.md
-      - build_rules/gen_rule.md
+      - build_rules/vcpkg.md
       - build_rules/go.md
       - build_rules/idl.md
       - build_rules/java.md
+      - build_rules/scala.md
       - build_rules/lexyacc.md
       - build_rules/package.md
       - build_rules/python.md
-      - build_rules/scala.md
       - build_rules/shell.md
       - build_rules/swig.md
-      - build_rules/vcpkg.md
+      - build_rules/gen_rule.md
+      - build_rules/extension.md
+      - build_rules/custom_rule.md
   - Upgrade:
       - upgrade-to-v3.md
       - upgrade-to-v2.md

--- a/doc/mkdocs-zh.yml
+++ b/doc/mkdocs-zh.yml
@@ -50,19 +50,19 @@ nav:
       - misc.md
   - 构建规则:
       - build_rules/cc.md
-      - build_rules/custom_rule.md
-      - build_rules/extension.md
-      - build_rules/gen_rule.md
+      - build_rules/vcpkg.md
       - build_rules/go.md
       - build_rules/idl.md
       - build_rules/java.md
+      - build_rules/scala.md
       - build_rules/lexyacc.md
       - build_rules/package.md
       - build_rules/python.md
-      - build_rules/scala.md
       - build_rules/shell.md
       - build_rules/swig.md
-      - build_rules/vcpkg.md
+      - build_rules/gen_rule.md
+      - build_rules/extension.md
+      - build_rules/custom_rule.md
   - 升级:
       - upgrade-to-v3.md
       - upgrade-to-v2.md


### PR DESCRIPTION
Reorders the Build Rules section in both MkDocs navs — vcpkg surfaced earlier, gen_rule/extension/custom_rule moved to the end. Nav-only; both sites build clean.