### PR TITLE
test: run the omitted integration tests + guard against re-omission

### DIFF
--- a/src/test/blade_main_test.py
+++ b/src/test/blade_main_test.py
@@ -45,48 +45,78 @@ from cc_coverage_test import TestCcCoverage
 from go_coverage_test import TestGoCoverage
 from py_coverage_test import TestPyCoverage
 from sanitizer_test import TestSanitizerAsan, TestSanitizerUbsan, TestSanitizerTsan
+# Previously omitted from the suite (they only ran when invoked by hand); wired
+# in below. A guard test (tests/unit/integration_suite_coverage_test.py) now
+# fails if any src/test/*_test.py class is left out.
+from go_build_test import (
+    TestGoBinary,
+    TestGoLibrary,
+    TestSubdirModule,
+    TestCgo,
+    TestGoUnconfigured,
+)
+from guard_suppression_test import TestGuardSuppression
+from header_only_incstk_test import TestHeaderOnlyIncstk
+from tags_test import TagsTest
 
 from html_test_runner import HTMLTestRunner
 from test_target_test import TestTestRunner
 
 
+# Every integration TestCase CI runs. Keep this exhaustive: the guard test
+# tests/unit/integration_suite_coverage_test.py fails if any src/test/*_test.py
+# class with `test*` methods is missing here, so a new test can't be silently
+# dropped from CI (the bug this list caused before).
+TEST_CASES = [
+    TargetPatternTest,
+    TestCcLibrary,
+    TestCcBinary,
+    TestCcPlugin,
+    TestCcTest,
+    DeclareHdrsVirtualPathTest,
+    EffectiveTimeoutTest,
+    ExportIncsListTest,
+    GetCcFlagsTest,
+    GetIncsListTest,
+    GetenvTest,
+    TestDump,
+    TestExtension,
+    TestGenRule,
+    TestHdrDepCheck,
+    TestJava,
+    TestLexYacc,
+    TestProtoLibrary,
+    TestResourceLibrary,
+    TestQuery,
+    TestTestRunner,
+    TestPrebuildCcLibrary,
+    LinkerScriptsTest,
+    BuildFromSubdirTest,
+    RootCommandTest,
+    TestDeprecatedDep,
+    TestCcCoverage,
+    TestGoCoverage,
+    TestPyCoverage,
+    TestSanitizerAsan,
+    TestSanitizerUbsan,
+    TestSanitizerTsan,
+    # Newly wired in (were silently omitted from the suite):
+    TestGoBinary,
+    TestGoLibrary,
+    TestSubdirModule,
+    TestCgo,
+    TestGoUnconfigured,
+    TestGuardSuppression,
+    TestHeaderOnlyIncstk,
+    TagsTest,
+]
+
+
 def _main():
     """main method."""
     suite_test = unittest.TestSuite()
-    suite_test.addTests([
-        unittest.defaultTestLoader.loadTestsFromTestCase(TargetPatternTest),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestCcLibrary),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestCcBinary),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestCcPlugin),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestCcTest),
-        unittest.defaultTestLoader.loadTestsFromTestCase(DeclareHdrsVirtualPathTest),
-        unittest.defaultTestLoader.loadTestsFromTestCase(EffectiveTimeoutTest),
-        unittest.defaultTestLoader.loadTestsFromTestCase(ExportIncsListTest),
-        unittest.defaultTestLoader.loadTestsFromTestCase(GetCcFlagsTest),
-        unittest.defaultTestLoader.loadTestsFromTestCase(GetIncsListTest),
-        unittest.defaultTestLoader.loadTestsFromTestCase(GetenvTest),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestDump),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestExtension),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestGenRule),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestHdrDepCheck),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestJava),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestLexYacc),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestProtoLibrary),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestResourceLibrary),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestQuery),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestTestRunner),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestPrebuildCcLibrary),
-        unittest.defaultTestLoader.loadTestsFromTestCase(LinkerScriptsTest),
-        unittest.defaultTestLoader.loadTestsFromTestCase(BuildFromSubdirTest),
-        unittest.defaultTestLoader.loadTestsFromTestCase(RootCommandTest),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestDeprecatedDep),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestCcCoverage),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestGoCoverage),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestPyCoverage),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestSanitizerAsan),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestSanitizerUbsan),
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestSanitizerTsan),
-        ])
+    suite_test.addTests(
+        unittest.defaultTestLoader.loadTestsFromTestCase(tc) for tc in TEST_CASES)
 
     generate_html = len(sys.argv) > 1 and sys.argv[1].startswith('html')
     if generate_html:

