### PR TITLE
doc: switch the MkDocs site to the Material theme

### DIFF
--- a/doc/en/css/extra.css
+++ b/doc/en/css/extra.css
@@ -1,5 +1,0 @@
-/* Keep the last navigation entry (e.g. FAQ) clear of the sidebar's fixed
-   footer / version flyout, which otherwise overlaps it on shorter viewports. */
-.wy-menu-vertical {
-  padding-bottom: 4rem;
-}

--- a/doc/mkdocs-en.yml
+++ b/doc/mkdocs-en.yml
@@ -1,4 +1,4 @@
-# MkDocs config for the English documentation site (readthedocs theme).
+# MkDocs config for the English documentation site (Material theme).
 # Built and deployed to blade-build.github.io/docs/en/ by .github/workflows.
 # Page titles are taken from each file's H1 (already localized); only the
 # section headers below are spelled out.
@@ -15,18 +15,46 @@ hooks:
   - mkdocs_hooks.py
 
 theme:
-  name: readthedocs
-  highlightjs: true
-
-extra_css:
-  - css/extra.css
+  name: material
+  language: en
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.tabs.link
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
 
 markdown_extensions:
   - admonition
+  - tables
   - toc:
       permalink: true
-  - tables
-  - fenced_code
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.tabbed:
+      alternate_style: true
 
 nav:
   - README.md

--- a/doc/mkdocs-zh.yml
+++ b/doc/mkdocs-zh.yml
@@ -1,4 +1,4 @@
-# MkDocs config for the Chinese documentation site (readthedocs theme).
+# MkDocs config for the Chinese documentation site (Material theme).
 # Built and deployed to blade-build.github.io/docs/zh/ by .github/workflows.
 # Page titles come from each file's H1 (already in Chinese); only the section
 # headers below are spelled out.
@@ -15,19 +15,46 @@ hooks:
   - mkdocs_hooks.py
 
 theme:
-  name: readthedocs
-  highlightjs: true
+  name: material
   language: zh
-
-extra_css:
-  - css/extra.css
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.tabs.link
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: 切换到深色模式
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: 切换到浅色模式
 
 markdown_extensions:
   - admonition
+  - tables
   - toc:
       permalink: true
-  - tables
-  - fenced_code
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.tabbed:
+      alternate_style: true
 
 nav:
   - README.md

--- a/doc/zh_CN/css/extra.css
+++ b/doc/zh_CN/css/extra.css
@@ -1,5 +1,0 @@
-/* Keep the last navigation entry (e.g. FAQ) clear of the sidebar's fixed
-   footer / version flyout, which otherwise overlaps it on shorter viewports. */
-.wy-menu-vertical {
-  padding-bottom: 4rem;
-}


### PR DESCRIPTION
Switches the docs site from the built-in **readthedocs** theme to **Material for MkDocs** (better search, dark mode, navigation, mobile).

- `mkdocs-{en,zh}.yml`: `theme: material` with a light/dark palette toggle, navigation features, and `pymdownx` extensions (details/superfences/tabbed/highlight).
- Removes the readthedocs-only `extra.css` FAQ-padding hack — Material handles long navs natively.
- Nav and content markdown unchanged.

Requires `mkdocs-material` in the build pipeline — the github.io **Build Docs** Action was updated to `pip install mkdocs-material` (backward-compatible). After this merges, a Build Docs run publishes the Material site to judge live; trivially revertible if we don't like it.

Docs-config only.