### PR TITLE
go: modules-only foundation (#1405 phase 1)

### DIFF
--- a/doc/en/build_rules/go.md
+++ b/doc/en/build_rules/go.md
@@ -116,23 +116,25 @@ Blade scans the current directory for `.go` files:
 - Otherwise, a `go_library` is created.
 - If `*_test.go` files exist, a `go_test` is created automatically.
 
+The generated targets are named after `name`: the `go_binary`/`go_library` takes
+`name`, and the auto-created test is `<name>_test`.
+
 ## Dependencies
 
-A go target's `deps` lists **other Blade targets** it depends on — `go_library`
-targets and `proto_library` targets that emit Go code. Blade builds those first
-and makes them importable.
+A go target's `deps` lists **other Blade targets** it must be built with — other
+`go_library` targets and `proto_library` targets that emit Go code. Blade builds
+those first.
 
-How you pull in **third-party packages** (e.g. `github.com/...`) depends on the
-mode configured in `go_config`:
+Within one module you generally **don't need to declare Go→Go `deps`**: `go build`
+resolves intra-module imports from the source itself. Declare a dep when it
+crosses a language/build boundary Blade must order — a `proto_library` (generated
+code) or a `cc_library` (cgo) — or when you want visibility / dependency
+governance on it.
 
-- **Go modules** (`go_module_enabled = True`, recommended): declare third-party
-  packages in your `go.mod` as usual. Blade invokes `go` inside the module
-  directory (`go_module_relpath`), so `go` resolves, downloads, and builds those
-  dependencies — you do **not** list them in Blade `deps`.
-- **GOPATH mode** (the default): packages are resolved from
-  `$go_home/src/<import-path>`. Place the third-party source under, for example,
-  `$go_home/src/github.com/golang/glog`, then either let `go` pick it up from
-  `GOPATH` or build it as its own `go_library` and depend on that target.
+Pull in **third-party packages** (e.g. `github.com/...`) the normal Go way:
+declare them in `go.mod` (or a `go.work` for multiple local modules). Blade
+delegates to `go`, which resolves, downloads, and builds them — you do **not**
+list them in Blade `deps`.
 
 ## Using Protobuf with Go
 

--- a/doc/en/build_rules/go.md
+++ b/doc/en/build_rules/go.md
@@ -9,20 +9,16 @@ Before using go targets, configure the Go toolchain in `BLADE_ROOT`:
 
 ```python
 go_config(
-    go = '/usr/local/go/bin/go',
-    go_home = '/usr/local/go',
+    go = '/usr/local/go/bin/go',   # required
+    go_home = '/usr/local/go',     # GOPATH / build cache; optional (empty = go default)
 )
 ```
 
-When Go modules are enabled, set `go_module_enabled = True`:
-
-```python
-go_config(
-    go_home = '/usr/local/go',
-    go_module_enabled = True,
-    go_module_relpath = '',
-)
-```
+Blade builds Go in **module mode only**: each target's package must sit under a
+`go.mod` (the nearest one at or above the target's directory is its module).
+GOPATH-mode projects are not supported. A workspace may contain multiple modules;
+for local cross-module imports use a [`go.work`](https://go.dev/ref/mod#workspaces)
+file or `replace` directives, which `go` resolves.
 
 ## go_library
 
@@ -49,7 +45,12 @@ Attributes:
 - `visibility`: Visibility specification.
 - `tags`: Build tags.
 
-Output: a `.a` archive file placed under `$go_home/pkg/$GOOS_$GOARCH/`.
+A `go_library` has **no linkable artifact** (the Go build cache replaced the
+GOPATH archive). Building one compile-checks the package (`go build`) and emits a
+stamp; consumers depend on it for ordering and visibility and let `go` recompile
+the package. A `go_library` is optional — a pure-Go package with no cross-language
+dependency needs no Blade target, since `go build` of a consuming `go_binary`/
+`go_test` pulls it in.
 
 ## go_binary
 
@@ -68,6 +69,10 @@ go_binary(
 ```
 
 Attributes are the same as `go_library`.
+
+A `go_binary` is built from its `srcs` in **file mode** (`go build <srcs...>`), not
+by whole package. This means a single directory holding several `main` files can
+be split into separate `go_binary` targets — one per program.
 
 ## go_test
 

--- a/doc/zh_CN/build_rules/go.md
+++ b/doc/zh_CN/build_rules/go.md
@@ -8,20 +8,15 @@ Blade 通过 `go_library`、`go_binary`、`go_test` 构建 Go 程序，另外提
 
 ```python
 go_config(
-    go = '/usr/local/go/bin/go',
-    go_home = '/usr/local/go',
+    go = '/usr/local/go/bin/go',   # 必填
+    go_home = '/usr/local/go',     # GOPATH / 构建缓存；可选（留空则用 go 默认值）
 )
 ```
 
-如果启用了 Go modules，设置 `go_module_enabled = True`：
-
-```python
-go_config(
-    go_home = '/usr/local/go',
-    go_module_enabled = True,
-    go_module_relpath = '',
-)
-```
+Blade 只支持 **module 模式**：每个目标的包必须位于某个 `go.mod` 之下（其上层最近的
+`go.mod` 即为该目标所属模块），不再支持 GOPATH 模式。一个工作区可以包含多个模块；
+若模块间存在本地互相 import，请使用 [`go.work`](https://go.dev/ref/mod#workspaces)
+或 `replace` 指令，由 `go` 负责解析。
 
 ## go_library
 
@@ -48,7 +43,10 @@ go_library(
 - `visibility`：可见性控制。
 - `tags`：构建标记。
 
-输出：`.a` 归档文件，位于 `$go_home/pkg/$GOOS_$GOARCH/`。
+`go_library` **没有可链接的产物**（Go 的构建缓存取代了 GOPATH 归档）。构建它会对该
+包做一次编译检查（`go build`）并生成一个 stamp；使用方依赖它以获得构建顺序与可见性
+约束，实际编译仍交给 `go`。`go_library` 是**可选**的——纯 Go、且不跨语言依赖的包无需
+Blade 目标，因为使用它的 `go_binary`/`go_test` 在 `go build` 时会自动带上它。
 
 ## go_binary
 
@@ -67,6 +65,10 @@ go_binary(
 ```
 
 参数与 `go_library` 相同。
+
+`go_binary` 以 **文件模式**（`go build <srcs...>`）从其 `srcs` 构建，而非按整个包构建。
+因此，一个目录下若有多个 `main` 文件，可以拆分为各自独立的 `go_binary` 目标——每个程序
+一个。
 
 ## go_test
 

--- a/doc/zh_CN/build_rules/go.md
+++ b/doc/zh_CN/build_rules/go.md
@@ -112,19 +112,22 @@ Blade 会扫描当前目录的 `.go` 文件：
 - 否则创建 `go_library`。
 - 如果有 `*_test.go` 文件，自动创建 `go_test`。
 
+生成的目标名基于 `name`：`go_binary` / `go_library` 使用 `name`，自动创建的测试名为
+`<name>_test`。
+
 ## 依赖
 
-go 目标的 `deps` 列出它所依赖的**其他 Blade 目标**——`go_library` 目标，以及生成
-Go 代码的 `proto_library` 目标。Blade 会先构建它们，并使其可被 import。
+go 目标的 `deps` 列出它构建时所需的**其他 Blade 目标**——其他 `go_library`，以及生成
+Go 代码的 `proto_library`。Blade 会先构建它们。
 
-如何引入**第三方包**（如 `github.com/...`）取决于 `go_config` 中配置的模式：
+在同一个模块内，通常**无需声明 Go→Go 的 `deps`**：`go build` 会从源码自身解析模块内的
+import。只有当依赖跨越 Blade 需要排序的语言 / 构建边界时才需要声明——例如
+`proto_library`（生成代码）或 `cc_library`（cgo）——或者你希望对它施加可见性 / 依赖
+治理时。
 
-- **Go modules**（`go_module_enabled = True`，推荐）：像平常一样在 `go.mod` 中声明
-  第三方包。Blade 会在模块目录（`go_module_relpath`）下调用 `go`，由 `go` 负责解析、
-  下载并构建这些依赖——你**无需**在 Blade 的 `deps` 中列出它们。
-- **GOPATH 模式**（默认）：包从 `$go_home/src/<导入路径>` 解析。把第三方源码放到
-  例如 `$go_home/src/github.com/golang/glog` 下，再让 `go` 从 `GOPATH` 中找到它，
-  或将其构建为独立的 `go_library` 并加以依赖。
+引入**第三方包**（如 `github.com/...`）按 Go 的常规方式：在 `go.mod`（多个本地模块时用
+`go.work`）中声明，由 Blade 交给 `go` 解析、下载并构建——你**无需**在 Blade `deps`
+中列出它们。
 
 ## 与 Protobuf 集成
 

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -317,11 +317,10 @@ _CONFIG_TEMPLATE = {
     'go_config': {
         '__help__': 'Golang Configuration',
         'go': '',
-        'go_home': os.path.expandvars('$HOME/go'),  # GOPATH
-        # enable go module for explicit use
-        'go_module_enabled': os.environ.get("GO111MODULE") == "on",
-        # onetree repository go module doesn't work in repository root
-        'go_module_relpath': os.environ.get("go_module_relpath"),
+        # GOPATH -- the Go module/build cache location. Blade builds Go in
+        # module mode only (a go.mod at the module root); this is not a source
+        # root. Leave empty to use the go toolchain's default GOPATH.
+        'go_home': os.path.expandvars('$HOME/go'),
     },
 
     'proto_library_config': {

--- a/src/blade/go_targets.py
+++ b/src/blade/go_targets.py
@@ -5,15 +5,29 @@
 # Date:   July 12, 2016
 
 """
-Implement go_library, go_binary and go_test. In addition, provide
-a simple wrapper function go_package wrapping all sorts of go tar-
-gets totally.
+Implement go_library, go_binary and go_test, plus the go_package wrapper.
+
+Go modules only (GOPATH mode is not supported). Compilation is delegated to the
+`go` toolchain; Blade owns the dependency graph and ordering:
+
+  * go_binary   -- built from its declared srcs in **file mode**
+                   (`go build <srcs...>`), so a directory with multiple `main`
+                   files can be split into separate binaries.
+  * go_test     -- `go test -c` over its package directory.
+  * go_library  -- package-scoped **compile-check** (`go build <pkg>`); it has
+                   no linkable artifact (the Go build cache replaced the GOPATH
+                   archive), only a stamp file. It exists as a dependency-graph
+                   node (ordering / visibility) and an early per-package check;
+                   consumers take the stamp as an order-only dep and let `go`
+                   recompile the package (a build-cache hit).
+
+Each target is compiled in the context of its owning module -- the nearest
+`go.mod` at or above the target's directory -- via `go -C <module_dir>`.
 """
 
 
 import os
 import re
-import textwrap
 
 from blade import build_manager
 from blade import build_rules
@@ -23,17 +37,32 @@ from blade import rule_registry
 from blade.blade_types import StrOrListOpt
 from blade.ninja_rule import NinjaRule
 from blade.target import Target
-from blade.util import run_command, var_to_list, var_to_list_or_none
+from blade.util import var_to_list, var_to_list_or_none
 
 
 _package_re = re.compile(r'^\s*package\s+(\w+)\s*$')
 
 
-class GoTarget(Target):
-    """This class is the base of all go targets."""
+def _find_module_dir(start):
+    """Find the owning module directory: the nearest ancestor of `start`
+    (a workspace-relative dir, '' == workspace root) that contains a `go.mod`.
 
-    _go_os = None
-    _go_arch = None
+    Existence is checked relative to the current directory, which is the
+    workspace root during target analysis. Returns the workspace-relative module
+    directory ('' for the root module) or None if no `go.mod` is found.
+    """
+    cur = start
+    while True:
+        gomod = os.path.join(cur, 'go.mod') if cur else 'go.mod'
+        if os.path.exists(gomod):
+            return cur
+        if not cur:
+            return None
+        cur = os.path.dirname(cur)
+
+
+class GoTarget(Target):
+    """Base of all go targets."""
 
     def __init__(self,
                  name: str | None,
@@ -44,9 +73,6 @@ class GoTarget(Target):
                  visibility: StrOrListOpt,
                  tags: StrOrListOpt,
                  kwargs: dict[str, object]):
-        """Init the go target."""
-        # Normalize BUILD-file-friendly StrOrList unions to list[str] once,
-        # right at the top; Target.__init__ below sees layer-2 shapes.
         srcs = var_to_list(srcs)
         deps = var_to_list(deps)
         tags = var_to_list(tags)
@@ -63,224 +89,143 @@ class GoTarget(Target):
                 tags=tags,
                 kwargs=kwargs)
 
-        self._set_go_package()
-        self._init_go_environment()
         self.attr['extra_goflags'] = extra_goflags
         self._add_tags('lang:go')
+        self._resolve_module()
 
-    def _set_go_package(self):
-        """
-        Set the package path from the source path inside the workspace
-        specified by GOPATH. All the go sources of the same package
-        should be in the same directory.
+    def _resolve_module(self):
+        """Locate the owning Go module and compute module-relative paths.
+
+        Go sources of one package must share a directory; the module is the
+        nearest `go.mod` at or above it.
         """
         srcs = [self._source_file_path(s) for s in self.srcs]
         dirs = {os.path.dirname(s) for s in srcs}
         if len(dirs) != 1:
-            self.error('Go sources belonging to the same package should be in the same '
+            self.error('Go sources of the same target must be in the same '
                        'directory. Sources: %s' % ', '.join(self.srcs))
+            self._module_dir = '.'
+            self._pkg = '.'
             return
-        go_home = config.get_item('go_config', 'go_home')
-        go_module_enabled = config.get_item('go_config', 'go_module_enabled')
-        go_module_relpath = config.get_item('go_config', 'go_module_relpath')
-        if go_module_enabled and not go_module_relpath:
-            self.attr['go_package'] = os.path.join("./", self.path)
-        else:
-            self.attr['go_package'] = os.path.relpath(self.path, os.path.join(go_home, 'src'))
-
-    def _init_go_environment(self):
-        if GoTarget._go_os is None and GoTarget._go_arch is None:
-            go = config.get_item('go_config', 'go')
-            returncode, stdout, stderr = run_command([go, 'env'])
-            if returncode != 0:
-                self.error('Failed to initialize go environment: %s' % stderr)
-                return
-            for line in stdout.splitlines():
-                if line.startswith('GOOS='):
-                    GoTarget._go_os = line.replace('GOOS=', '').strip('"')
-                elif line.startswith('GOARCH='):
-                    GoTarget._go_arch = line.replace('GOARCH=', '').strip('"')
+        module_dir = _find_module_dir(self.path)
+        if module_dir is None:
+            self.error(
+                'No go.mod found at or above "%s". Blade builds Go in module '
+                'mode only; add a go.mod at the module root.' % (self.path or '.'))
+            module_dir = ''
+        # `-C` dir and paths back into the module, all workspace-relative
+        # (ninja/analysis run from the workspace root).
+        self._module_dir = module_dir or '.'
+        pkg_rel = os.path.relpath(self.path or '.', module_dir or '.')
+        self._pkg = '.' if pkg_rel == '.' else './' + pkg_rel
+        # module-relative source files, for file-mode `go build`
+        self._go_files = ' '.join(
+            os.path.relpath(s, module_dir or '.') for s in srcs)
+        # go.mod / go.sum as build inputs (workspace-relative)
+        self._module_files = []
+        for f in ('go.mod', 'go.sum'):
+            p = os.path.join(module_dir, f) if module_dir else f
+            if os.path.exists(p):
+                self._module_files.append(p)
 
     def _expand_deps_generation(self):
         build_targets = self.blade.get_build_targets()
         assert self.expanded_deps is not None, 'expanded_deps not expanded'
         for dep in self.expanded_deps:
-            d = build_targets[dep]
-            d.attr['generate_go'] = True
+            build_targets[dep].attr['generate_go'] = True
 
-    def _go_dependencies(self):
+    def _go_implicit_deps(self):
+        """Ninja implicit deps: own srcs, module files, and dep outputs.
+
+        Depending on a dep's output (a go_library stamp, or a proto_library's
+        generated `.pb.go` files) gives both ordering and stamp-chain
+        incrementality without declaring Go->Go imports by hand.
+        """
         targets = self.blade.get_build_targets()
-        srcs = [self._source_file_path(s) for s in self.srcs]
-        implicit_deps = []
+        deps = list(self._module_files)
+        deps += [self._source_file_path(s) for s in self.srcs]
         for key in self.deps:
             path = targets[key]._get_target_file('gopkg')
             if path:
-                # There are two cases for go package(gopkg)
-                #
-                #   - gopkg produced by another go_library,
-                #     the target file here is a path to the
-                #     generated lib
-                #
-                #   - gopkg produced by a proto_library, the
-                #     target file is a list of pb.go files
-                implicit_deps += var_to_list(path)
-        return srcs + implicit_deps
+                deps += var_to_list(path)
+        return deps
 
-    def _go_target_path(self):
-        """Return the full path of generate target file"""
-        return self._target_file_path(self.name)
+    def _go_variables(self):
+        return {
+            'module_dir': self._module_dir,
+            'package': self._pkg,
+            'gofiles': self._go_files,
+            'extra_goflags': self.attr['extra_goflags'],
+        }
 
     def generate(self):
-        implicit_deps = self._go_dependencies()
-        output = self._go_target_path()
-        variables = {'package': self.attr['go_package']}
-        if self.attr['extra_goflags']:
-            variables['extra_goflags'] = self.attr['extra_goflags']
+        output = self._target_file_path(self.name)
         self.generate_build(self.attr['go_rule'], output,
-                            implicit_deps=implicit_deps,
-                            variables=variables)
+                            implicit_deps=self._go_implicit_deps(),
+                            variables=self._go_variables())
         label = self.attr.get('go_label')
         if label:
             self._add_target_file(label, output)
 
 
 class GoLibrary(GoTarget):
-    """GoLibrary generates build rules for a go package."""
+    """A Go package built as a compile-check (no artifact, just a stamp)."""
 
-    def __init__(self,
-                 name: str | None,
-                 srcs: StrOrListOpt,
-                 deps: StrOrListOpt,
-                 visibility: StrOrListOpt,
-                 tags: StrOrListOpt,
-                 extra_goflags: StrOrListOpt,
-                 kwargs: dict[str, object]):
+    def __init__(self, name, srcs, deps, visibility, tags, extra_goflags, kwargs):
         super().__init__(
-                name=name,
-                type='go_library',
-                srcs=srcs,
-                deps=deps,
-                visibility=visibility,
-                tags=tags,
-                extra_goflags=extra_goflags,
+                name=name, type='go_library', srcs=srcs, deps=deps,
+                visibility=visibility, tags=tags, extra_goflags=extra_goflags,
                 kwargs=kwargs)
-        self.attr['go_rule'] = 'gopackage'
+        self.attr['go_rule'] = 'golibrary'
         self.attr['go_label'] = 'gopkg'
         self._add_tags('type:library')
 
-    def _go_target_path(self):  # Override
-        """Return package object path according to the standard go directory layout."""
-        go_home = config.get_item('go_config', 'go_home')
-        return os.path.join(go_home, 'pkg',
-                            f'{GoTarget._go_os}_{GoTarget._go_arch}',
-                            '%s.a' % self.attr['go_package'])
-
 
 class GoBinary(GoTarget):
-    """GoBinary generates build rules for a go command executable."""
+    """A Go executable, built from its srcs in file mode."""
 
-    def __init__(self,
-                 name: str | None,
-                 srcs: StrOrListOpt,
-                 deps: StrOrListOpt,
-                 visibility: StrOrListOpt,
-                 tags: StrOrListOpt,
-                 extra_goflags: StrOrListOpt,
-                 kwargs: dict[str, object]):
+    def __init__(self, name, srcs, deps, visibility, tags, extra_goflags, kwargs):
         super().__init__(
-                name=name,
-                type='go_binary',
-                srcs=srcs,
-                deps=deps,
-                visibility=visibility,
-                tags=tags,
-                extra_goflags=extra_goflags,
+                name=name, type='go_binary', srcs=srcs, deps=deps,
+                visibility=visibility, tags=tags, extra_goflags=extra_goflags,
                 kwargs=kwargs)
-        self.attr['go_rule'] = 'gocommand'
+        self.attr['go_rule'] = 'gobinary'
         self.attr['go_label'] = 'bin'
         self._add_tags('type:binary')
 
 
 class GoTest(GoTarget):
-    """GoTest generates build rules for a go test binary."""
+    """A Go test binary, built with `go test -c` over its package."""
 
-    def __init__(self,
-                 name: str | None,
-                 srcs: StrOrListOpt,
-                 deps: StrOrListOpt,
-                 visibility: StrOrListOpt,
-                 tags: StrOrListOpt,
-                 testdata: StrOrListOpt,
-                 extra_goflags: StrOrListOpt,
-                 kwargs: dict[str, object]):
+    def __init__(self, name, srcs, deps, visibility, tags, testdata, extra_goflags, kwargs):
         super().__init__(
-                name=name,
-                type='go_test',
-                srcs=srcs,
-                deps=deps,
-                visibility=visibility,
-                tags=tags,
-                extra_goflags=extra_goflags,
+                name=name, type='go_test', srcs=srcs, deps=deps,
+                visibility=visibility, tags=tags, extra_goflags=extra_goflags,
                 kwargs=kwargs)
         self.attr['go_rule'] = 'gotest'
         self.attr['testdata'] = var_to_list(testdata)
         self._add_tags('type:test')
 
 
-def go_library(
-        name: str,
-        srcs: StrOrListOpt,
-        deps: StrOrListOpt = None,
-        extra_goflags: StrOrListOpt = None,
-        visibility: StrOrListOpt = None,
-        tags: StrOrListOpt = None,
-        **kwargs: object):
+def go_library(name, srcs, deps=None, extra_goflags=None, visibility=None,
+               tags=None, **kwargs):
     build_manager.instance.register_target(GoLibrary(
-        name=name,
-        srcs=srcs,
-        deps=deps,
-        visibility=visibility,
-        tags=tags,
-        extra_goflags=extra_goflags,
-        kwargs=kwargs))
+        name=name, srcs=srcs, deps=deps, visibility=visibility, tags=tags,
+        extra_goflags=extra_goflags, kwargs=kwargs))
 
 
-def go_binary(
-        name: str,
-        srcs: StrOrListOpt,
-        deps: StrOrListOpt = None,
-        visibility: StrOrListOpt = None,
-        tags: StrOrListOpt = None,
-        extra_goflags: StrOrListOpt = None,
-        **kwargs: object):
+def go_binary(name, srcs, deps=None, visibility=None, tags=None,
+              extra_goflags=None, **kwargs):
     build_manager.instance.register_target(GoBinary(
-            name=name,
-            srcs=srcs,
-            deps=deps,
-            extra_goflags=extra_goflags,
-            visibility=visibility,
-            tags=tags,
-            kwargs=kwargs))
+        name=name, srcs=srcs, deps=deps, extra_goflags=extra_goflags,
+        visibility=visibility, tags=tags, kwargs=kwargs))
 
 
-def go_test(
-        name: str,
-        srcs: StrOrListOpt,
-        deps: StrOrListOpt = None,
-        visibility: StrOrListOpt = None,
-        tags: StrOrListOpt = None,
-        testdata: StrOrListOpt = None,
-        extra_goflags: StrOrListOpt = None,
-        **kwargs: object):
+def go_test(name, srcs, deps=None, visibility=None, tags=None, testdata=None,
+            extra_goflags=None, **kwargs):
     build_manager.instance.register_target(GoTest(
-            name=name,
-            srcs=srcs,
-            deps=deps,
-            visibility=visibility,
-            tags=tags,
-            testdata=testdata,
-            extra_goflags=extra_goflags,
-            kwargs=kwargs))
+        name=name, srcs=srcs, deps=deps, visibility=visibility, tags=tags,
+        testdata=testdata, extra_goflags=extra_goflags, kwargs=kwargs))
 
 
 def find_go_srcs(path):
@@ -305,24 +250,15 @@ def extract_go_package(path):
     raise Exception('Failed to find package in %s' % path)
 
 
-def go_package(
-        name,
-        deps=None,
-        testdata=None,
-        visibility=None,
-        extra_goflags=None):
+def go_package(name, deps=None, testdata=None, visibility=None, extra_goflags=None):
     path = build_manager.instance.get_current_source_path()
     srcs, tests = find_go_srcs(path)
     if not srcs and not tests:
         console.error('Empty go sources in %s' % path)
         return
     if srcs:
-        main = False
-        for src in srcs:
-            package = extract_go_package(os.path.join(path, src))
-            if package == 'main':
-                main = True
-                break
+        main = any(extract_go_package(os.path.join(path, src)) == 'main'
+                   for src in srcs)
         if main:
             go_binary(name=name, srcs=srcs, deps=deps, visibility=visibility,
                       extra_goflags=extra_goflags)
@@ -330,11 +266,8 @@ def go_package(
             go_library(name=name, srcs=srcs, deps=deps, visibility=visibility,
                        extra_goflags=extra_goflags)
     if tests:
-        go_test(name='%s_test' % name,
-                srcs=tests,
-                deps=deps,
-                visibility=visibility,
-                testdata=testdata,
+        go_test(name='%s_test' % name, srcs=tests, deps=deps,
+                visibility=visibility, testdata=testdata,
                 extra_goflags=extra_goflags)
 
 
@@ -345,51 +278,35 @@ build_rules.register_function(go_package)
 
 
 def _generate_go_rules(ctx):
-    """Ninja rules for go_library / go_binary / go_test.
+    """Ninja rules for go_library / go_binary / go_test (modules only).
 
-    No-op unless go is configured (go_home + go), matching the original
-    behaviour of emitting nothing when there is no go toolchain.
+    No-op unless `go` is configured. Each rule compiles in the target's module
+    via `go -C ${module_dir}`; outputs are written with an absolute path
+    (`$PWD/${out}`) since `-C` also reinterprets `-o`. No serialization pool --
+    the Go build cache is concurrency-safe.
     """
-    go_home = config.get_item('go_config', 'go_home')
     go = config.get_item('go_config', 'go')
-    go_module_enabled = config.get_item('go_config', 'go_module_enabled')
-    go_module_relpath = config.get_item('go_config', 'go_module_relpath')
-    if not (go_home and go):
+    if not go:
         return
-    go_pool = 'golang_pool'
-    ctx.add_line(textwrap.dedent('''\
-            pool %s
-              depth = 1
-            ''') % go_pool)
-    go_path = os.path.normpath(os.path.abspath(go_home))
-    out_relative = ""
-    if go_module_enabled:
-        prefix = go
-        if go_module_relpath:
-            relative_prefix = os.path.relpath(prefix, go_module_relpath)
-            prefix = f"cd {go_module_relpath} && {relative_prefix}"
-            # add slash to the end of the relpath
-            out_relative = os.path.join(os.path.relpath("./", go_module_relpath), "")
-    else:
-        prefix = f'GOPATH={go_path} {go}'
+    go_home = config.get_item('go_config', 'go_home')
+    goenv = 'GOPATH=%s ' % os.path.abspath(go_home) if go_home else ''
+    gocover = ' -cover -covermode=count' if getattr(ctx.options, 'coverage', False) else ''
+
     ctx.emit_rule(NinjaRule(
-        name='gopackage',
-        command='%s install ${extra_goflags} ${package}' % prefix,
-        description='GO INSTALL ${package}',
-        pool=go_pool))
+        name='golibrary',
+        command=f'{goenv}{go} -C ${{module_dir}} build ${{extra_goflags}} ${{package}} '
+                f'&& touch ${{out}}',
+        description='GO BUILD ${package}'))
     ctx.emit_rule(NinjaRule(
-        name='gocommand',
-        command=f'{prefix} build -o {out_relative}${{out}} ${{extra_goflags}} ${{package}}',
-        description='GO BUILD ${package}',
-        pool=go_pool))
-    # Under --coverage, build the test binary with coverage instrumentation;
-    # the test runner then passes -test.coverprofile to collect a profile.
-    gotest_cover = ' -cover -covermode=count' if getattr(ctx.options, 'coverage', False) else ''
+        name='gobinary',
+        command=f'{goenv}{go} -C ${{module_dir}} build ${{extra_goflags}} '
+                f'-o $$PWD/${{out}} ${{gofiles}}',
+        description='GO LINK ${out}'))
     ctx.emit_rule(NinjaRule(
         name='gotest',
-        command=f'{prefix} test -c{gotest_cover} -o {out_relative}${{out}} ${{extra_goflags}} ${{package}}',
-        description='GO TEST ${package}',
-        pool=go_pool))
+        command=f'{goenv}{go} -C ${{module_dir}} test -c{gocover} ${{extra_goflags}} '
+                f'-o $$PWD/${{out}} ${{package}}',
+        description='GO TEST ${package}'))
 
 
 rule_registry.register_rule_provider(

--- a/src/blade/init_command.py
+++ b/src/blade/init_command.py
@@ -71,8 +71,8 @@ _LANG_BLOCKS = {
 ''',
     'go': '''\
 # go_config(
-#     # go = 'go',                # the go command
-#     go_module_enabled = True,
+#     go = 'go',                  # the go command (required for go targets)
+#     # go_home = '',             # GOPATH / build cache; empty = go default
 # )
 ''',
     'python': '''\

--- a/src/blade/proto_library_target.py
+++ b/src/blade/proto_library_target.py
@@ -754,14 +754,12 @@ def _generate_proto_rules(ctx):
     protoc_go_plugin = proto_config['protoc_go_plugin']
     if protoc_go_plugin:
         go_home = config.get_item('go_config', 'go_home')
-        go_module_enabled = config.get_item('go_config', 'go_module_enabled')
-        go_module_relpath = config.get_item('go_config', 'go_module_relpath')
         if not go_home:
             console.fatal('"go_config.go_home" is not configured')
-        if go_module_enabled and not go_module_relpath:
-            outdir = proto_config['protobuf_go_path']
-        else:
-            outdir = os.path.join(go_home, 'src')
+        # Modules-only: emit into the configured module-relative go path.
+        # (A full proto->Go rework -- generate in-tree, no GOPATH -- is tracked
+        # separately; see the Go modernization issue.)
+        outdir = proto_config['protobuf_go_path']
         subplugins = proto_config['protoc_go_subplugins']
         if subplugins:
             go_out = 'plugins={}:{}'.format('+'.join(subplugins), outdir)

--- a/src/test/go_build_test.py
+++ b/src/test/go_build_test.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026 Tencent Inc.
+# All rights reserved.
+#
+# Author: CHEN Feng <chen3feng@gmail.com>
+
+"""Integration tests for the modules-only Go rules (#1405 foundation).
+
+Each test stands up a throwaway Go-module workspace and drives the real `blade`
+binary, exercising:
+  * go_binary built in file mode from its srcs;
+  * multiple `main` files in one directory built as separate go_binary targets
+    (impossible under package-mode building);
+  * go_library compile-check (stamp) consumed by a go_binary that imports it;
+  * per-target module discovery when the go.mod lives in a subdirectory.
+
+Skipped when the go toolchain is unavailable.
+"""
+
+import glob
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+@unittest.skipUnless(shutil.which('go'), 'go toolchain not available')
+class GoBuildTestBase(unittest.TestCase):
+    def setUp(self):
+        self.cur_dir = os.getcwd()
+        here = os.path.dirname(os.path.abspath(__file__))
+        self.blade = os.path.join(here, '..', '..', 'blade')
+        self.work = tempfile.mkdtemp(prefix='blade_go_build_')
+        go = shutil.which('go')
+        self._write('BLADE_ROOT',
+                    "go_config(go='%s', go_home='%s')\n"
+                    % (go, os.path.join(self.work, 'gopath')))
+
+    def tearDown(self):
+        os.chdir(self.cur_dir)
+        shutil.rmtree(self.work, ignore_errors=True)
+
+    def _write(self, rel, text):
+        path = os.path.join(self.work, rel)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(text)
+
+    def _blade(self, *args):
+        os.chdir(self.work)
+        return subprocess.run(
+            [self.blade, *args],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
+
+    def _built(self, rel):
+        """A file rel-path under any build_* dir, or None."""
+        hits = glob.glob(os.path.join(self.work, 'build*', rel))
+        return hits[0] if hits else None
+
+
+class TestGoBinary(GoBuildTestBase):
+    def testFileModeBinaryBuildsAndRuns(self):
+        self._write('go.mod', 'module app\n\ngo 1.20\n')
+        self._write('hello/hello.go', textwrap.dedent('''\
+            package main
+            import "fmt"
+            func main() { fmt.Println("hello-blade-go") }
+            '''))
+        self._write('hello/BUILD', "go_binary(name='hello', srcs=['hello.go'])\n")
+        p = self._blade('build', 'hello:hello')
+        self.assertEqual(p.returncode, 0, p.stdout)
+        binpath = self._built('hello/hello')
+        self.assertIsNotNone(binpath, 'binary not built:\n%s' % p.stdout)
+        out = subprocess.run([binpath], stdout=subprocess.PIPE, encoding='utf-8')
+        self.assertEqual(out.stdout.strip(), 'hello-blade-go')
+
+    def testMultipleMainsInOneDir(self):
+        # Two files, each `package main` with its own main() -- one go_binary
+        # each. Package-mode building would fail ("multiple definitions of
+        # main"); file-mode builds each independently.
+        self._write('go.mod', 'module tools\n\ngo 1.20\n')
+        self._write('cmd/foo.go', textwrap.dedent('''\
+            package main
+            import "fmt"
+            func main() { fmt.Println("foo") }
+            '''))
+        self._write('cmd/bar.go', textwrap.dedent('''\
+            package main
+            import "fmt"
+            func main() { fmt.Println("bar") }
+            '''))
+        self._write('cmd/BUILD', textwrap.dedent('''\
+            go_binary(name='foo', srcs=['foo.go'])
+            go_binary(name='bar', srcs=['bar.go'])
+            '''))
+        p = self._blade('build', 'cmd:foo', 'cmd:bar')
+        self.assertEqual(p.returncode, 0, p.stdout)
+        for name, want in (('foo', 'foo'), ('bar', 'bar')):
+            path = self._built('cmd/%s' % name)
+            self.assertIsNotNone(path, 'binary %s not built:\n%s' % (name, p.stdout))
+            out = subprocess.run([path], stdout=subprocess.PIPE, encoding='utf-8')
+            self.assertEqual(out.stdout.strip(), want)
+
+
+class TestGoLibrary(GoBuildTestBase):
+    def testLibraryStampAndBinaryDependency(self):
+        self._write('go.mod', 'module example\n\ngo 1.20\n')
+        self._write('calc/calc.go', textwrap.dedent('''\
+            package calc
+            func Add(a, b int) int { return a + b }
+            '''))
+        self._write('calc/BUILD',
+                    "go_library(name='calc', srcs=['calc.go'], visibility=['PUBLIC'])\n")
+        self._write('app/main.go', textwrap.dedent('''\
+            package main
+            import (
+                "fmt"
+                "example/calc"
+            )
+            func main() { fmt.Println(calc.Add(2, 3)) }
+            '''))
+        self._write('app/BUILD',
+                    "go_binary(name='app', srcs=['main.go'], deps=['//calc:calc'])\n")
+        p = self._blade('build', 'app:app')
+        self.assertEqual(p.returncode, 0, p.stdout)
+        # go_library produced its compile-check stamp...
+        self.assertIsNotNone(self._built('calc/calc'),
+                             'go_library stamp missing:\n%s' % p.stdout)
+        # ...and the binary that imports it built and runs.
+        binpath = self._built('app/app')
+        self.assertIsNotNone(binpath, 'binary not built:\n%s' % p.stdout)
+        out = subprocess.run([binpath], stdout=subprocess.PIPE, encoding='utf-8')
+        self.assertEqual(out.stdout.strip(), '5')
+
+
+class TestSubdirModule(GoBuildTestBase):
+    def testModuleInSubdirectory(self):
+        # go.mod lives in svc/, not the workspace root: the target must be built
+        # in the svc module (via `go -C svc`).
+        self._write('svc/go.mod', 'module svc\n\ngo 1.20\n')
+        self._write('svc/main.go', textwrap.dedent('''\
+            package main
+            import "fmt"
+            func main() { fmt.Println("in-subdir-module") }
+            '''))
+        self._write('svc/BUILD', "go_binary(name='svc', srcs=['main.go'])\n")
+        p = self._blade('build', 'svc:svc')
+        self.assertEqual(p.returncode, 0, p.stdout)
+        binpath = self._built('svc/svc')
+        self.assertIsNotNone(binpath, 'binary not built:\n%s' % p.stdout)
+        out = subprocess.run([binpath], stdout=subprocess.PIPE, encoding='utf-8')
+        self.assertEqual(out.stdout.strip(), 'in-subdir-module')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test/go_coverage_test.py
+++ b/src/test/go_coverage_test.py
@@ -43,7 +43,7 @@ class TestGoCoverage(unittest.TestCase):
     def testGoCoverageReport(self):
         go = shutil.which('go')
         self._write('BLADE_ROOT',
-                    "go_config(go='%s', go_home='%s', go_module_enabled=True)\n"
+                    "go_config(go='%s', go_home='%s')\n"
                     % (go, os.path.join(self.work, 'gopath')))
         self._write('go.mod', 'module calc\n\ngo 1.20\n')
         self._write('calc/calc.go', textwrap.dedent('''\

--- a/src/tests/unit/go_module_discovery_test.py
+++ b/src/tests/unit/go_module_discovery_test.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for go_targets._find_module_dir (module discovery, #1405).
+
+The walker resolves a target's owning Go module as the nearest `go.mod` at or
+above the target dir, checked relative to the current directory (the workspace
+root during analysis). Returns the workspace-relative module dir ('' for the
+root module) or None.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade.go_targets import _find_module_dir  # noqa: E402
+
+
+class FindModuleDirTest(unittest.TestCase):
+    def setUp(self):
+        self.cur = os.getcwd()
+        self.work = tempfile.mkdtemp(prefix='blade_go_mod_')
+        os.chdir(self.work)  # analysis runs from the workspace root
+
+    def tearDown(self):
+        os.chdir(self.cur)
+        import shutil
+        shutil.rmtree(self.work, ignore_errors=True)
+
+    def _mkgomod(self, reldir):
+        d = os.path.join(self.work, reldir) if reldir else self.work
+        os.makedirs(d, exist_ok=True)
+        open(os.path.join(d, 'go.mod'), 'w').close()
+
+    def test_root_module_from_root(self):
+        self._mkgomod('')
+        self.assertEqual(_find_module_dir(''), '')
+
+    def test_root_module_from_subdir(self):
+        self._mkgomod('')
+        os.makedirs('a/b/c', exist_ok=True)
+        self.assertEqual(_find_module_dir('a/b/c'), '')
+
+    def test_nearest_module_wins(self):
+        self._mkgomod('')        # root module
+        self._mkgomod('svc')     # nested module
+        os.makedirs('svc/cmd', exist_ok=True)
+        self.assertEqual(_find_module_dir('svc/cmd'), 'svc')
+        self.assertEqual(_find_module_dir('svc'), 'svc')
+
+    def test_module_in_subdir_only(self):
+        self._mkgomod('svc')     # no root go.mod
+        os.makedirs('svc/pkg', exist_ok=True)
+        self.assertEqual(_find_module_dir('svc/pkg'), 'svc')
+
+    def test_no_module_found(self):
+        os.makedirs('a/b', exist_ok=True)
+        self.assertIsNone(_find_module_dir('a/b'))
+        self.assertIsNone(_find_module_dir(''))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
First phase of the Go modernization (#1405): rework the Go rules around **Go modules**; GOPATH mode is removed. Compilation is delegated to the `go` toolchain (`go -C <module_dir>`) while Blade owns the dependency graph.

## What changed

- **Per-target module discovery** — a target's module is the nearest `go.mod` at or above its dir. Multi-module workspaces work (local cross-module imports resolved by `go.work`/`replace`, not Blade).
- **`go_binary` file-mode** — built from its declared `srcs` (`go build <srcs...>`), so a directory with **multiple `main` files** can be split into separate `go_binary` targets (previously impossible).
- **`go_library` = compile-check + stamp** — no GOPATH `.a` artifact (the build cache replaced it). Building it runs `go build` on the package and emits a stamp; consumers take it as an **order-only dep** and let `go` recompile (cache hit). Optional for pure-Go packages.
- **`go_test`** — `go test -c` over the package (coverage path unchanged).
- **Parallelism** — removed the `depth=1` `golang_pool`; the module build cache is concurrency-safe.
- **Incrementality** — `go.mod`/`go.sum` are implicit deps; dep stamps give stamp-chain rebuilds.
- **Config** — dropped `go_module_enabled` / `go_module_relpath` (always modules); `go_home` is now just GOPATH/cache. Minimal fixes to `proto_library` / `init_command` for the removed keys. Docs (`build_rules/go.md`, en + zh) updated to match.

## ⚠️ Breaking changes
GOPATH-mode Go targets and the `go_module_enabled` / `go_module_relpath` config items are **no longer supported** (per the #1405 decision — GOPATH deprecated since Go 1.16).

## Deferred to follow-up PRs (per #1405)
In-tree **proto→Go** generation, **cgo/`cc_library`** interop, the **import↔deps hygiene** check, and **`go list`-based** incrementality. This PR is the foundation those build on.

## Tests
- New **integration** tests (`src/test/go_build_test.py`): file-mode binary builds+runs, **multiple `main`s in one dir** → separate binaries, `go_library` stamp consumed by a binary that imports it, and a **subdir module** (module discovery + `go -C`).
- New **unit** tests (`src/tests/unit/go_module_discovery_test.py`) for `_find_module_dir`.
- Existing `go_coverage_test` updated (drops the removed flag) and still passes.
- Validated locally with **go 1.24**; pyright clean; full unit suite (888) green.

Requesting review before merge.