### PR TITLE
dsl: add a Starlark-compatible fail() builtin

### DIFF
--- a/src/blade/load_build_files.py
+++ b/src/blade/load_build_files.py
@@ -26,6 +26,7 @@ from blade import console
 from blade import dsl_api  # lgtm[py/cyclic-import]
 from blade import restricted
 from blade import target_tags
+from blade import util
 
 from pathlib import Path
 from blade.util import path_under_dir, var_to_list, exec_file, source_location
@@ -96,6 +97,19 @@ def enable_if(cond, true_value, false_value=None):
     if ret is None:
         ret = []
     return ret
+
+
+def fail(*args, sep=' '):
+    """Abort the current BUILD/extension with a fatal, source-located error.
+
+    The Starlark-compatible way to signal a hard error from the DSL (Starlark has
+    no `assert` / `raise` / exceptions): `fail('message')`. Positional args are
+    joined by `sep`, matching Starlark's `fail`. Raising SystemExit routes through
+    the loader's clean `except SystemExit` path (no Python traceback).
+    """
+    message = sep.join(str(a) for a in args)
+    console.diagnose(util.calling_source_location(1), 'error', message)
+    raise SystemExit(1)
 
 
 def _current_source_location():
@@ -342,6 +356,7 @@ def load(name, *symbols, **aliases):
 
 
 build_rules.register_function(enable_if)
+build_rules.register_function(fail)
 build_rules.register_function(glob)
 build_rules.register_function(include)
 build_rules.register_function(load)

--- a/src/tests/unit/fail_test.py
+++ b/src/tests/unit/fail_test.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Unit tests for the `fail()` DSL builtin.
+
+`fail(*args, sep=' ')` is the Starlark-compatible way to raise a hard error from
+a BUILD / extension file (Starlark has no `assert` / `raise` / exceptions). It
+reports a source-located error and aborts by raising SystemExit, which the
+loader turns into a clean fatal (no Python traceback).
+"""
+
+import os
+import sys
+import unittest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'src'))
+
+from blade import build_rules  # noqa: E402  (sys.path tweak above)
+from blade import console  # noqa: E402
+from blade import load_build_files  # noqa: E402
+
+
+class FailTest(unittest.TestCase):
+    def setUp(self):
+        # Capture diagnostics rather than printing them.
+        self._orig_diagnose = console.diagnose
+        self.diagnostics = []
+        console.diagnose = lambda loc, sev, msg: self.diagnostics.append((sev, msg))
+
+    def tearDown(self):
+        console.diagnose = self._orig_diagnose
+
+    def test_aborts_with_system_exit(self):
+        # SystemExit is the path the loader catches to emit a clean fatal.
+        with self.assertRaises(SystemExit):
+            load_build_files.fail('boom')
+
+    def test_reports_an_error_diagnostic(self):
+        with self.assertRaises(SystemExit):
+            load_build_files.fail('bad thing')
+        self.assertEqual([('error', 'bad thing')], self.diagnostics)
+
+    def test_joins_positional_args_with_default_space(self):
+        with self.assertRaises(SystemExit):
+            load_build_files.fail('got', 2, 'files')
+        self.assertEqual('got 2 files', self.diagnostics[0][1])
+
+    def test_custom_separator(self):
+        with self.assertRaises(SystemExit):
+            load_build_files.fail('a', 'b', 'c', sep=', ')
+        self.assertEqual('a, b, c', self.diagnostics[0][1])
+
+    def test_registered_as_a_dsl_builtin(self):
+        # Available to BUILD files (extensions inherit BUILD globals).
+        self.assertIs(load_build_files.fail, build_rules.get_all().get('fail'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds `fail(*args, sep=' ')` to the BUILD/extension DSL — the Starlark-compatible way to raise a hard error (Starlark has no `assert`/`raise`/exceptions). It emits a **source-located** error and aborts via SystemExit, which the loader turns into a clean fatal (no Python traceback):

```
app/BUILD:3: error: cc_flare_library can only accept a single .proto file, got 2
Blade(error): app/BUILD: Fatal error
```

Registered like `enable_if`, so it's available in BUILD files and `.bld` extensions. This lets extension code replace `assert`/`raise` (which Starlark lacks) with `fail()`, a step toward Starlark-forward-compatible `.bld` files.

Unit tests: `src/tests/unit/fail_test.py` (aborts via SystemExit, reports the error, joins args by `sep`, registered as a builtin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)