### PR TITLE
go: clear error when the go toolchain is unconfigured

### DIFF
--- a/src/blade/go_targets.py
+++ b/src/blade/go_targets.py
@@ -99,6 +99,12 @@ class GoTarget(Target):
 
         self.attr['extra_goflags'] = extra_goflags
         self._add_tags('lang:go')
+        if not config.get_item('go_config', 'go'):
+            # Without this, generation still emits `gobinary`/etc. build edges
+            # while the rule provider (no `go`) emits no rules, and the failure
+            # surfaces only as a cryptic `ninja: unknown build rule 'gobinary'`.
+            self.error('Go toolchain is not configured; set '
+                       '`go_config(go="/path/to/go")` in BLADE_ROOT.')
         self._resolve_module()
 
     def _resolve_module(self):

--- a/src/test/go_build_test.py
+++ b/src/test/go_build_test.py
@@ -235,5 +235,40 @@ class TestCgo(GoBuildTestBase):
         self.assertEqual(out.stdout.strip(), 'hi-from-base')
 
 
+class TestGoUnconfigured(unittest.TestCase):
+    """A go target with `go` unconfigured must fail with a clear analyze-stage
+    message, not a cryptic `ninja: unknown build rule 'gobinary'`. Needs no go
+    toolchain -- it exercises exactly the unconfigured path."""
+
+    def setUp(self):
+        self.cur_dir = os.getcwd()
+        here = os.path.dirname(os.path.abspath(__file__))
+        self.blade = os.path.join(here, '..', '..', 'blade')
+        self.work = tempfile.mkdtemp(prefix='blade_go_noconf_')
+        self._write('BLADE_ROOT', "go_config(go='')\n")  # unconfigured
+        self._write('go.mod', 'module x\n\ngo 1.20\n')
+        self._write('app/main.go', 'package main\nfunc main() {}\n')
+        self._write('app/BUILD', "go_binary(name='app', srcs='main.go')\n")
+
+    def tearDown(self):
+        os.chdir(self.cur_dir)
+        shutil.rmtree(self.work, ignore_errors=True)
+
+    def _write(self, rel, text):
+        path = os.path.join(self.work, rel)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(text)
+
+    def testClearErrorWhenGoUnconfigured(self):
+        os.chdir(self.work)
+        p = subprocess.run(
+            [self.blade, 'build', 'app:app'],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
+        self.assertNotEqual(p.returncode, 0)
+        self.assertIn('Go toolchain is not configured', p.stdout)
+        self.assertNotIn('unknown build rule', p.stdout)  # not the cryptic one
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes the last minor item from #1405: a go target built with `go` unconfigured (`go_config`'s default `go=''`) failed only with a cryptic `ninja: unknown build rule 'gobinary'`. Now it fails in the analyze stage with a clear message telling you to set `go_config(go=...)` in BLADE_ROOT.

Test: `go_build_test.py::TestGoUnconfigured` (needs no go toolchain — it exercises the unconfigured path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)