### PR TITLE
doc: show the VS Code extension demo in the README

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -74,11 +74,15 @@ cc_binary(
 
 这样一来，当库的实现发生变化、或新增、删除依赖时，库的使用方无需同步修改。Blade 会自动维护这层间接依赖；在构建 `my_app` 时，也会自动检查 `foo` 与 `common` 是否需要更新。
 
-## 演示
+## 用户界面
 
 我们看一个真实的演示来感受 Blade 的简洁和高效：
 
 [![asciicast](https://asciinema.org/a/1203812.svg)](https://asciinema.org/a/1203812)
+
+除了命令行，Blade 还提供官方 [VS Code 扩展](https://marketplace.visualstudio.com/items?itemName=blade-build.vscode-blade)，把目标浏览、构建/运行/测试/调试以及 BUILD 文件的语言特性带进编辑器：
+
+[![Blade for VS Code](https://raw.githubusercontent.com/blade-build/vscode-blade/main/assets/demo.gif)](https://marketplace.visualstudio.com/items?itemName=blade-build.vscode-blade)
 
 ## 特点
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,15 @@ cc_binary(
 
 This way, when a library's implementation changes, or dependencies are added or removed, the library's users don't need to change anything in step. Blade automatically maintains this layer of indirect dependencies; when building `my_app`, it also automatically checks whether `foo` and `common` need to be updated.
 
-## Demo
+## User Interface
 
 Let's look at a real demo to get a feel for how concise and efficient Blade is:
 
 [![asciicast](https://asciinema.org/a/1203812.svg)](https://asciinema.org/a/1203812)
+
+Beyond the command line, Blade has an official [VS Code extension](https://marketplace.visualstudio.com/items?itemName=blade-build.vscode-blade) that brings the targets explorer, build/run/test/debug, and BUILD-file language features into the editor:
+
+[![Blade for VS Code](https://raw.githubusercontent.com/blade-build/vscode-blade/main/assets/demo.gif)](https://marketplace.visualstudio.com/items?itemName=blade-build.vscode-blade)
 
 ## Features
 


### PR DESCRIPTION
Improves the demo section of both top-level READMEs:

- Renames **Demo → User Interface** (it now covers both the CLI demo and the editor).
- Embeds the **vscode-blade demo GIF** (from `blade-build/vscode-blade`, clickable → Marketplace) in place of the placeholder.
- Adds the matching **VS Code** subsection to the **English** README, which previously had no extension mention.

README-only; GIF served from the vscode-blade repo's raw URL (HTTP 200).