--- a/src/tests/unit/integration_suite_coverage_test.py
+++ b/src/tests/unit/integration_suite_coverage_test.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Blade Authors.
+# All rights reserved.
+
+"""Guard: every integration test class is registered in blade_main_test.py.
+
+CI runs the integration tests only through src/test/blade_main_test.py, whose
+suite is built from an explicit `TEST_CASES` list. Historically new
+src/test/*_test.py files were silently dropped from that list and so never ran
+in CI (e.g. go_build_test). This test parses (via AST, no imports) every
+src/test/*_test.py, finds classes that define a `test*` method, and fails if any
+is absent from `TEST_CASES` -- making that omission impossible to reintroduce.
+"""
+
+import ast
+import glob
+import os
+import unittest
+
+_TEST_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..', 'test'))  # -> src/test
+_RUNNER = os.path.join(_TEST_DIR, 'blade_main_test.py')
+
+
+def _defines_own_test_method(classdef):
+    return any(isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+               and n.name.startswith('test')
+               for n in classdef.body)
+
+
+def _runnable_test_classes():
+    """{class_name: filename} for classes that define their own `test*` method.
+
+    A class with a `test*` method is something unittest will run, so it must be
+    registered. Pure base/helper classes (setUp/helpers only, e.g.
+    GoBuildTestBase) define no `test*` method and are correctly ignored.
+    """
+    found = {}
+    for path in sorted(glob.glob(os.path.join(_TEST_DIR, '*_test.py'))):
+        base = os.path.basename(path)
+        if base == 'blade_main_test.py':      # the runner itself
+            continue
+        with open(path, encoding='utf-8') as f:
+            tree = ast.parse(f.read())
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and _defines_own_test_method(node):
+                found[node.name] = base
+    return found
+
+
+def _registered_class_names():
+    """Names listed in blade_main_test.py's `TEST_CASES`."""
+    with open(_RUNNER, encoding='utf-8') as f:
+        tree = ast.parse(f.read())
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == 'TEST_CASES'
+                for t in node.targets):
+            return {e.id for e in node.value.elts if isinstance(e, ast.Name)}
+    return set()
+
+
+class IntegrationSuiteCoverageTest(unittest.TestCase):
+    def test_every_integration_test_is_registered(self):
+        registered = _registered_class_names()
+        self.assertTrue(registered,
+                        'Could not find TEST_CASES in %s' % _RUNNER)
+        runnable = _runnable_test_classes()
+        missing = {c: f for c, f in runnable.items() if c not in registered}
+        self.assertEqual(
+            {}, missing,
+            'Integration test classes missing from blade_main_test.py '
+            'TEST_CASES (they would never run in CI):\n' +
+            '\n'.join('  %s  (%s)' % (c, f) for c, f in sorted(missing.items())))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Problem:** the integration runner `src/test/blade_main_test.py` builds its suite from a hand-maintained list, and CI runs only that suite. Several `src/test/*_test.py` files were never added, so they **never ran in CI** — notably `go_build_test.py` (the #1405 go_binary/go_library/cgo/go-unconfigured tests), plus `guard_suppression_test`, `header_only_incstk_test`, `tags_test`.

**Fix:**
- Wire the four omitted files into the suite; refactor it to build from a module-level `TEST_CASES` list (40 classes → 66 tests).
- Add `tests/unit/integration_suite_coverage_test.py`: an **AST-based guard** that fails if any `src/test/*_test.py` class defining a `test*` method is missing from `TEST_CASES`. This makes the omission impossible to reintroduce (verified: dropping any class makes the guard fail).

All four newly-wired files pass locally; full unit suite green (incl. the guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)