### PR TITLE
doc(go): document third-party dependencies (modules vs GOPATH)

### DIFF
--- a/doc/en/build_rules/go.md
+++ b/doc/en/build_rules/go.md
@@ -111,6 +111,24 @@ Blade scans the current directory for `.go` files:
 - Otherwise, a `go_library` is created.
 - If `*_test.go` files exist, a `go_test` is created automatically.
 
+## Dependencies
+
+A go target's `deps` lists **other Blade targets** it depends on — `go_library`
+targets and `proto_library` targets that emit Go code. Blade builds those first
+and makes them importable.
+
+How you pull in **third-party packages** (e.g. `github.com/...`) depends on the
+mode configured in `go_config`:
+
+- **Go modules** (`go_module_enabled = True`, recommended): declare third-party
+  packages in your `go.mod` as usual. Blade invokes `go` inside the module
+  directory (`go_module_relpath`), so `go` resolves, downloads, and builds those
+  dependencies — you do **not** list them in Blade `deps`.
+- **GOPATH mode** (the default): packages are resolved from
+  `$go_home/src/<import-path>`. Place the third-party source under, for example,
+  `$go_home/src/github.com/golang/glog`, then either let `go` pick it up from
+  `GOPATH` or build it as its own `go_library` and depend on that target.
+
 ## Using Protobuf with Go
 
 Add a `proto_library` dependency to generate Go protobuf code:

--- a/doc/zh_CN/build_rules/go.md
+++ b/doc/zh_CN/build_rules/go.md
@@ -110,6 +110,20 @@ Blade 会扫描当前目录的 `.go` 文件：
 - 否则创建 `go_library`。
 - 如果有 `*_test.go` 文件，自动创建 `go_test`。
 
+## 依赖
+
+go 目标的 `deps` 列出它所依赖的**其他 Blade 目标**——`go_library` 目标，以及生成
+Go 代码的 `proto_library` 目标。Blade 会先构建它们，并使其可被 import。
+
+如何引入**第三方包**（如 `github.com/...`）取决于 `go_config` 中配置的模式：
+
+- **Go modules**（`go_module_enabled = True`，推荐）：像平常一样在 `go.mod` 中声明
+  第三方包。Blade 会在模块目录（`go_module_relpath`）下调用 `go`，由 `go` 负责解析、
+  下载并构建这些依赖——你**无需**在 Blade 的 `deps` 中列出它们。
+- **GOPATH 模式**（默认）：包从 `$go_home/src/<导入路径>` 解析。把第三方源码放到
+  例如 `$go_home/src/github.com/golang/glog` 下，再让 `go` 从 `GOPATH` 中找到它，
+  或将其构建为独立的 `go_library` 并加以依赖。
+
 ## 与 Protobuf 集成
 
 在 deps 中添加 `proto_library` 即可自动生成 Go protobuf 代码：


### PR DESCRIPTION
Adds a **Dependencies** section to `build_rules/go.md` (en + zh): what a go target's `deps` mean, and how to pull in third-party packages (`github.com/...`) under both **Go modules** (`go_module_enabled`) and **GOPATH** mode.

This closes the documentation gap behind the long-stale #688 ("how to build Go / declare deps / set GOPATH") — Go is now fully supported and documented.

Docs-only.