### PR TITLE
ci: set up Go in the e2e-smoke job

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -127,6 +127,10 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
+    - name: Set up Go  # //suites/go_basic in blade-test needs a go toolchain
+      uses: actions/setup-go@v5
+      with:
+        go-version: 'stable'
     - name: Install ninja
       run: |
         sudo apt-get update


### PR DESCRIPTION
The cross-repo `e2e-smoke` job builds blade-test's `//suites/...`, which will include a new `go_basic` suite ([blade-test#30](https://github.com/blade-build/blade-test/pull/30)). Add `actions/setup-go` so it has a Go toolchain explicitly rather than relying on the runner's preinstalled Go. CI-only.