### PR TITLE
doc: fix FAQ nav item hidden behind sidebar footer

### DIFF
--- a/doc/en/css/extra.css
+++ b/doc/en/css/extra.css
@@ -1,0 +1,5 @@
+/* Keep the last navigation entry (e.g. FAQ) clear of the sidebar's fixed
+   footer / version flyout, which otherwise overlaps it on shorter viewports. */
+.wy-menu-vertical {
+  padding-bottom: 4rem;
+}

--- a/doc/mkdocs-en.yml
+++ b/doc/mkdocs-en.yml
@@ -18,6 +18,9 @@ theme:
   name: readthedocs
   highlightjs: true
 
+extra_css:
+  - css/extra.css
+
 markdown_extensions:
   - admonition
   - toc:

--- a/doc/mkdocs-zh.yml
+++ b/doc/mkdocs-zh.yml
@@ -19,6 +19,9 @@ theme:
   highlightjs: true
   language: zh
 
+extra_css:
+  - css/extra.css
+
 markdown_extensions:
   - admonition
   - toc:

--- a/doc/zh_CN/css/extra.css
+++ b/doc/zh_CN/css/extra.css
@@ -1,0 +1,5 @@
+/* Keep the last navigation entry (e.g. FAQ) clear of the sidebar's fixed
+   footer / version flyout, which otherwise overlaps it on shorter viewports. */
+.wy-menu-vertical {
+  padding-bottom: 4rem;
+}


### PR DESCRIPTION
The last nav entry (FAQ) was overlapped by the readthedocs theme's fixed sidebar footer on shorter viewports. Adds a small `extra_css` (bottom padding on `.wy-menu-vertical`) to both en and zh sites.